### PR TITLE
Remove branch restriction from auto-merge workflow for plugin version updates

### DIFF
--- a/.github/workflows/auto-merge-plugin-updates.yml
+++ b/.github/workflows/auto-merge-plugin-updates.yml
@@ -3,8 +3,6 @@ name: Auto-merge plugin version update PRs
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-    branches:
-      - main
     paths:
       - 'public/data/vscode.json'
       - 'public/data/jetbrains.json'


### PR DESCRIPTION
Eliminate the branch restriction in the auto-merge workflow to allow version updates for plugins regardless of the branch.