### PR TITLE
Add workflow for auto-merging plugin version update PRs

### DIFF
--- a/.github/workflows/auto-merge-plugin-updates.yml
+++ b/.github/workflows/auto-merge-plugin-updates.yml
@@ -48,6 +48,12 @@ jobs:
               core.setFailed('PR changes files beyond allowed plugin data JSONs.');
             }
 
+      - name: Verify PR author
+        run: |
+          if [[ "${{ github.event.pull_request.user.login }}" != "github-actions[bot]" ]]; then
+            echo "Auto-merge only allowed for github-actions bot"
+            exit 1
+          fi
       - name: Enable auto-merge
         uses: peter-evans/enable-pull-request-automerge@v3
         with:


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the merging of plugin version update pull requests. The workflow is designed to trigger only when changes are made to specific plugin data files and ensures that no other files are modified in the PR before enabling auto-merge.