### PR TITLE
Export pdf and csv reports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -84,7 +84,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -1752,7 +1751,6 @@
       "integrity": "sha512-WOhQTZ4G8xZ1tjJTvKOpyEVSGgOTvJAfDK3FNFgELyaTpzhdgHVHeqW8V+UJvzF5BT+/B54T/1S2K6gd9c7bbA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -1763,7 +1761,6 @@
       "integrity": "sha512-WmdoynAX8Stew/36uTSVMcLJJ1KRh6L3IZRx1PZ7qJtBqT3dYTgyDTx8H1qoRghErydW7xw9mSJ3wS//tCRpFA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -1823,7 +1820,6 @@
       "integrity": "sha512-N9lBGA9o9aqb1hVMc9hzySbhKibHmB+N3IpoShyV6HyQYRGIhlrO5rQgttypi+yEeKsKI4idxC8Jw6gXKD4THA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.49.0",
         "@typescript-eslint/types": "8.49.0",
@@ -2310,7 +2306,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2672,7 +2667,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2789,7 +2783,6 @@
       "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.1.tgz",
       "integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@kurkle/color": "^0.3.0"
       },
@@ -3280,7 +3273,6 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3466,7 +3458,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -5665,7 +5656,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.1.tgz",
       "integrity": "sha512-DGrYcCWK7tvYMnWh79yrPHt+vdx9tY+1gPZa7nJQtO/p8bLTDaHp4dzwEhQB7pZ4Xe3ok4XKuEPrVuc+wlpkmw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5685,7 +5675,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.1.tgz",
       "integrity": "sha512-ibrK8llX2a4eOskq1mXKu/TGZj9qzomO+sNfO98M6d9zIPOEhlBkMkBUBLd1vgS0gQsLDBzA+8jJBVXDnfHmJg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -6378,7 +6367,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6572,7 +6560,6 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6868,7 +6855,6 @@
       "integrity": "sha512-AvvthqfqrAhNH9dnfmrfKzX5upOdjUVJYFqNSlkmGf64gRaTzlPwz99IHYnVs28qYAybvAlBV+H7pn0saFY4Ig==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/components/features/overview/OverviewDashboard.tsx
+++ b/src/components/features/overview/OverviewDashboard.tsx
@@ -1,21 +1,24 @@
 'use client';
 
-import React from 'react';
-import { MetricsStats } from '../../../types/metrics';
-import { DailyEngagementData, DailyChatUsersData, DailyChatRequestsData } from '../../../domain/calculators/metricCalculators';
+import React, { useMemo } from 'react';
+import { MetricsStats, UserSummary } from '../../../types/metrics';
+import { DailyEngagementData, DailyChatUsersData, DailyChatRequestsData, LanguageStats } from '../../../domain/calculators/metricCalculators';
 import FilterPanel from '../../FilterPanel';
-import { MetricTileGroup, MetricTileIcon } from '../../ui';
+import { MetricTileGroup, MetricTileIcon, ExportButton } from '../../ui';
 import EngagementChart from '../../charts/EngagementChart';
 import ChatUsersChart from '../../charts/ChatUsersChart';
 import ChatRequestsChart from '../../charts/ChatRequestsChart';
 import { DateRangeFilter } from '../../../types/filters';
 import { ViewMode, VIEW_MODES } from '../../../types/navigation';
 import type { VoidCallback, ValueCallback, BooleanFilterCallback } from '../../../types/events';
