### PR TITLE
Configure Dependabot for npm package updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "npm" 
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Updated package ecosystem to 'npm' for Dependabot.