### PR TITLE
Rename PRU chart to Premium and remove Service Value

### DIFF
--- a/src/components/charts/PRUModelUsageChart.tsx
+++ b/src/components/charts/PRUModelUsageChart.tsx
@@ -33,12 +33,10 @@ export default function PRUModelUsageChart({ data, hideInsights = false }: PRUMo
   const totalStandardRequests = calculateTotal(data, d => d.standardModels);
   const totalUnknownRequests = calculateTotal(data, d => d.unknownModels);
   const totalPRUs = calculateTotal(data, d => d.totalPRUs);
-  const totalCost = calculateTotal(data, d => d.serviceValue);
   const grandTotal = totalPRURequests + totalStandardRequests + totalUnknownRequests;
   const pruAdoptionInsight = computePruAdoptionInsight(totalPRURequests, totalStandardRequests, totalUnknownRequests);
   const billingCycleInsight = computeBillingCycleInsight(data);
   const avgPRUs = calculateAverage(data, d => d.totalPRUs);
-  const avgCost = calculateAverage(data, d => d.serviceValue);
 
   const chartData = {
     labels: data.map(d => formatShortDate(d.date)),
@@ -53,7 +51,7 @@ export default function PRUModelUsageChart({ data, hideInsights = false }: PRUMo
         tension: 0.4
       },
       {
-        label: 'Standard Models (GPT-4.1/4o)',
+        label: 'Standard Models',
         data: data.map(d => d.standardModels),
         backgroundColor: chartColors.green.alpha60,
         borderColor: chartColors.green.solid,
@@ -85,18 +83,17 @@ export default function PRUModelUsageChart({ data, hideInsights = false }: PRUMo
 
   return (
     <ChartContainer
-      title="Daily PRU vs Standard Model Usage"
+      title="Daily Premium vs Standard Model Usage"
       isEmpty={!data || data.length === 0}
       emptyState="No model usage data available"
       headerActions={
         <ChartToggleButtons options={CHART_TYPE_OPTIONS} value={chartType} onChange={setChartType} />
       }
       summaryStats={[
-        { value: totalPRURequests, label: 'PRU Requests', sublabel: grandTotal > 0 ? `${Math.round((totalPRURequests / grandTotal) * 100)}%` : '0%', colorClass: 'text-red-600' },
+        { value: totalPRURequests, label: 'Premium Requests', sublabel: grandTotal > 0 ? `${Math.round((totalPRURequests / grandTotal) * 100)}%` : '0%', colorClass: 'text-red-600' },
         { value: totalStandardRequests, label: 'Standard Requests', sublabel: grandTotal > 0 ? `${Math.round((totalStandardRequests / grandTotal) * 100)}%` : '0%', colorClass: 'text-green-600' },
         { value: totalUnknownRequests, label: 'Unknown Requests', sublabel: grandTotal > 0 ? `${Math.round((totalUnknownRequests / grandTotal) * 100)}%` : '0%', colorClass: 'text-gray-600' },
-        { value: Math.round(totalPRUs * 100) / 100, label: 'Total PRUs', sublabel: `Avg: ${avgPRUs}/day`, colorClass: 'text-blue-600' },
-        { value: `$${Math.round(totalCost * 100) / 100}`, label: 'Service Value', sublabel: `Avg: $${avgCost}/day`, colorClass: 'text-purple-600' },
+        { value: Math.round(totalPRUs * 100) / 100, label: 'Total Premium Requests', sublabel: `Avg: ${avgPRUs}/day`, colorClass: 'text-blue-600' },
       ]}
       chartHeight="h-96"
       footer={


### PR DESCRIPTION
## Summary

Cleans up the PRU Model Usage chart by replacing internal `PRU` terminology with user-friendly `Premium` labels and removing the Service Value stat that is no longer needed.

| Commit | Change |
|--------|--------|
| `refactor:` rename PRU labels to Premium and remove Service Value stat | Renamed chart title from *Daily PRU vs Standard Model Usage* → *Daily Premium vs Standard Model Usage* |
| | Renamed *PRU Requests* summary stat → *Premium Requests* |
| | Renamed *Total PRUs* summary stat → *Total Premium Requests* |
| | Removed *Service Value* summary stat and its `totalCost`/`avgCost` calculation logic |
| | Simplified *Standard Models (GPT-4.1/4o)* legend label → *Standard Models* |
