### PR TITLE
fix(ci): improve dependency audit workflow output quality

### DIFF
--- a/.github/workflows/dependency-audit.lock.yml
+++ b/.github/workflows/dependency-audit.lock.yml
@@ -23,7 +23,7 @@
 #
 # Weekly dependency audit — find vulnerabilities and outdated packages, apply updates, and open a PR.
 #
-# frontmatter-hash: ccf22a9ca29216dbc9592d72668369bf349219cc836cb2dec835b701575e8995
+# frontmatter-hash: 4682706287850566596a56457dd18b9fa7333dbaf09c51f5ea8f604b6fda8b23
 
 name: "Weekly Dependency Audit"
 "on":
@@ -209,12 +209,12 @@ jobs:
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
           cat > /opt/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_EOF'
-          {"create_pull_request":{"expires":14},"missing_data":{},"missing_tool":{},"noop":{"max":1}}
+          {"create_pull_request":{"expires":336},"missing_data":{},"missing_tool":{},"noop":{"max":1}}
           GH_AW_SAFE_OUTPUTS_CONFIG_EOF
           cat > /opt/gh-aw/safeoutputs/tools.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_EOF'
           [
             {
-              "description": "Create a new GitHub pull request to propose code changes. Use this after making file edits to submit them for review and merging. The PR will be created from the current branch with your committed changes. For code review comments on an existing PR, use create_pull_request_review_comment instead. CONSTRAINTS: Maximum 1 pull request(s) can be created. Title will be prefixed with \"[deps] \". Labels [dependencies automated] will be automatically added. PRs will be created as drafts.",
+              "description": "Create a new GitHub pull request to propose code changes. Use this after making file edits to submit them for review and merging. The PR will be created from the current branch with your committed changes. For code review comments on an existing PR, use create_pull_request_review_comment instead. CONSTRAINTS: Maximum 1 pull request(s) can be created. Title will be prefixed with \"[deps] \". Labels [dependencies automated] will be automatically added. PRs will be created as drafts. Reviewers [copilot] will be assigned.",
               "inputSchema": {
                 "additionalProperties": false,
                 "properties": {
@@ -1117,7 +1117,7 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           GH_AW_AGENT_OUTPUT: ${{ env.GH_AW_AGENT_OUTPUT }}
-          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"create_pull_request\":{\"base_branch\":\"${{ github.ref_name }}\",\"draft\":true,\"expires\":14,\"labels\":[\"dependencies\",\"automated\"],\"max\":1,\"max_patch_size\":1024,\"title_prefix\":\"[deps] \"},\"missing_data\":{},\"missing_tool\":{}}"
+          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"create_pull_request\":{\"base_branch\":\"${{ github.ref_name }}\",\"draft\":true,\"expires\":336,\"labels\":[\"dependencies\",\"automated\"],\"max\":1,\"max_patch_size\":1024,\"title_prefix\":\"[deps] \"},\"missing_data\":{},\"missing_tool\":{}}"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/dependency-audit.md
+++ b/.github/workflows/dependency-audit.md
@@ -35,8 +35,9 @@ safe-outputs:
   create-pull-request:
     title-prefix: "[deps] "
     labels: ["dependencies", "automated"]
+    reviewers: ["copilot"]
     draft: true
-    expires: 14
+    expires: 14d
 
 timeout-minutes: 30
 
@@ -54,17 +55,18 @@ Perform a full dependency audit, apply safe updates, and open a pull request.
 
 ## Phase 1 — Assess
 
-1. Run `npm audit --json` and save the output. Identify all vulnerabilities grouped by severity (critical, high, moderate, low).
+1. Run `npm audit --json` and save the output. Identify all vulnerabilities grouped by severity (critical, high, moderate, low). For each vulnerability, note whether it affects a **production** dependency or a **dev-only** dependency.
 2. Run `npm outdated --json` and save the output. Identify all outdated packages, noting which have **major** version bumps vs minor/patch.
 3. If there are **no** vulnerabilities and **no** outdated packages, call `noop` with the message "All dependencies are up to date and no vulnerabilities found." and stop.
 
 ## Phase 2 — Fix vulnerabilities
 
-1. If `npm audit` reported fixable vulnerabilities, run `npm audit fix` (without `--force`).
-2. Run `npm run build` to verify the build still passes.
-3. Run `npm run lint` to verify linting still passes.
-4. If the build or lint fails, revert the changes with `git checkout -- .` and skip to Phase 3.
-5. If changes were made and everything passes, create an atomic commit:
+1. First run `npm audit fix --dry-run` to check if any non-breaking fixes are available. If no fixes would be applied, skip to Phase 3.
+2. If fixes are available, run `npm audit fix` (without `--force`).
+3. Run `npm run build` to verify the build still passes.
+4. Run `npm run lint` to verify linting still passes.
+5. If the build or lint fails, revert the changes with `git checkout -- .` and skip to Phase 3.
+6. If changes were made and everything passes, create an atomic commit:
    - Message: `fix(deps): resolve npm audit vulnerabilities`
    - Include only `package.json` and `package-lock.json`.
 
@@ -94,11 +96,32 @@ For each outdated package that has a **major** version update available (from th
 
 If **any** commits were made in Phases 2–4, create a pull request:
 - **Title**: `Weekly dependency update — <date>`  (use today's date in YYYY-MM-DD format)
-- **Body** must include:
-  - A summary of all changes grouped by phase
-  - The full vulnerability report from `npm audit` (before fixes)
-  - The full outdated report from `npm outdated` (before updates)
-  - A list of any skipped major updates and why they were skipped
-  - Confirmation that every commit passed build and lint checks
+- **Body** must include all sections below. Use **markdown tables**, not raw JSON.
+
+### Required PR body sections
+
+1. **Summary** — one-paragraph overview of what changed.
+
+2. **Changes Applied** — for each phase that made changes, list the updated packages in a table:
+
+   | Package | Previous | Updated | Type |
+   |---------|----------|---------|------|
+   | example | 1.0.0    | 1.1.0   | minor |
+
+3. **Vulnerability Report** (before fixes) — summarise `npm audit` results in a table:
+
+   | Package | Severity | Dev-only? | Fix available | Notes |
+   |---------|----------|-----------|---------------|-------|
+
+   Include a short note at the top stating total counts per severity and how many are production vs dev-only dependencies.
+
+4. **Outdated Packages** (before updates) — summarise `npm outdated` results in a table:
+
+   | Package | Current | Wanted | Latest | Update type |
+   |---------|---------|--------|--------|-------------|
+
+5. **Skipped Updates** — list any major updates that were skipped and why (e.g., "breaks build", "breaks lint"). If none, state "None".
+
+6. **Validation** — confirm that every commit passed build and lint checks.
 
 If no commits were made (all updates failed validation), call `noop` with a message explaining that updates were attempted but none passed validation.


### PR DESCRIPTION
## Summary

Improves the weekly dependency audit agentic workflow based on analysis of the first successful run (#203).

### Changes

- **Markdown tables** — instruct agent to format PR body with structured tables instead of raw JSON blobs (vulnerability report, outdated packages, changes applied)
- **Dev vs prod distinction** — agent now identifies whether each vulnerability affects a production or dev-only dependency
- **Dry-run check** — Phase 2 now runs `npm audit fix --dry-run` first to skip unnecessary work when no non-breaking fixes are available
- **Copilot reviewer** — added `reviewers: ["copilot"]` to auto-request Copilot PR review
- **Explicit expiry units** — changed `expires: 14` to `expires: 14d` for clarity

### Context

First run produced PR #203 which worked end-to-end but had HTML-escaped JSON in the body and didn't distinguish dev dependencies from production ones.

| Commit | Change |
|--------|--------|
| `fix(ci):` improve dependency audit workflow output quality | Enhanced workflow instructions for better PR formatting, added dev/prod dependency distinction, dry-run check, Copilot reviewer auto-request, and explicit time units |