### PR TITLE
Remove static site generator configuration from Setup Pages step

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,8 +39,6 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@v5
         if: github.ref == 'refs/heads/main'
-        with:
-          static_site_generator: next
           
       - name: Restore cache
         uses: actions/cache@v4


### PR DESCRIPTION
Eliminate the static site generator configuration from the Setup Pages step to streamline the process.