### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/update-plugins.yml
+++ b/.github/workflows/update-plugins.yml
@@ -1,4 +1,7 @@
 name: Scheduled Plugin Versions Update
+permissions:
+  contents: read
+  actions: write
 
 on:
   schedule:


### PR DESCRIPTION
Potential fix for [https://github.com/asizikov-demos/copilot-user-level-statistics-viewer/security/code-scanning/3](https://github.com/asizikov-demos/copilot-user-level-statistics-viewer/security/code-scanning/3)

The correct fix is to add a `permissions` block specifying the minimum required privileges. According to the analysis, the workflow mostly checks out source, installs dependencies, runs updates, uses git to check for file changes, and calls another workflow. None of these steps require write access to contents or admin rights. However, the last step triggers another workflow via `benc-uk/workflow-dispatch@v1`, which requires `actions: write` permission. Therefore, the most restrictive correct `permissions` block would be:

```yaml
permissions:
  contents: read
  actions: write
```

This block can be added at the workflow root (directly below the `name:` key), which will apply to the entire workflow unless overridden at the job level. This satisfies the principle of least privilege.

**Required changes:**  
- Insert the following block after the `name: ...` line (line 1) and before the `on:` block (line 3):

    ```yaml
    permissions:
      contents: read
      actions: write
    ```

No new imports, methods, or additional YAML constructs are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
