### PR TITLE
docs: clean up README — remove outdated and redundant content

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,25 +2,29 @@
 
 Visualize GitHub Copilot usage metrics from your organization. Upload metrics NDJSON files to analyze user engagement, feature usage, and adoption patterns.
 
-![Next.js](https://img.shields.io/badge/Next.js-16.0.8-black?logo=next.js&logoColor=white)
+![Next.js](https://img.shields.io/badge/Next.js-16-black?logo=next.js&logoColor=white)
 ![TypeScript](https://img.shields.io/badge/TypeScript-5-blue?logo=typescript&logoColor=white)
 ![Tailwind CSS](https://img.shields.io/badge/Tailwind-4-blue?logo=tailwindcss&logoColor=white)
 
 ## Features
 
 - Upload and parse GitHub Copilot metrics NDJSON files
-- View user breakdowns: unique users, chat users, agent users, completion-only users
-- Interactive charts (Chart.js) for usage patterns
-- Drill down into individual user activity
-- Statistics by IDE, programming language, and Copilot feature
-- Responsive layout
+- Executive summary with key adoption metrics
+- User breakdowns: unique users, chat users, agent users, CLI users, completion-only users
+- Interactive charts for usage patterns and trends
+- Drill down into individual user activity with feature adoption radar charts
+- Model usage and premium request analysis
+- CLI adoption trends, sessions, and token usage
+- IDE and VS Code extension version analysis
+- Statistics by programming language and Copilot feature
+- Responsive layout, deployable as a static site to GitHub Pages
 
 ## Getting Started
 
 ### Prerequisites
 
-- Node.js 20.9.0+ (required by Next.js 16)
-- npm, yarn, pnpm, or bun
+- Node.js (^20.19.0 || >=22.12.0)
+- npm
 
 ### Installation
 
@@ -33,72 +37,27 @@ cd user-level-metrics-viewer
 2. Install dependencies:
 ```bash
 npm install
-# or
-yarn install
-# or
-pnpm install
-# or
-bun install
 ```
 
 3. Run the development server:
 ```bash
 npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
 ```
 
 4. Open [http://localhost:3000](http://localhost:3000)
 
-## Tech Stack
-
-- [Next.js 16](https://nextjs.org) with App Router
-- [TypeScript 5](https://www.typescriptlang.org)
-- [Tailwind CSS 4](https://tailwindcss.com)
-- [Chart.js](https://www.chartjs.org) / [react-chartjs-2](https://react-chartjs-2.js.org)
-- [ESLint](https://eslint.org)
-
 ## Commands
 
 ```bash
-npm run dev    # Start development server with Turbopack
-npm run build  # Build for production
-npm run start  # Start production server
-npm run lint   # Run ESLint
+npm run dev       # Start development server with Turbopack
+npm run build     # Build for production (static export)
+npm run lint      # Run ESLint
+npm run test:run  # Run tests
 ```
 
 ## Data Format
 
-The application expects GitHub Copilot metrics NDJSON files:
-
-```typescript
-interface CopilotMetrics {
-  report_start_day: string;
-  report_end_day: string;
-  day: string;
-  enterprise_id: string;
-  user_id: number;
-  user_login: string;
-  user_initiated_interaction_count: number;
-  code_generation_activity_count: number;
-  code_acceptance_activity_count: number;
-  loc_added_sum: number;
-  loc_deleted_sum: number;
-  loc_suggested_to_add_sum: number;
-  loc_suggested_to_delete_sum: number;
-  used_agent: boolean;
-  used_chat: boolean;
-  totals_by_ide: Array<{...}>;
-  totals_by_feature: Array<{...}>;
-  totals_by_language_feature: Array<{...}>;
-  totals_by_language_model: Array<{...}>;
-  totals_by_model_feature: Array<{...}>;
-}
-```
+The application expects GitHub Copilot user-level metrics NDJSON files as provided by the [GitHub Copilot Metrics API](https://docs.github.com/en/rest/copilot/copilot-metrics). See [`src/types/metrics.ts`](src/types/metrics.ts) for the full `CopilotMetrics` interface.
 
 ## Contributing
 


### PR DESCRIPTION
## Summary

Cleans up README.md by removing outdated, redundant, and misleading content and updating it to reflect the current state of the project.

| Commit | Change |
|--------|--------|
| `docs:` remove outdated badge patch version | Badge now shows `Next.js-16` instead of pinned `16.0.8` |
| `docs:` fix Node.js prerequisite | Updated to `^20.19.0 \|\| >=22.12.0` matching the `engines` field in package.json |
| `docs:` remove yarn/pnpm/bun alternatives | Project uses npm exclusively; removed misleading alternative install/run commands |
| `docs:` remove redundant Tech Stack section | Duplicated information already conveyed by the header badges |
| `docs:` remove misleading `npm run start` | App is a static export (`output: 'export'`); `next start` doesn't apply |
| `docs:` replace inline Data Format block with link | Replaced stale TypeScript interface with a link to `src/types/metrics.ts` and the Copilot Metrics API docs |
| `docs:` update Features list | Added CLI adoption, model/premium-request analysis, executive summary, radar charts, IDE/extension version analysis, static-site deployment |
| `docs:` add `test:run` command | Documented the `npm run test:run` command in the Commands section |

Build: ✅ clean · Lint: ✅ clean