+import type { ExportData } from '../../../utils/exports';
 
 interface OverviewDashboardProps {
   stats: MetricsStats;
   originalStats: MetricsStats | null;
   enterpriseName: string | null;
+  userSummaries: UserSummary[];
+  languageStats: LanguageStats[];
   engagementData: DailyEngagementData[];
   chatUsersData: DailyChatUsersData[];
   chatRequestsData: DailyChatRequestsData[];
@@ -32,6 +35,8 @@ const OverviewDashboard: React.FC<OverviewDashboardProps> = ({
   stats,
   originalStats,
   enterpriseName,
+  userSummaries,
+  languageStats,
   engagementData,
   chatUsersData,
   chatRequestsData,
@@ -51,6 +56,16 @@ const OverviewDashboard: React.FC<OverviewDashboardProps> = ({
     });
   };
 
+  const exportData: ExportData = useMemo(() => ({
+    stats,
+    enterpriseName,
+    userSummaries,
+    languageStats,
+    engagementData,
+    chatUsersData,
+    chatRequestsData,
+  }), [stats, enterpriseName, userSummaries, languageStats, engagementData, chatUsersData, chatRequestsData]);
+
   return (
     <div className="flex gap-6">
       <div className="flex-1 bg-white rounded-lg shadow-sm border border-gray-200 p-6">
@@ -63,12 +78,14 @@ const OverviewDashboard: React.FC<OverviewDashboardProps> = ({
               </>
             )}
           </h2>
-          <button
-            onClick={onReset}
-            className="px-4 py-2 text-sm font-medium text-blue-600 bg-blue-50 hover:bg-blue-100 border border-blue-200 rounded-md transition-colors"
-          >
-            Upload New File
-          </button>
+          <div className="flex items-center gap-3">
+            <button
+              onClick={onReset}
+              className="px-4 py-2 text-sm font-medium text-blue-600 bg-blue-50 hover:bg-blue-100 border border-blue-200 rounded-md transition-colors"
+            >
+              Upload New File
+            </button>
+          </div>
         </div>
       
         <MetricTileGroup
@@ -174,6 +191,11 @@ const OverviewDashboard: React.FC<OverviewDashboardProps> = ({
       </div>
 
       <div className="w-64 flex-shrink-0">
+        <div className="mb-6 bg-white rounded-lg shadow-sm border border-gray-200 p-4">
+          <h3 className="text-sm font-semibold text-gray-900 mb-3">Export Data</h3>
+          <ExportButton exportData={exportData} fullWidth />
+        </div>
+        
         <FilterPanel
           onDateRangeChange={onDateRangeChange}
           currentFilter={dateRange}

--- a/src/components/layout/ViewRouter.tsx
+++ b/src/components/layout/ViewRouter.tsx
@@ -194,6 +194,8 @@ const ViewRouter: React.FC = () => {
           stats={stats}
           originalStats={originalStats}
           enterpriseName={enterpriseName}
+          userSummaries={userSummaries}
+          languageStats={languageStats}
           engagementData={engagementData}
           chatUsersData={chatUsersData}
           chatRequestsData={chatRequestsData}

--- a/src/components/ui/ExportButton.tsx
+++ b/src/components/ui/ExportButton.tsx
@@ -1,0 +1,181 @@
+'use client';
+
+import React, { useState, useRef, useEffect } from 'react';
+import {
+  ExportData,
+  exportSummaryStatsCsv,
+  exportUserSummariesCsv,
+  exportLanguageStatsCsv,
+  exportEngagementDataCsv,
+  exportFullReportCsv,
+  exportReportPdf,
+} from '../../utils/exports';
+
+interface ExportButtonProps {
+  exportData: ExportData;
+  fullWidth?: boolean;
+}
+
+type ExportOption = {
+  id: string;
+  label: string;
+  description: string;
+  icon: React.ReactNode;
+  action: (data: ExportData) => void;
+};
+
+const DownloadIcon = () => (
+  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
+  </svg>
+);
+
+const CsvIcon = () => (
+  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+  </svg>
+);
+
+const PdfIcon = () => (
+  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M7 21h10a2 2 0 002-2V9.414a1 1 0 00-.293-.707l-5.414-5.414A1 1 0 0012.586 3H7a2 2 0 00-2 2v14a2 2 0 002 2z" />
+  </svg>
+);
+
+const ChevronDownIcon = () => (
+  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+  </svg>
+);
+
+const exportOptions: ExportOption[] = [
+  {
+    id: 'full-csv',
+    label: 'Full Report (CSV)',
+    description: 'Complete metrics report with all data',
+    icon: <CsvIcon />,
+    action: (data) => exportFullReportCsv(
+      data.stats,
+      data.enterpriseName,
+      data.userSummaries,
+      data.languageStats,
+      data.engagementData,
+      data.chatUsersData,
+      data.chatRequestsData
+    ),
+  },
+  {
+    id: 'pdf',
+    label: 'Summary Report (PDF)',
+    description: 'Printable summary with key metrics',
+    icon: <PdfIcon />,
+    action: (data) => exportReportPdf(
+      data.stats,
+      data.enterpriseName,
+      data.userSummaries,
+      data.languageStats,
+      data.engagementData,
+      data.chatUsersData,
+      data.chatRequestsData
+    ),
+  },
+  {
+    id: 'summary-csv',
+    label: 'Summary Stats (CSV)',
+    description: 'Overview statistics only',
+    icon: <CsvIcon />,
+    action: (data) => exportSummaryStatsCsv(data.stats, data.enterpriseName),
+  },
+  {
+    id: 'users-csv',
+    label: 'User Data (CSV)',
+    description: 'All user summaries',
+    icon: <CsvIcon />,
+    action: (data) => exportUserSummariesCsv(data.userSummaries, data.stats),
+  },
+  {
+    id: 'languages-csv',
+    label: 'Language Stats (CSV)',
+    description: 'Language breakdown',
+    icon: <CsvIcon />,
+    action: (data) => exportLanguageStatsCsv(data.languageStats, data.stats),
+  },
+  {
+    id: 'engagement-csv',
+    label: 'Daily Engagement (CSV)',
+    description: 'Day-by-day activity',
+    icon: <CsvIcon />,
+    action: (data) => exportEngagementDataCsv(data.engagementData, data.stats),
+  },
+];
+
+const ExportButton: React.FC<ExportButtonProps> = ({ exportData, fullWidth = false }) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
+  const handleExport = (option: ExportOption) => {
+    option.action(exportData);
+    setIsOpen(false);
+  };
+
+  return (
+    <div className="relative" ref={dropdownRef}>
+      <button
+        onClick={() => setIsOpen(!isOpen)}
+        className={`inline-flex items-center justify-between gap-2 px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 transition-colors ${fullWidth ? 'w-full' : ''}`}
+        aria-haspopup="true"
+        aria-expanded={isOpen}
+      >
+        <span className="inline-flex items-center gap-2">
+          <DownloadIcon />
+          Export
+        </span>
+        <ChevronDownIcon />
+      </button>
+
+      {isOpen && (
+        <div className={`absolute z-20 mt-2 w-64 origin-top-left rounded-lg bg-white shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none ${fullWidth ? 'left-0' : 'right-0'}`}>
+          <div className="py-1">
+            <div className="px-4 py-2 border-b border-gray-100">
+              <p className="text-xs font-semibold text-gray-500 uppercase tracking-wide">Export Options</p>
+            </div>
+            {exportOptions.map((option, index) => (
+              <button
+                key={option.id}
+                onClick={() => handleExport(option)}
+                className={`w-full flex items-start gap-3 px-4 py-3 text-left hover:bg-gray-50 transition-colors ${
+                  index === 0 ? 'bg-blue-50 hover:bg-blue-100' : ''
+                }`}
+              >
+                <span className={`mt-0.5 ${index === 0 ? 'text-blue-600' : 'text-gray-400'}`}>
+                  {option.icon}
+                </span>
+                <div className="flex-1 min-w-0">
+                  <p className={`text-sm font-medium ${index === 0 ? 'text-blue-900' : 'text-gray-900'}`}>
+                    {option.label}
+                  </p>
+                  <p className={`text-xs ${index === 0 ? 'text-blue-600' : 'text-gray-500'}`}>
+                    {option.description}
+                  </p>
+                </div>
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ExportButton;

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -19,3 +19,5 @@ export type { MetricTileIconName } from "./icons/MetricTileIcon";
 
 export { default as DashboardStatsCardGroup } from "./DashboardStatsCardGroup";
 export type { DashboardStatsCardGroupProps } from "./DashboardStatsCardGroup";
+
+export { default as ExportButton } from "./ExportButton";

--- a/src/utils/exports/csvExport.ts
+++ b/src/utils/exports/csvExport.ts
@@ -1,0 +1,223 @@
+import {
+  DailyEngagementData,
+  DailyChatUsersData,
+  DailyChatRequestsData,
+  LanguageStats,
+  MetricsStats,
+  UserSummary,
+} from './types';
+import { formatDateRangeForFilename, downloadFile } from './helpers';
+
+function escapeCsvValue(value: string | number | boolean | null | undefined): string {
+  if (value === null || value === undefined) return '';
+  const stringValue = String(value);
+  if (stringValue.includes(',') || stringValue.includes('\n') || stringValue.includes('"')) {
+    return `"${stringValue.replace(/"/g, '""')}"`;
+  }
+  return stringValue;
+}
+
+function arrayToCsv<T extends object>(
+  data: T[],
+  headers: { key: keyof T; label: string }[]
+): string {
+  const headerRow = headers.map((h) => escapeCsvValue(h.label)).join(',');
+  const dataRows = data.map((row) =>
+    headers.map((h) => escapeCsvValue(row[h.key] as string | number | boolean)).join(',')
+  );
+  return [headerRow, ...dataRows].join('\n');
+}
+
+export function exportSummaryStatsCsv(
+  stats: MetricsStats,
+  enterpriseName: string | null
+): void {
+  const data = [
+    { metric: 'Enterprise', value: enterpriseName || 'N/A' },
+    { metric: 'Report Start Date', value: stats.reportStartDay },
+    { metric: 'Report End Date', value: stats.reportEndDay },
+    { metric: 'Total Records', value: stats.totalRecords },
+    { metric: 'Unique Users', value: stats.uniqueUsers },
+    { metric: 'Chat Users', value: stats.chatUsers },
+    { metric: 'Agent Users', value: stats.agentUsers },
+    { metric: 'Completion Only Users', value: stats.completionOnlyUsers },
+    { metric: 'Top Language', value: stats.topLanguage?.name || 'N/A' },
+    { metric: 'Top Language Engagements', value: stats.topLanguage?.engagements || 0 },
+    { metric: 'Top IDE', value: stats.topIde?.name || 'N/A' },
+    { metric: 'Top IDE Users', value: stats.topIde?.entries || 0 },
+    { metric: 'Top Model', value: stats.topModel?.name || 'N/A' },
+    { metric: 'Top Model Engagements', value: stats.topModel?.engagements || 0 },
+  ];
+
+  const csv = arrayToCsv(data, [
+    { key: 'metric', label: 'Metric' },
+    { key: 'value', label: 'Value' },
+  ]);
+
+  const dateRange = formatDateRangeForFilename(stats.reportStartDay, stats.reportEndDay);
+  downloadFile(csv, `copilot-summary-stats_${dateRange}.csv`, 'text/csv;charset=utf-8;');
+}
+
+export function exportUserSummariesCsv(userSummaries: UserSummary[], stats: MetricsStats): void {
+  const csv = arrayToCsv(userSummaries, [
+    { key: 'user_login', label: 'Username' },
+    { key: 'user_id', label: 'User ID' },
+    { key: 'days_active', label: 'Days Active' },
+    { key: 'total_user_initiated_interactions', label: 'Total Interactions' },
+    { key: 'total_code_generation_activities', label: 'Code Generations' },
+    { key: 'total_code_acceptance_activities', label: 'Code Acceptances' },
+    { key: 'total_loc_added', label: 'LOC Added' },
+    { key: 'total_loc_deleted', label: 'LOC Deleted' },
+    { key: 'total_loc_suggested_to_add', label: 'LOC Suggested to Add' },
+    { key: 'total_loc_suggested_to_delete', label: 'LOC Suggested to Delete' },
+    { key: 'used_chat', label: 'Used Chat' },
+    { key: 'used_agent', label: 'Used Agent' },
+  ]);
+
+  const dateRange = formatDateRangeForFilename(stats.reportStartDay, stats.reportEndDay);
+  downloadFile(csv, `copilot-user-summaries_${dateRange}.csv`, 'text/csv;charset=utf-8;');
+}
+
+export function exportEngagementDataCsv(engagementData: DailyEngagementData[], stats: MetricsStats): void {
+  const csv = arrayToCsv(engagementData, [
+    { key: 'date', label: 'Date' },
+    { key: 'activeUsers', label: 'Active Users' },
+    { key: 'totalUsers', label: 'Total Users' },
+    { key: 'engagementPercentage', label: 'Engagement %' },
+  ]);
+
+  const dateRange = formatDateRangeForFilename(stats.reportStartDay, stats.reportEndDay);
+  downloadFile(csv, `copilot-daily-engagement_${dateRange}.csv`, 'text/csv;charset=utf-8;');
+}
+
+export function exportLanguageStatsCsv(languageStats: LanguageStats[], stats: MetricsStats): void {
+  const csv = arrayToCsv(languageStats, [
+    { key: 'language', label: 'Language' },
+    { key: 'totalGenerations', label: 'Total Generations' },
+    { key: 'totalAcceptances', label: 'Total Acceptances' },
+    { key: 'locAdded', label: 'LOC Added' },
+    { key: 'locDeleted', label: 'LOC Deleted' },
+    { key: 'locSuggestedToAdd', label: 'LOC Suggested to Add' },
+    { key: 'locSuggestedToDelete', label: 'LOC Suggested to Delete' },
+  ]);
+
+  const dateRange = formatDateRangeForFilename(stats.reportStartDay, stats.reportEndDay);
+  downloadFile(csv, `copilot-language-stats_${dateRange}.csv`, 'text/csv;charset=utf-8;');
+}
+
+export function exportChatUsersDataCsv(chatUsersData: DailyChatUsersData[], stats: MetricsStats): void {
+  const csv = arrayToCsv(chatUsersData, [
+    { key: 'date', label: 'Date' },
+    { key: 'askModeUsers', label: 'Ask Mode Users' },
+    { key: 'agentModeUsers', label: 'Agent Mode Users' },
+    { key: 'editModeUsers', label: 'Edit Mode Users' },
+    { key: 'inlineModeUsers', label: 'Inline Mode Users' },
+  ]);
+
+  const dateRange = formatDateRangeForFilename(stats.reportStartDay, stats.reportEndDay);
+  downloadFile(csv, `copilot-daily-chat-users_${dateRange}.csv`, 'text/csv;charset=utf-8;');
+}
+
+export function exportChatRequestsDataCsv(chatRequestsData: DailyChatRequestsData[], stats: MetricsStats): void {
+  const csv = arrayToCsv(chatRequestsData, [
+    { key: 'date', label: 'Date' },
+    { key: 'askModeRequests', label: 'Ask Mode Requests' },
+    { key: 'agentModeRequests', label: 'Agent Mode Requests' },
+    { key: 'editModeRequests', label: 'Edit Mode Requests' },
+    { key: 'inlineModeRequests', label: 'Inline Mode Requests' },
+  ]);
+
+  const dateRange = formatDateRangeForFilename(stats.reportStartDay, stats.reportEndDay);
+  downloadFile(csv, `copilot-daily-chat-requests_${dateRange}.csv`, 'text/csv;charset=utf-8;');
+}
+
+export function exportFullReportCsv(
+  stats: MetricsStats,
+  enterpriseName: string | null,
+  userSummaries: UserSummary[],
+  languageStats: LanguageStats[],
+  engagementData: DailyEngagementData[],
+  chatUsersData: DailyChatUsersData[],
+  chatRequestsData: DailyChatRequestsData[]
+): void {
+  const sections: string[] = [];
+  
+  // Summary section
+  sections.push('=== SUMMARY STATISTICS ===');
+  sections.push(`Enterprise,${escapeCsvValue(enterpriseName || 'N/A')}`);
+  sections.push(`Report Period,${stats.reportStartDay} to ${stats.reportEndDay}`);
+  sections.push(`Total Records,${stats.totalRecords}`);
+  sections.push(`Unique Users,${stats.uniqueUsers}`);
+  sections.push(`Chat Users,${stats.chatUsers}`);
+  sections.push(`Agent Users,${stats.agentUsers}`);
+  sections.push(`Completion Only Users,${stats.completionOnlyUsers}`);
+  sections.push(`Top Language,${stats.topLanguage?.name || 'N/A'}`);
+  sections.push(`Top IDE,${stats.topIde?.name || 'N/A'}`);
+  sections.push(`Top Model,${stats.topModel?.name || 'N/A'}`);
+  sections.push('');
+
+  // User summaries section
+  sections.push('=== USER SUMMARIES ===');
+  sections.push(arrayToCsv(userSummaries, [
+    { key: 'user_login', label: 'Username' },
+    { key: 'user_id', label: 'User ID' },
+    { key: 'days_active', label: 'Days Active' },
+    { key: 'total_user_initiated_interactions', label: 'Total Interactions' },
+    { key: 'total_code_generation_activities', label: 'Code Generations' },
+    { key: 'total_code_acceptance_activities', label: 'Code Acceptances' },
+    { key: 'total_loc_added', label: 'LOC Added' },
+    { key: 'total_loc_deleted', label: 'LOC Deleted' },
+    { key: 'used_chat', label: 'Used Chat' },
+    { key: 'used_agent', label: 'Used Agent' },
+  ]));
+  sections.push('');
+
+  // Language stats section
+  sections.push('=== LANGUAGE STATISTICS ===');
+  sections.push(arrayToCsv(languageStats, [
+    { key: 'language', label: 'Language' },
+    { key: 'totalGenerations', label: 'Total Generations' },
+    { key: 'totalAcceptances', label: 'Total Acceptances' },
+    { key: 'locAdded', label: 'LOC Added' },
+    { key: 'locDeleted', label: 'LOC Deleted' },
+  ]));
+  sections.push('');
+
+  // Daily engagement section
+  sections.push('=== DAILY ENGAGEMENT ===');
+  sections.push(arrayToCsv(engagementData, [
+    { key: 'date', label: 'Date' },
+    { key: 'activeUsers', label: 'Active Users' },
+    { key: 'totalUsers', label: 'Total Users' },
+    { key: 'engagementPercentage', label: 'Engagement %' },
+  ]));
+  sections.push('');
+
+  // Chat users section
+  if (chatUsersData.length > 0) {
+    sections.push('=== DAILY CHAT USERS ===');
+    sections.push(arrayToCsv(chatUsersData, [
+      { key: 'date', label: 'Date' },
+      { key: 'askModeUsers', label: 'Ask Mode Users' },
+      { key: 'agentModeUsers', label: 'Agent Mode Users' },
+      { key: 'editModeUsers', label: 'Edit Mode Users' },
+      { key: 'inlineModeUsers', label: 'Inline Mode Users' },
+    ]));
+    sections.push('');
+  }
+
+  // Chat requests section
+  if (chatRequestsData.length > 0) {
+    sections.push('=== DAILY CHAT REQUESTS ===');
+    sections.push(arrayToCsv(chatRequestsData, [
+      { key: 'date', label: 'Date' },
+      { key: 'askModeRequests', label: 'Ask Mode Requests' },
+      { key: 'agentModeRequests', label: 'Agent Mode Requests' },
+      { key: 'editModeRequests', label: 'Edit Mode Requests' },
+      { key: 'inlineModeRequests', label: 'Inline Mode Requests' },
+    ]));
+  }
+
+  const dateRange = formatDateRangeForFilename(stats.reportStartDay, stats.reportEndDay);
+  downloadFile(sections.join('\n'), `copilot-full-report_${dateRange}.csv`, 'text/csv;charset=utf-8;');
+}

--- a/src/utils/exports/helpers.ts
+++ b/src/utils/exports/helpers.ts
@@ -1,0 +1,15 @@
+export function formatDateRangeForFilename(startDate: string, endDate: string): string {
+  return `${startDate}_to_${endDate}`;
+}
+
+export function downloadFile(content: string, filename: string, mimeType: string): void {
+  const blob = new Blob([content], { type: mimeType });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+}

--- a/src/utils/exports/index.ts
+++ b/src/utils/exports/index.ts
@@ -1,0 +1,13 @@
+export {
+  exportSummaryStatsCsv,
+  exportUserSummariesCsv,
+  exportEngagementDataCsv,
+  exportLanguageStatsCsv,
+  exportChatUsersDataCsv,
+  exportChatRequestsDataCsv,
+  exportFullReportCsv,
+} from './csvExport';
+
+export { exportReportPdf } from './pdfExport';
+
+export type { ExportData } from './types';

--- a/src/utils/exports/pdfExport.ts
+++ b/src/utils/exports/pdfExport.ts
@@ -1,0 +1,805 @@
+import {
+  DailyEngagementData,
+  DailyChatUsersData,
+  DailyChatRequestsData,
+  LanguageStats,
+  MetricsStats,
+  UserSummary,
+} from './types';
+import { formatDateRangeForFilename } from './helpers';
+import { formatDate } from '../formatters';
+
+export function exportReportPdf(
+  stats: MetricsStats,
+  enterpriseName: string | null,
+  userSummaries: UserSummary[],
+  languageStats: LanguageStats[],
+  engagementData: DailyEngagementData[],
+  chatUsersData: DailyChatUsersData[],
+  chatRequestsData: DailyChatRequestsData[]
+): void {
+  const reportHtml = generatePdfHtml(
+    stats,
+    enterpriseName,
+    userSummaries,
+    languageStats,
+    engagementData,
+    chatUsersData,
+    chatRequestsData
+  );
+
+  const printWindow = window.open('', '_blank');
+  if (printWindow) {
+    printWindow.document.write(reportHtml);
+    printWindow.document.close();
+    printWindow.onload = () => {
+      printWindow.print();
+    };
+  }
+}
+
+function generatePdfHtml(
+  stats: MetricsStats,
+  enterpriseName: string | null,
+  userSummaries: UserSummary[],
+  languageStats: LanguageStats[],
+  engagementData: DailyEngagementData[],
+  chatUsersData: DailyChatUsersData[],
+  chatRequestsData: DailyChatRequestsData[]
+): string {
+  const formattedStartDate = formatDate(stats.reportStartDay);
+  const formattedEndDate = formatDate(stats.reportEndDay);
+  
+  // Calculate totals from user summaries
+  const totalInteractions = userSummaries.reduce((sum, u) => sum + u.total_user_initiated_interactions, 0);
+  const totalGenerations = userSummaries.reduce((sum, u) => sum + u.total_code_generation_activities, 0);
+  const totalAcceptances = userSummaries.reduce((sum, u) => sum + u.total_code_acceptance_activities, 0);
+  const acceptanceRate = totalGenerations > 0 ? ((totalAcceptances / totalGenerations) * 100).toFixed(1) : '0';
+  
+  const topLanguages = languageStats.slice(0, 10);
+  const topUsers = [...userSummaries]
+    .sort((a, b) => b.total_code_acceptance_activities - a.total_code_acceptance_activities)
+    .slice(0, 10);
+
+  const dateRangeFilename = formatDateRangeForFilename(stats.reportStartDay, stats.reportEndDay);
+
+  return `
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>GitHub Copilot Usage Report ${dateRangeFilename}</title>
+  <style>
+    ${getPdfStyles()}
+  </style>
+</head>
+<body>
+  <div class="header">
+    <h1>GitHub Copilot Usage Report</h1>
+    <p class="subtitle">
+      ${formattedStartDate} — ${formattedEndDate}
+      ${enterpriseName ? `<span class="enterprise"> | ${enterpriseName}</span>` : ''}
+    </p>
+  </div>
+
+  <h2>Summary Statistics</h2>
+  ${renderSummaryStats(stats, totalInteractions, totalGenerations, totalAcceptances, acceptanceRate)}
+
+  <h2>Daily User Engagement</h2>
+  <p class="chart-description">Percentage of total users active each day during the reporting period</p>
+  ${renderEngagementChart(engagementData)}
+
+  ${chatUsersData.length > 0 ? `
+  <h2>Daily Chat Users Trends</h2>
+  <p class="chart-description">Number of unique users using different chat modes each day</p>
+  ${renderChatUsersChart(chatUsersData)}
+  ` : ''}
+
+  ${chatRequestsData.length > 0 ? `
+  <h2>Daily Chat Requests</h2>
+  <p class="chart-description">Number of user-initiated chat interactions per mode each day</p>
+  ${renderChatRequestsChart(chatRequestsData)}
+  ` : ''}
+
+  <h2>Top Languages</h2>
+  ${renderLanguagesTable(topLanguages)}
+
+  <h2>Top Users by Code Acceptances</h2>
+  ${renderUsersTable(topUsers)}
+
+  <h2>Daily Activity Summary</h2>
+  <h3>Engagement Trends</h3>
+  ${renderEngagementTable(engagementData)}
+
+  ${chatUsersData.length > 0 ? `
+  <h3>Chat &amp; Agent Mode User Trends</h3>
+  ${renderChatUsersTable(chatUsersData)}
+  ` : ''}
+
+  ${chatRequestsData.length > 0 ? `
+  <h3>Chat &amp; Agent Mode Request Trends</h3>
+  ${renderChatRequestsTable(chatRequestsData)}
+  ` : ''}
+
+  <div class="footer">
+    <p>Generated on ${new Date().toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric', hour: '2-digit', minute: '2-digit' })}</p>
+    <p>GitHub Copilot Usage Metrics Viewer</p>
+  </div>
+</body>
+</html>
+  `;
+}
+
+function getPdfStyles(): string {
+  return `
+    * {
+      margin: 0;
+      padding: 0;
+      box-sizing: border-box;
+    }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+      font-size: 12px;
+      line-height: 1.5;
+      color: #1f2937;
+      padding: 40px;
+      max-width: 1000px;
+      margin: 0 auto;
+    }
+    h1 {
+      font-size: 24px;
+      font-weight: 700;
+      color: #111827;
+      margin-bottom: 8px;
+    }
+    h2 {
+      font-size: 18px;
+      font-weight: 600;
+      color: #374151;
+      margin-top: 32px;
+      margin-bottom: 16px;
+      padding-bottom: 8px;
+      border-bottom: 2px solid #e5e7eb;
+    }
+    h3 {
+      font-size: 14px;
+      font-weight: 600;
+      color: #4b5563;
+      margin-top: 24px;
+      margin-bottom: 12px;
+    }
+    .header {
+      margin-bottom: 32px;
+    }
+    .subtitle {
+      color: #6b7280;
+      font-size: 14px;
+    }
+    .enterprise {
+      color: #2563eb;
+      font-weight: 500;
+    }
+    .stats-grid {
+      display: grid;
+      grid-template-columns: repeat(4, 1fr);
+      gap: 16px;
+      margin-bottom: 32px;
+    }
+    .stat-card {
+      background: #f9fafb;
+      border: 1px solid #e5e7eb;
+      border-radius: 8px;
+      padding: 16px;
+    }
+    .stat-value {
+      font-size: 24px;
+      font-weight: 700;
+      color: #111827;
+    }
+    .stat-label {
+      font-size: 12px;
+      color: #6b7280;
+      margin-top: 4px;
+    }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      margin-bottom: 24px;
+    }
+    th, td {
+      padding: 10px 12px;
+      text-align: left;
+      border-bottom: 1px solid #e5e7eb;
+    }
+    th {
+      background: #f9fafb;
+      font-weight: 600;
+      color: #374151;
+    }
+    tr:hover {
+      background: #f9fafb;
+    }
+    .text-right {
+      text-align: right;
+    }
+    .text-center {
+      text-align: center;
+    }
+    .badge {
+      display: inline-block;
+      padding: 2px 8px;
+      border-radius: 4px;
+      font-size: 11px;
+      font-weight: 500;
+    }
+    .badge-green {
+      background: #d1fae5;
+      color: #065f46;
+    }
+    .badge-blue {
+      background: #dbeafe;
+      color: #1e40af;
+    }
+    .footer {
+      margin-top: 48px;
+      padding-top: 16px;
+      border-top: 1px solid #e5e7eb;
+      color: #9ca3af;
+      font-size: 11px;
+      text-align: center;
+    }
+    .chart-container {
+      background: #f9fafb;
+      border: 1px solid #e5e7eb;
+      border-radius: 8px;
+      padding: 20px;
+      margin-bottom: 24px;
+    }
+    .chart-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: flex-start;
+      margin-bottom: 12px;
+      flex-wrap: wrap;
+      gap: 12px;
+    }
+    .chart-description {
+      color: #6b7280;
+      font-size: 12px;
+      margin-bottom: 16px;
+    }
+    .chart-legend {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 16px;
+      font-size: 11px;
+    }
+    .legend-item {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+    }
+    .legend-color {
+      width: 12px;
+      height: 12px;
+      border-radius: 2px;
+    }
+    .chart-stats {
+      display: flex;
+      gap: 24px;
+      margin-top: 12px;
+      font-size: 11px;
+      color: #6b7280;
+    }
+    .chart-stats strong {
+      color: #374151;
+    }
+    .chart-stats-inline {
+      display: flex;
+      gap: 16px;
+      font-size: 11px;
+      color: #6b7280;
+    }
+    .chart-stats-inline strong {
+      color: #111827;
+    }
+    .chart-footer {
+      margin-top: 12px;
+      font-size: 11px;
+      color: #6b7280;
+    }
+    .chart-footer-grid {
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      gap: 8px;
+      margin-top: 12px;
+      font-size: 11px;
+      color: #6b7280;
+    }
+    @media print {
+      body {
+        padding: 20px;
+      }
+      .stats-grid {
+        grid-template-columns: repeat(4, 1fr);
+      }
+      .chart-container {
+        page-break-inside: avoid;
+      }
+      h2 {
+        page-break-before: auto;
+        page-break-after: avoid;
+      }
+      table {
+        page-break-inside: avoid;
+      }
+    }
+  `;
+}
+
+function renderSummaryStats(
+  stats: MetricsStats,
+  totalInteractions: number,
+  totalGenerations: number,
+  totalAcceptances: number,
+  acceptanceRate: string
+): string {
+  return `
+  <div class="stats-grid">
+    <div class="stat-card">
+      <div class="stat-value">${stats.uniqueUsers.toLocaleString()}</div>
+      <div class="stat-label">Unique Users</div>
+    </div>
+    <div class="stat-card">
+      <div class="stat-value">${stats.chatUsers.toLocaleString()}</div>
+      <div class="stat-label">Chat Users</div>
+    </div>
+    <div class="stat-card">
+      <div class="stat-value">${stats.agentUsers.toLocaleString()}</div>
+      <div class="stat-label">Agent Users</div>
+    </div>
+    <div class="stat-card">
+      <div class="stat-value">${stats.totalRecords.toLocaleString()}</div>
+      <div class="stat-label">Total Records</div>
+    </div>
+  </div>
+
+  <div class="stats-grid">
+    <div class="stat-card">
+      <div class="stat-value">${totalInteractions.toLocaleString()}</div>
+      <div class="stat-label">Total Interactions</div>
+    </div>
+    <div class="stat-card">
+      <div class="stat-value">${totalGenerations.toLocaleString()}</div>
+      <div class="stat-label">Total Generations</div>
+    </div>
+    <div class="stat-card">
+      <div class="stat-value">${totalAcceptances.toLocaleString()}</div>
+      <div class="stat-label">Total Acceptances</div>
+    </div>
+    <div class="stat-card">
+      <div class="stat-value">${acceptanceRate}%</div>
+      <div class="stat-label">Acceptance Rate</div>
+    </div>
+  </div>
+  `;
+}
+
+function renderLanguagesTable(topLanguages: LanguageStats[]): string {
+  return `
+  <table>
+    <thead>
+      <tr>
+        <th>Language</th>
+        <th class="text-right">Generations</th>
+        <th class="text-right">Acceptances</th>
+        <th class="text-right">LOC Added</th>
+        <th class="text-right">LOC Deleted</th>
+      </tr>
+    </thead>
+    <tbody>
+      ${topLanguages.map(lang => `
+        <tr>
+          <td>${lang.language}</td>
+          <td class="text-right">${lang.totalGenerations.toLocaleString()}</td>
+          <td class="text-right">${lang.totalAcceptances.toLocaleString()}</td>
+          <td class="text-right">${lang.locAdded.toLocaleString()}</td>
+          <td class="text-right">${lang.locDeleted.toLocaleString()}</td>
+        </tr>
+      `).join('')}
+    </tbody>
+  </table>
+  `;
+}
+
+function renderUsersTable(topUsers: UserSummary[]): string {
+  return `
+  <table>
+    <thead>
+      <tr>
+        <th>Username</th>
+        <th class="text-right">Days Active</th>
+        <th class="text-right">Interactions</th>
+        <th class="text-right">Acceptances</th>
+        <th class="text-center">Chat</th>
+        <th class="text-center">Agent</th>
+      </tr>
+    </thead>
+    <tbody>
+      ${topUsers.map(user => `
+        <tr>
+          <td>${user.user_login}</td>
+          <td class="text-right">${user.days_active}</td>
+          <td class="text-right">${user.total_user_initiated_interactions.toLocaleString()}</td>
+          <td class="text-right">${user.total_code_acceptance_activities.toLocaleString()}</td>
+          <td class="text-center">${user.used_chat ? '<span class="badge badge-blue">Yes</span>' : 'No'}</td>
+          <td class="text-center">${user.used_agent ? '<span class="badge badge-green">Yes</span>' : 'No'}</td>
+        </tr>
+      `).join('')}
+    </tbody>
+  </table>
+  `;
+}
+
+function renderEngagementTable(engagementData: DailyEngagementData[]): string {
+  return `
+  <table>
+    <thead>
+      <tr>
+        <th>Date</th>
+        <th class="text-right">Active Users</th>
+        <th class="text-right">Total Users</th>
+        <th class="text-right">Engagement %</th>
+      </tr>
+    </thead>
+    <tbody>
+      ${engagementData.slice(0, 30).map(day => `
+        <tr>
+          <td>${day.date}</td>
+          <td class="text-right">${day.activeUsers.toLocaleString()}</td>
+          <td class="text-right">${day.totalUsers.toLocaleString()}</td>
+          <td class="text-right">${day.engagementPercentage.toFixed(1)}%</td>
+        </tr>
+      `).join('')}
+      ${engagementData.length > 30 ? `
+        <tr>
+          <td colspan="4" class="text-center" style="color: #6b7280; font-style: italic;">
+            ... and ${engagementData.length - 30} more days
+          </td>
+        </tr>
+      ` : ''}
+    </tbody>
+  </table>
+  `;
+}
+
+function renderChatUsersTable(chatUsersData: DailyChatUsersData[]): string {
+  return `
+  <table>
+    <thead>
+      <tr>
+        <th>Date</th>
+        <th class="text-right">Ask Mode</th>
+        <th class="text-right">Agent Mode</th>
+        <th class="text-right">Edit Mode</th>
+        <th class="text-right">Inline Mode</th>
+      </tr>
+    </thead>
+    <tbody>
+      ${chatUsersData.slice(0, 30).map(day => `
+        <tr>
+          <td>${day.date}</td>
+          <td class="text-right">${day.askModeUsers.toLocaleString()}</td>
+          <td class="text-right">${day.agentModeUsers.toLocaleString()}</td>
+          <td class="text-right">${day.editModeUsers.toLocaleString()}</td>
+          <td class="text-right">${day.inlineModeUsers.toLocaleString()}</td>
+        </tr>
+      `).join('')}
+      ${chatUsersData.length > 30 ? `
+        <tr>
+          <td colspan="5" class="text-center" style="color: #6b7280; font-style: italic;">
+            ... and ${chatUsersData.length - 30} more days
+          </td>
+        </tr>
+      ` : ''}
+    </tbody>
+  </table>
+  `;
+}
+
+function renderEngagementChart(data: DailyEngagementData[]): string {
+  if (data.length === 0) return '<p>No engagement data available</p>';
+
+  const width = 800;
+  const height = 300;
+  const padding = { top: 40, right: 30, bottom: 60, left: 80 };
+  const chartWidth = width - padding.left - padding.right;
+  const chartHeight = height - padding.top - padding.bottom;
+
+  const values = data.map(d => d.engagementPercentage);
+  const maxValue = 100;
+  const minValue = 0;
+
+  const avg = values.reduce((a, b) => a + b, 0) / values.length;
+  const max = Math.max(...values);
+  const min = Math.min(...values);
+
+  const pointCoords = data.map((d, i) => {
+    const x = padding.left + (i / (data.length - 1 || 1)) * chartWidth;
+    const y = padding.top + chartHeight - ((d.engagementPercentage - minValue) / (maxValue - minValue)) * chartHeight;
+    return { x, y };
+  });
+
+  const points = pointCoords.map(p => `${p.x},${p.y}`).join(' ');
+  const areaPoints = `${padding.left},${padding.top + chartHeight} ${points} ${padding.left + chartWidth},${padding.top + chartHeight}`;
+
+  const dataPointCircles = pointCoords.map(p => 
+    `<circle cx="${p.x}" cy="${p.y}" r="3" fill="#3b82f6" stroke="white" stroke-width="1" />`
+  ).join('');
+
+  const xLabels = getChartXLabelsEnhanced(data.map(d => d.date), chartWidth, padding, height);
+  const yLabels = getChartYLabelsEnhanced(0, maxValue, chartHeight, padding, '%', 10);
+  const gridLines = renderChartGridEnhanced(chartWidth, chartHeight, padding, 10);
+
+  return `
+  <div class="chart-container">
+    <div class="chart-header">
+      <div class="chart-legend">
+        <span class="legend-item"><span class="legend-color" style="background: #3b82f6"></span> User Engagement %</span>
+      </div>
+      <div class="chart-stats-inline">
+        <span>Avg: <strong>${avg.toFixed(2)}%</strong></span>
+        <span>Max: <strong>${max.toFixed(2)}%</strong></span>
+        <span>Min: <strong>${min.toFixed(2)}%</strong></span>
+      </div>
+    </div>
+    <svg width="${width}" height="${height}" viewBox="0 0 ${width} ${height}">
+      ${gridLines}
+      <polygon points="${areaPoints}" fill="rgba(59, 130, 246, 0.1)" />
+      <polyline points="${points}" fill="none" stroke="#3b82f6" stroke-width="2" />
+      ${dataPointCircles}
+      ${xLabels}
+      ${yLabels}
+      <text x="${padding.left + chartWidth / 2}" y="${height - 10}" text-anchor="middle" font-size="11" fill="#374151" font-weight="500">Date</text>
+      <text x="15" y="${padding.top + chartHeight / 2}" text-anchor="middle" font-size="11" fill="#374151" font-weight="500" transform="rotate(-90, 15, ${padding.top + chartHeight / 2})">Engagement Percentage (%)</text>
+    </svg>
+    <div class="chart-footer">
+      Total unique users in reporting period: ${data[0]?.totalUsers || 0}
+    </div>
+  </div>
+  `;
+}
+
+function renderChatUsersChart(data: DailyChatUsersData[]): string {
+  if (data.length === 0) return '<p>No chat users data available</p>';
+
+  const width = 800;
+  const height = 300;
+  const padding = { top: 40, right: 30, bottom: 60, left: 80 };
+  const chartWidth = width - padding.left - padding.right;
+  const chartHeight = height - padding.top - padding.bottom;
+
+  const allValues = data.flatMap(d => [d.askModeUsers, d.agentModeUsers, d.editModeUsers, d.inlineModeUsers]);
+  const rawMaxValue = Math.max(...allValues, 1);
+  const maxValue = getNiceMaxValue(rawMaxValue);
+
+  const datasets = [
+    { values: data.map(d => d.askModeUsers), color: '#22c55e', label: 'Ask Mode' },
+    { values: data.map(d => d.agentModeUsers), color: '#a855f7', label: 'Agent Mode' },
+    { values: data.map(d => d.editModeUsers), color: '#f59e0b', label: 'Edit Mode' },
+    { values: data.map(d => d.inlineModeUsers), color: '#ef4444', label: 'Inline Mode' },
+  ];
+
+  const linesAndPoints = datasets.map(dataset => {
+    const pointCoords = dataset.values.map((v, i) => {
+      const x = padding.left + (i / (data.length - 1 || 1)) * chartWidth;
+      const y = padding.top + chartHeight - (v / maxValue) * chartHeight;
+      return { x, y };
+    });
+    const points = pointCoords.map(p => `${p.x},${p.y}`).join(' ');
+    const circles = pointCoords.map(p => 
+      `<circle cx="${p.x}" cy="${p.y}" r="3" fill="${dataset.color}" stroke="white" stroke-width="1" />`
+    ).join('');
+    return `<polyline points="${points}" fill="none" stroke="${dataset.color}" stroke-width="2" />${circles}`;
+  }).join('');
+
+  const xLabels = getChartXLabelsEnhanced(data.map(d => d.date), chartWidth, padding, height);
+  const yLabels = getChartYLabelsEnhanced(0, maxValue, chartHeight, padding, '', 5);
+  const gridLines = renderChartGridEnhanced(chartWidth, chartHeight, padding, 5);
+
+  const legend = datasets.map(d => `
+    <span class="legend-item">
+      <span class="legend-color" style="background: ${d.color}"></span>
+      ${d.label}
+    </span>
+  `).join('');
+
+  return `
+  <div class="chart-container">
+    <div class="chart-header">
+      <div class="chart-legend">${legend}</div>
+    </div>
+    <svg width="${width}" height="${height}" viewBox="0 0 ${width} ${height}">
+      ${gridLines}
+      ${linesAndPoints}
+      ${xLabels}
+      ${yLabels}
+      <text x="${padding.left + chartWidth / 2}" y="${height - 10}" text-anchor="middle" font-size="11" fill="#374151" font-weight="500">Date</text>
+      <text x="15" y="${padding.top + chartHeight / 2}" text-anchor="middle" font-size="11" fill="#374151" font-weight="500" transform="rotate(-90, 15, ${padding.top + chartHeight / 2})">Number of Users</text>
+    </svg>
+  </div>
+  `;
+}
+
+function getNiceMaxValue(value: number): number {
+  if (value <= 0) return 10;
+  const magnitude = Math.pow(10, Math.floor(Math.log10(value)));
+  const normalized = value / magnitude;
+  let niceNormalized: number;
+  if (normalized <= 1) niceNormalized = 1;
+  else if (normalized <= 2) niceNormalized = 2;
+  else if (normalized <= 5) niceNormalized = 5;
+  else niceNormalized = 10;
+  return niceNormalized * magnitude;
+}
+
+function renderChartGridEnhanced(chartWidth: number, chartHeight: number, padding: { top: number; left: number }, tickCount: number): string {
+  const lines = [];
+  for (let i = 0; i <= tickCount; i++) {
+    const y = padding.top + (i / tickCount) * chartHeight;
+    lines.push(`<line x1="${padding.left}" y1="${y}" x2="${padding.left + chartWidth}" y2="${y}" stroke="#e5e7eb" stroke-width="1" />`);
+  }
+  return lines.join('');
+}
+
+function getChartXLabelsEnhanced(dates: string[], chartWidth: number, padding: { top: number; left: number }, svgHeight: number): string {
+  const step = Math.ceil(dates.length / 10);
+  return dates
+    .filter((_, i) => i % step === 0 || i === dates.length - 1)
+    .map((date) => {
+      const originalIndex = dates.indexOf(date);
+      const x = padding.left + (originalIndex / (dates.length - 1 || 1)) * chartWidth;
+      const formattedDate = new Date(date).toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+      return `<text x="${x}" y="${svgHeight - 25}" text-anchor="middle" font-size="10" fill="#6b7280">${formattedDate}</text>`;
+    })
+    .join('');
+}
+
+function getChartYLabelsEnhanced(min: number, max: number, chartHeight: number, padding: { top: number; left: number }, suffix: string, tickCount: number): string {
+  const labels = [];
+  for (let i = 0; i <= tickCount; i++) {
+    const value = min + ((max - min) * (tickCount - i)) / tickCount;
+    const y = padding.top + (i / tickCount) * chartHeight;
+    labels.push(`<text x="${padding.left - 10}" y="${y + 4}" text-anchor="end" font-size="10" fill="#6b7280">${Math.round(value)}${suffix}</text>`);
+  }
+  return labels.join('');
+}
+
+function renderChatRequestsChart(data: DailyChatRequestsData[]): string {
+  if (data.length === 0) return '<p>No chat requests data available</p>';
+
+  const width = 800;
+  const height = 300;
+  const padding = { top: 40, right: 30, bottom: 60, left: 80 };
+  const chartWidth = width - padding.left - padding.right;
+  const chartHeight = height - padding.top - padding.bottom;
+
+  const allValues = data.flatMap(d => [d.askModeRequests, d.agentModeRequests, d.editModeRequests, d.inlineModeRequests]);
+  const rawMaxValue = Math.max(...allValues, 1);
+  const maxValue = getNiceMaxValue(rawMaxValue);
+
+  const totalAsk = data.reduce((sum, d) => sum + d.askModeRequests, 0);
+  const totalAgent = data.reduce((sum, d) => sum + d.agentModeRequests, 0);
+  const totalEdit = data.reduce((sum, d) => sum + d.editModeRequests, 0);
+  const totalInline = data.reduce((sum, d) => sum + d.inlineModeRequests, 0);
+  const grandTotal = totalAsk + totalAgent + totalEdit + totalInline;
+
+  const avgAsk = Math.round(totalAsk / data.length);
+  const avgAgent = Math.round(totalAgent / data.length);
+  const avgEdit = Math.round(totalEdit / data.length);
+  const avgInline = Math.round(totalInline / data.length);
+
+  const maxAsk = Math.max(...data.map(d => d.askModeRequests));
+  const maxAgent = Math.max(...data.map(d => d.agentModeRequests));
+  const maxEdit = Math.max(...data.map(d => d.editModeRequests));
+  const maxInline = Math.max(...data.map(d => d.inlineModeRequests));
+
+  const datasets = [
+    { values: data.map(d => d.askModeRequests), color: '#22c55e', label: 'Ask Mode Requests' },
+    { values: data.map(d => d.agentModeRequests), color: '#a855f7', label: 'Agent Mode Requests' },
+    { values: data.map(d => d.editModeRequests), color: '#f59e0b', label: 'Edit Mode Requests' },
+    { values: data.map(d => d.inlineModeRequests), color: '#ef4444', label: 'Inline Mode Requests' },
+  ];
+
+  const linesAndPoints = datasets.map(dataset => {
+    const pointCoords = dataset.values.map((v, i) => {
+      const x = padding.left + (i / (data.length - 1 || 1)) * chartWidth;
+      const y = padding.top + chartHeight - (v / maxValue) * chartHeight;
+      return { x, y };
+    });
+    const points = pointCoords.map(p => `${p.x},${p.y}`).join(' ');
+    const circles = pointCoords.map(p => 
+      `<circle cx="${p.x}" cy="${p.y}" r="3" fill="${dataset.color}" stroke="white" stroke-width="1" />`
+    ).join('');
+    return `<polyline points="${points}" fill="none" stroke="${dataset.color}" stroke-width="2" />${circles}`;
+  }).join('');
+
+  const xLabels = getChartXLabelsEnhanced(data.map(d => d.date), chartWidth, padding, height);
+  const yLabels = getChartYLabelsEnhanced(0, maxValue, chartHeight, padding, '', 5);
+  const gridLines = renderChartGridEnhanced(chartWidth, chartHeight, padding, 5);
+
+  const legend = datasets.map(d => `
+    <span class="legend-item">
+      <span class="legend-color" style="background: ${d.color}"></span>
+      ${d.label}
+    </span>
+  `).join('');
+
+  return `
+  <div class="chart-container">
+    <div class="chart-header">
+      <div class="chart-legend">${legend}</div>
+      <div class="chart-stats-inline">
+        <span>Avg Ask: <strong>${avgAsk}</strong></span>
+        <span>Avg Agent: <strong>${avgAgent}</strong></span>
+        <span>Avg Edit: <strong>${avgEdit}</strong></span>
+        <span>Avg Inline: <strong>${avgInline}</strong></span>
+      </div>
+    </div>
+    <svg width="${width}" height="${height}" viewBox="0 0 ${width} ${height}">
+      ${gridLines}
+      ${linesAndPoints}
+      ${xLabels}
+      ${yLabels}
+      <text x="${padding.left + chartWidth / 2}" y="${height - 10}" text-anchor="middle" font-size="11" fill="#374151" font-weight="500">Date</text>
+      <text x="15" y="${padding.top + chartHeight / 2}" text-anchor="middle" font-size="11" fill="#374151" font-weight="500" transform="rotate(-90, 15, ${padding.top + chartHeight / 2})">Number of Requests</text>
+    </svg>
+    <div class="chart-footer-grid">
+      <div><span style="color: #22c55e; font-weight: 500;">Ask Mode:</span> ${totalAsk.toLocaleString()} total (max ${maxAsk}/day)</div>
+      <div><span style="color: #a855f7; font-weight: 500;">Agent Mode:</span> ${totalAgent.toLocaleString()} total (max ${maxAgent}/day)</div>
+      <div><span style="color: #f59e0b; font-weight: 500;">Edit Mode:</span> ${totalEdit.toLocaleString()} total (max ${maxEdit}/day)</div>
+      <div><span style="color: #ef4444; font-weight: 500;">Inline Mode:</span> ${totalInline.toLocaleString()} total (max ${maxInline}/day)</div>
+      <div><span style="color: #374151; font-weight: 500;">All Modes:</span> ${grandTotal.toLocaleString()} total requests</div>
+    </div>
+  </div>
+  `;
+}
+
+function renderChatRequestsTable(data: DailyChatRequestsData[]): string {
+  return `
+  <table>
+    <thead>
+      <tr>
+        <th>Date</th>
+        <th class="text-right">Ask Mode</th>
+        <th class="text-right">Agent Mode</th>
+        <th class="text-right">Edit Mode</th>
+        <th class="text-right">Inline Mode</th>
+        <th class="text-right">Total</th>
+      </tr>
+    </thead>
+    <tbody>
+      ${data.slice(0, 30).map(day => {
+        const total = day.askModeRequests + day.agentModeRequests + day.editModeRequests + day.inlineModeRequests;
+        return `
+        <tr>
+          <td>${day.date}</td>
+          <td class="text-right">${day.askModeRequests.toLocaleString()}</td>
+          <td class="text-right">${day.agentModeRequests.toLocaleString()}</td>
+          <td class="text-right">${day.editModeRequests.toLocaleString()}</td>
+          <td class="text-right">${day.inlineModeRequests.toLocaleString()}</td>
+          <td class="text-right"><strong>${total.toLocaleString()}</strong></td>
+        </tr>
+      `}).join('')}
+      ${data.length > 30 ? `
+        <tr>
+          <td colspan="6" class="text-center" style="color: #6b7280; font-style: italic;">
+            ... and ${data.length - 30} more days
+          </td>
+        </tr>
+      ` : ''}
+    </tbody>
+  </table>
+  `;
+}

--- a/src/utils/exports/types.ts
+++ b/src/utils/exports/types.ts
@@ -1,0 +1,26 @@
+import {
+  DailyEngagementData,
+  DailyChatUsersData,
+  DailyChatRequestsData,
+  LanguageStats,
+} from '../../domain/calculators/metricCalculators';
+import { MetricsStats, UserSummary } from '../../types/metrics';
+
+export interface ExportData {
+  stats: MetricsStats;
+  enterpriseName: string | null;
+  userSummaries: UserSummary[];
+  languageStats: LanguageStats[];
+  engagementData: DailyEngagementData[];
+  chatUsersData: DailyChatUsersData[];
+  chatRequestsData: DailyChatRequestsData[];
+}
+
+export type {
+  DailyEngagementData,
+  DailyChatUsersData,
+  DailyChatRequestsData,
+  LanguageStats,
+  MetricsStats,
+  UserSummary,
+};


### PR DESCRIPTION
This pull request introduces a comprehensive data export feature to the overview dashboard, allowing users to download key metrics and reports in CSV and PDF formats. It adds a new `ExportButton` component with multiple export options, implements various CSV export utilities, and updates the dashboard to support exporting all relevant data.

**Export feature implementation:**

* Added a new `ExportButton` component that provides a dropdown menu for exporting data in different formats (CSV and PDF), including full reports, summary statistics, user data, language stats, and daily engagement. (`src/components/ui/ExportButton.tsx`)
* Integrated the `ExportButton` into the overview dashboard sidebar, passing all necessary data for export. 
* Registered the new export UI component in the shared UI exports. (`src/components/ui/index.ts`)

**CSV export utilities:**

* Implemented a set of CSV export functions for summary statistics, user summaries, language stats, engagement data, chat users, chat requests, and a full report, including helpers for formatting and downloading files. (`src/utils/exports/csvExport.ts`, `src/utils/exports/helpers.ts`) 
* Defined a unified `ExportData` type for passing exportable data between components and utility functions. (`src/utils/exports/types.ts`)
* Centralized export utilities and types in the exports index. (`src/utils/exports/index.ts`)

These changes enable users to easily export and share dashboard data, supporting both detailed and summary reports in multiple formats.