### PR TITLE
fix: resolve truncated x-axis labels in remaining CLI charts

### DIFF
--- a/src/components/charts/CLIAdoptionTrendChart.tsx
+++ b/src/components/charts/CLIAdoptionTrendChart.tsx
@@ -118,7 +118,7 @@ export default function CLIAdoptionTrendChart({ data }: CLIAdoptionTrendChartPro
         { value: peakUsers, label: 'Peak Daily Users', colorClass: 'text-indigo-600' },
       ]}
     >
-      <div style={{ height: 350 }}>
+      <div className="h-full">
         <Chart type="bar" data={chartData} options={options} />
       </div>
     </ChartContainer>

--- a/src/components/charts/CLIUsersChart.tsx
+++ b/src/components/charts/CLIUsersChart.tsx
@@ -47,7 +47,7 @@ export default function CLIUsersChart({ data }: CLIUsersChartProps) {
         { value: maxUsers.toLocaleString(), label: 'Peak Daily Users' },
       ]}
     >
-      <div style={{ height: 350 }}>
+      <div className="h-full">
         <Bar data={chartData} options={options} />
       </div>
     </ChartContainer>


### PR DESCRIPTION
## Summary

The x-axis "Date" label was being truncated (clipped) in `CLIAdoptionTrendChart` and `CLIUsersChart` because the chart wrapper used a fixed `style={{ height: 350 }}`. The 350px height caused the chart to overflow the `ChartContainer` layout, and the axis title was cut off.

This applies the same fix from commit d862e0f (`CLISessionChart.tsx`) to the two remaining CLI chart components: replace the fixed 350px inline style with `className="h-full"` so the chart fills the `ChartContainer` default `h-80` height, which prevents overflow clipping.

## Changes

| Commit | Change |
|--------|--------|
| `fix: resolve truncated x-axis labels in remaining CLI charts` | Replace `style={{ height: 350 }}` with `className="h-full"` in `CLIAdoptionTrendChart.tsx` and `CLIUsersChart.tsx` to match the fix in d862e0f |

## Verification

- Build: ✅ clean
- Lint: ✅ clean