### PR TITLE
Regenerate sample report user ids sequentially

### DIFF
--- a/data-utils/anonymize-report.test.ts
+++ b/data-utils/anonymize-report.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildSequentialUserIdMap, getUserIdentityKey } from './anonymize-report';
+
+describe('getUserIdentityKey', () => {
+  it('prefers user_login when available', () => {
+    expect(getUserIdentityKey({ user_login: 'octocat', user_id: 42 })).toBe('login:octocat');
+  });
+
+  it('falls back to user_id when login is missing', () => {
+    expect(getUserIdentityKey({ user_id: 42 })).toBe('id:42');
+  });
+
+  it('returns null when neither login nor user_id is usable', () => {
+    expect(getUserIdentityKey({ user_login: '   ' })).toBeNull();
+  });
+});
+
+describe('buildSequentialUserIdMap', () => {
+  it('assigns stable sequential ids in first-seen order', () => {
+    const map = buildSequentialUserIdMap([
+      { user_login: 'alpha', user_id: 999 },
+      { user_login: 'beta', user_id: 123 },
+      { user_login: 'alpha', user_id: 999 },
+      { user_id: 777 },
+    ]);
+
+    expect(Array.from(map.entries())).toEqual([
+      ['login:alpha', 1],
+      ['login:beta', 2],
+      ['id:777', 3],
+    ]);
+  });
+});

