### PR TITLE
Update Pages workflows for Node 24

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,8 +9,6 @@ on:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 jobs:
   build:
@@ -70,6 +68,9 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
     concurrency:
       group: "pages"
       cancel-in-progress: false

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,20 +12,16 @@ permissions:
   pages: write
   id-token: write
 
-concurrency:
-  group: "pages"
-  cancel-in-progress: false
-
 jobs:
   build:
     runs-on: ubuntu-latest
     
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '24'
           cache: 'npm'
@@ -40,11 +36,11 @@ jobs:
         run: npm run test:run
 
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
         if: github.ref == 'refs/heads/main'
           
       - name: Restore cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         if: github.ref == 'refs/heads/main'
         with:
           path: |
@@ -64,7 +60,7 @@ jobs:
           NODE_ENV: production
         
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         if: github.ref == 'refs/heads/main'
         with:
           path: ./out
@@ -74,10 +70,13 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
+    concurrency:
+      group: "pages"
+      cancel-in-progress: false
     needs: build
     if: github.ref == 'refs/heads/main'
     
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/update-plugins.yml
+++ b/.github/workflows/update-plugins.yml
@@ -1,4 +1,5 @@
 name: Scheduled Plugin Versions Update
+
 permissions:
   contents: write
   pull-requests: write
@@ -14,12 +15,12 @@ jobs:
 
     steps:
       - name: Checkout main
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: main
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '24'
           cache: 'npm'


### PR DESCRIPTION
## Summary
Updates the GitHub Actions workflows used for Pages deployment and plugin maintenance so they use Node 24-compatible official actions, scopes Pages concurrency to the actual deploy job so PR validation runs do not block production deployments, and limits elevated Pages permissions to the deploy job only.

| Commit | Change |
|--------|--------|
| `ci: update pages workflows for Node 24` | Upgrades the official GitHub Actions used by the Pages and plugin workflows to Node 24-capable majors, and moves the `pages` concurrency lock from workflow scope to the deploy job so PR runs stop blocking `main` deployments. |
| `ci: scope Pages deploy permissions` | Keeps workflow defaults read-only and grants `pages: write` plus `id-token: write` only to the deploy job, addressing review feedback about PR validation token scope. |

## Validation
- `npm run build`
- `npm run lint`
- `npm run test:run`