--- a/data-utils/anonymize-report.ts
+++ b/data-utils/anonymize-report.ts
@@ -4,8 +4,13 @@
 import { readFile, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { randomInt } from 'node:crypto';
+import { pathToFileURL } from 'node:url';
 
 type JsonRecord = Record<string, unknown>;
+interface ParsedRecord {
+  lineNumber: number;
+  record: JsonRecord;
+}
 
 const ENTERPRISE_ID_ANON = '0000';
 const EMU_SUFFIX = '_octoemu';
@@ -235,6 +240,45 @@ function isNdjsonFileName(fileName: string): boolean {
   return fileName.toLowerCase().endsWith('.ndjson');
 }
 
+export function getUserIdentityKey(record: JsonRecord): string | null {
+  const login = record.user_login;
+  if (typeof login === 'string' && login.trim().length > 0) {
+    return `login:${login}`;
+  }
+
+  const userId = record.user_id;
+  if (typeof userId === 'number' && Number.isFinite(userId)) {
+    return `id:${userId}`;
+  }
+
+  if (typeof userId === 'string' && userId.trim().length > 0) {
+    return `id:${userId}`;
+  }
+
+  return null;
+}
+
+export function buildSequentialUserIdMap(records: JsonRecord[]): Map<string, number> {
+  const map = new Map<string, number>();
+
+  for (const record of records) {
+    const key = getUserIdentityKey(record);
+    if (!key || map.has(key)) continue;
+    map.set(key, map.size + 1);
+  }
+
+  return map;
+}
+
+function assertEveryRecordHasUserIdentity(records: ParsedRecord[]): void {
+  const missingIdentityRecord = records.find(({ record }) => getUserIdentityKey(record) === null);
+  if (!missingIdentityRecord) return;
+
+  throw new Error(
+    `Record on line ${missingIdentityRecord.lineNumber} is missing both user_login and user_id`,
+  );
+}
+
 function anonymizeLogin(original: string, existing: Set<string>, map: Map<string, string>): string {
   const cached = map.get(original);
   if (cached) return cached;
@@ -248,7 +292,7 @@ function anonymizeLogin(original: string, existing: Set<string>, map: Map<string
   return anonymized;
 }
 
-async function main(): Promise<void> {
+export async function main(): Promise<void> {
   const [inputArg, outputArg] = process.argv.slice(2);
 
   if (!inputArg) {
@@ -274,7 +318,7 @@ async function main(): Promise<void> {
   const content = await readFile(inputPath, 'utf8');
   const lines = content.split(/\r?\n/).filter((l) => l.trim().length > 0);
 
-  const records: JsonRecord[] = [];
+  const records: ParsedRecord[] = [];
   const uniqueLogins = new Set<string>();
 
   for (let i = 0; i < lines.length; i++) {
@@ -287,7 +331,7 @@ async function main(): Promise<void> {
         if (typeof login === 'string' && login.trim().length > 0) {
           uniqueLogins.add(login);
         }
-        records.push(rec);
+        records.push({ lineNumber: i + 1, record: rec });
       }
     } catch (e) {
       throw new Error(
@@ -296,15 +340,21 @@ async function main(): Promise<void> {
     }
   }
 
+  assertEveryRecordHasUserIdentity(records);
+
+  const plainRecords = records.map(({ record }) => record);
   const map = new Map<string, string>();
   const used = new Set<string>();
+  const userIdMap = buildSequentialUserIdMap(plainRecords);
 
   for (const login of uniqueLogins) {
     anonymizeLogin(login, used, map);
   }
 
   const outputLines: string[] = [];
-  for (const rec of records) {
+  for (const { record: rec } of records) {
+    const userKey = getUserIdentityKey(rec);
+
     if (typeof rec.enterprise_id === 'string') {
       rec.enterprise_id = ENTERPRISE_ID_ANON;
     }
@@ -313,6 +363,12 @@ async function main(): Promise<void> {
       rec.user_login = anonymizeLogin(rec.user_login, used, map);
     }
 
+    const anonymizedUserId = userKey ? userIdMap.get(userKey) : undefined;
+    if (!anonymizedUserId) {
+      throw new Error('Cannot assign anonymized user_id because the record is missing a user key');
+    }
+    rec.user_id = anonymizedUserId;
+
     outputLines.push(JSON.stringify(rec));
   }
 
@@ -320,10 +376,14 @@ async function main(): Promise<void> {
 
   console.log(`Processed ${records.length} records.`);
   console.log(`Anonymized ${uniqueLogins.size} unique user_login values.`);
+  console.log(`Reassigned ${userIdMap.size} unique user_id values to the range 1-${userIdMap.size}.`);
   console.log(`Wrote ${outputPath}`);
 }
 
-main().catch((error) => {
-  console.error('Anonymization failed:', error instanceof Error ? error.message : error);
-  process.exitCode = 1;
-});
+const entryPoint = process.argv[1];
+if (entryPoint && import.meta.url === pathToFileURL(path.resolve(entryPoint)).href) {
+  void main().catch((error) => {
+    console.error('Anonymization failed:', error instanceof Error ? error.message : error);
+    process.exitCode = 1;
+  });
+}

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test": "vitest",
     "test:ui": "vitest --ui",
     "test:run": "vitest run",
+    "anonymize:report": "node --experimental-strip-types data-utils/anonymize-report.ts",
     "update:plugins": "node --experimental-strip-types data-utils/update-plugin-versions.ts"
   },
   "dependencies": {


### PR DESCRIPTION
## Why
The sample report still carried large anonymized `user_id` values, which made the fixture harder to reason about and harder to regenerate consistently. This change teaches the anonymizer to remap each unique user to a compact sequential ID range so the sample data stays simpler and more predictable.

## What changed
- extend `data-utils/anonymize-report.ts` to build a first-seen mapping from each unique user identity to `user_id` values `1..N`
- validate input records up front so the script fails clearly if a record is missing both `user_login` and `user_id`
- add a dedicated `anonymize:report` npm script and regression tests for identity-key selection and sequential ID assignment
- regenerate `public/data/sample-report.ndjson` with the updated remapping logic

## Notes
- `user_id` remains a JSON number, so the regenerated fixture uses numeric IDs `1..177` rather than zero-padded strings like `0001`
- the sample report now contains 177 unique users mapped into that sequential range

## Validation
- `npm run anonymize:report -- public/data/sample-report.ndjson <temp-output>`
- `npm run build`
- `npm run lint`
- `npm run test:run`