### PR TITLE
Add Auto Mode usage insights

### DIFF
--- a/src/components/ModelDetailsView.tsx
+++ b/src/components/ModelDetailsView.tsx
@@ -3,6 +3,7 @@
 import React, { useMemo } from 'react';
 import ModelsUsageChart from './charts/ModelsUsageChart';
 import DailyPremiumBaseChart from './charts/DailyPremiumBaseChart';
+import AutoModeAdoptionTrendChart from './charts/AutoModeAdoptionTrendChart';
 import type { ModelBreakdownData } from '../types/metrics';
 import { ViewPanel } from './ui';
 
@@ -11,8 +12,41 @@ interface ModelDetailsViewProps {
 }
 
 export default function ModelDetailsView({ modelBreakdownData }: ModelDetailsViewProps) {
+  const autoModels = modelBreakdownData.autoModels ?? [];
+  const autoModeAdoptionTrend = modelBreakdownData.autoModeAdoptionTrend ?? [];
+
+  const autoModelEntries = useMemo(
+    () => autoModels,
+    [autoModels]
+  );
+
+  const premiumModelEntries = useMemo(
+    () => modelBreakdownData.premiumModels.filter(entry => entry.model !== 'auto'),
+    [modelBreakdownData.premiumModels]
+  );
+
+  const autoTotal = useMemo(
+    () => autoModelEntries.reduce((sum, entry) => sum + entry.total, 0),
+    [autoModelEntries]
+  );
+
+  const premiumTotalWithoutAuto = useMemo(
+    () => premiumModelEntries.reduce((sum, entry) => sum + entry.total, 0),
+    [premiumModelEntries]
+  );
+
+  const premiumBreakdownWithoutAuto = useMemo(
+    () => ({
+      ...modelBreakdownData,
+      premiumModels: premiumModelEntries,
+      premiumTotal: premiumTotalWithoutAuto,
+    }),
+    [modelBreakdownData, premiumModelEntries, premiumTotalWithoutAuto]
+  );
+
   const premiumUtilization = useMemo(() => {
-    const { premiumTotal, standardTotal, unknownTotal } = modelBreakdownData;
+    const { standardTotal, unknownTotal } = modelBreakdownData;
+    const premiumTotal = premiumTotalWithoutAuto;
 
     const trackedTotal = premiumTotal + standardTotal;
     const numberFormatter = new Intl.NumberFormat();
@@ -116,7 +150,7 @@ export default function ModelDetailsView({ modelBreakdownData }: ModelDetailsVie
           ? `There are ${numberFormatter.format(unknownTotal)} interactions from models that are not yet tagged as premium or standard.`
           : undefined
     };
-  }, [modelBreakdownData]);
+  }, [modelBreakdownData, premiumTotalWithoutAuto]);
 
   return (
     <ViewPanel
@@ -162,9 +196,11 @@ export default function ModelDetailsView({ modelBreakdownData }: ModelDetailsVie
             </div>
           </div>
         )}
-        <DailyPremiumBaseChart modelBreakdownData={modelBreakdownData} />
+        <DailyPremiumBaseChart modelBreakdownData={premiumBreakdownWithoutAuto} />
+        <ModelsUsageChart modelEntries={autoModelEntries} dates={modelBreakdownData.dates} totalInteractions={autoTotal} variant="auto" />
+        <AutoModeAdoptionTrendChart data={autoModeAdoptionTrend} />
         <ModelsUsageChart modelEntries={modelBreakdownData.standardModels} dates={modelBreakdownData.dates} totalInteractions={modelBreakdownData.standardTotal} variant="standard" />
-        <ModelsUsageChart modelEntries={modelBreakdownData.premiumModels} dates={modelBreakdownData.dates} totalInteractions={modelBreakdownData.premiumTotal} variant="premium" />
+        <ModelsUsageChart modelEntries={premiumModelEntries} dates={modelBreakdownData.dates} totalInteractions={premiumTotalWithoutAuto} variant="premium" />
       </div>
     </ViewPanel>
   );

--- a/src/components/UniqueUsersView.tsx
+++ b/src/components/UniqueUsersView.tsx
@@ -139,6 +139,11 @@ export default function UniqueUsersView({ users, onUserClick }: UniqueUsersViewP
               Cloud Agent
             </span>
           )}
+          {user.used_auto_mode && (
+            <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-violet-100 text-violet-800">
+              Auto Mode
+            </span>
+          )}
           {user.total_code_generation_activities > 0 && (
             <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-800">
               Completions

--- a/src/components/UserDetailsView.tsx
+++ b/src/components/UserDetailsView.tsx
@@ -156,6 +156,14 @@ export default function UserDetailsView({ userDetails, userSummary, userLogin, u
   const usedCodingAgent = userSummary.used_copilot_coding_agent;
 
   const { featureAggregates, ideAggregates, languageFeatureAggregates, modelFeatureAggregates } = userDetails;
+  const usedAutoMode = userSummary.used_auto_mode ?? modelFeatureAggregates.some(item => {
+    const activityCount =
+      item.user_initiated_interaction_count +
+      item.code_generation_activity_count +
+      item.code_acceptance_activity_count;
+
+    return item.model.trim().toLowerCase() === 'auto' && activityCount > 0;
+  });
 
   const agentInteractions = featureAggregates
     .filter(f => f.feature === 'chat_panel_agent_mode')
@@ -670,6 +678,7 @@ export default function UserDetailsView({ userDetails, userSummary, userLogin, u
         usedAgent={usedAgent}
         usedCli={usedCli}
         usedCodingAgent={usedCodingAgent}
+        usedAutoMode={usedAutoMode}
         ideChartData={ideAggregates.length > 0 || totalCliPrompts > 0 ? ideChartData : undefined}
         languageChartData={Object.keys(languageGenerations).length > 0 ? languageChartData : undefined}
         modelChartData={Object.keys(modelInteractions).length > 0 ? modelChartData : undefined}

--- a/src/components/charts/AutoModeAdoptionTrendChart.tsx
+++ b/src/components/charts/AutoModeAdoptionTrendChart.tsx
@@ -1,0 +1,164 @@
+'use client';
+
+import type { TooltipItem } from 'chart.js';
+import { Chart } from 'react-chartjs-2';
+import { registerChartJS } from './utils/chartSetup';
+import { createDualAxisChartOptions } from './utils/chartOptions';
+import { chartColors } from './utils/chartColors';
+import { computeAverageRetention, computeRetentionRates } from './utils/chartStyles';
+import { formatShortDate } from '../../utils/formatters';
+import type { AutoModeAdoptionTrendEntry } from '../../types/metrics';
+import ChartContainer from '../ui/ChartContainer';
+import InsightsCard from '../ui/InsightsCard';
+
+registerChartJS();
+
+interface AutoModeAdoptionTrendChartProps {
+  data: AutoModeAdoptionTrendEntry[];
+}
+
+export default function AutoModeAdoptionTrendChart({ data }: AutoModeAdoptionTrendChartProps) {
+  const activeData = data.filter(d => d.totalActiveUsers > 0);
+  const totalNewUsers = data.reduce((sum, d) => sum + d.newUsers, 0);
+  const avgDailyActive = activeData.length > 0
+    ? activeData.reduce((sum, d) => sum + d.totalActiveUsers, 0) / activeData.length
+    : 0;
+  const peakUsers = data.reduce((max, d) => Math.max(max, d.totalActiveUsers), 0);
+  const cumulativeTotal = data.length > 0 ? data[data.length - 1].cumulativeUsers : 0;
+  const retentionRates = computeRetentionRates(data);
+  const avgRetention = computeAverageRetention(activeData);
+
+  const chartData = {
+    labels: data.map(d => formatShortDate(d.date)),
+    datasets: [
+      {
+        type: 'bar' as const,
+        label: 'New Auto Users',
+        data: data.map(d => d.newUsers),
+        backgroundColor: chartColors.violet.alpha60,
+        borderColor: chartColors.violet.solid,
+        borderWidth: 1,
+        yAxisID: 'y',
+        stack: 'users',
+      },
+      {
+        type: 'bar' as const,
+        label: 'Returning Auto Users',
+        data: data.map(d => d.returningUsers),
+        backgroundColor: chartColors.green.alpha60,
+        borderColor: chartColors.green.solid,
+        borderWidth: 1,
+        yAxisID: 'y',
+        stack: 'users',
+      },
+      {
+        type: 'line' as const,
+        label: 'Cumulative Auto Users',
+        data: data.map(d => d.cumulativeUsers),
+        backgroundColor: chartColors.purple.alpha,
+        borderColor: chartColors.purple.solid,
+        borderWidth: 3,
+        fill: false,
+        tension: 0.4,
+        pointRadius: 3,
+        pointHoverRadius: 5,
+        yAxisID: 'y1',
+      },
+      {
+        type: 'line' as const,
+        label: 'Retention Rate',
+        data: retentionRates,
+        backgroundColor: chartColors.amber.alpha,
+        borderColor: chartColors.amber.solid,
+        borderWidth: 2,
+        borderDash: [5, 3],
+        fill: false,
+        tension: 0.4,
+        pointRadius: 2,
+        pointHoverRadius: 4,
+        spanGaps: true,
+        yAxisID: 'y2',
+      },
+    ],
+  };
+
+  const options = {
+    ...createDualAxisChartOptions({
+      xAxisLabel: 'Date',
+      yAxisLabel: 'Daily Active Auto Users',
+      y1AxisLabel: 'Cumulative Auto Users',
+      tooltipAfterBodyCallback: (context: TooltipItem<'line' | 'bar'>[]) => {
+        const dataIndex = context[0].dataIndex;
+        const day = data[dataIndex];
+        const retention = retentionRates[dataIndex];
+        return [
+          '',
+          `Total Active: ${day.totalActiveUsers}`,
+          `New: ${day.newUsers}`,
+          `Returning: ${day.returningUsers}`,
+          `Cumulative: ${day.cumulativeUsers}`,
+          `Retention: ${retention !== null ? `${retention}%` : 'N/A'}`,
+        ];
+      },
+    }),
+    scales: {
+      x: {
+        stacked: true,
+        display: true,
+        title: { display: true, text: 'Date' },
+        ticks: { maxRotation: 45, autoSkip: true },
+      },
+      y: {
+        stacked: true,
+        type: 'linear' as const,
+        display: true,
+        position: 'left' as const,
+        title: { display: true, text: 'Daily Active Auto Users' },
+        beginAtZero: true,
+        ticks: { stepSize: 1 },
+      },
+      y1: {
+        type: 'linear' as const,
+        display: true,
+        position: 'right' as const,
+        title: { display: true, text: 'Cumulative Auto Users' },
+        beginAtZero: true,
+        grid: { drawOnChartArea: false },
+      },
+      y2: {
+        type: 'linear' as const,
+        display: false,
+        min: 0,
+        max: 100,
+      },
+    },
+  };
+
+  const insightVariant = avgRetention >= 50 ? 'green' : cumulativeTotal > 0 ? 'blue' : 'orange';
+
+  return (
+    <ChartContainer
+      title="Auto Mode Adoption Trend"
+      description="New vs returning users choosing Copilot Auto mode per day, with cumulative growth and retention rate."
+      isEmpty={data.length === 0 || cumulativeTotal === 0}
+      emptyState="No Auto mode adoption data available"
+      summaryStats={[
+        { value: cumulativeTotal, label: 'Total Auto Users', colorClass: 'text-purple-600' },
+        { value: totalNewUsers, label: 'New Users (period)', colorClass: 'text-violet-600' },
+        { value: avgDailyActive.toFixed(1), label: 'Avg Daily Active', colorClass: 'text-green-600' },
+        { value: peakUsers, label: 'Peak Daily Users', colorClass: 'text-indigo-600' },
+        { value: `${avgRetention}%`, label: 'Avg Retention', colorClass: 'text-amber-600' },
+      ]}
+      footer={cumulativeTotal > 0 ? (
+        <InsightsCard title="Auto Mode Adoption" variant={insightVariant}>
+          Auto mode reached {cumulativeTotal.toLocaleString()} unique users in this reporting window, with a peak of {peakUsers.toLocaleString()} active users on a single day.
+          {avgRetention > 0 && ` Average retention across active Auto days is ${avgRetention}%.`}
+        </InsightsCard>
+      ) : undefined}
+    >
+      <div className="h-full">
+        <Chart type="bar" data={chartData} options={options} />
+      </div>
+    </ChartContainer>
+  );
+}

--- a/src/components/charts/ModelsUsageChart.tsx
+++ b/src/components/charts/ModelsUsageChart.tsx
@@ -5,6 +5,7 @@ import { TooltipItem } from 'chart.js';
 import { Bar } from 'react-chartjs-2';
 import { registerChartJS } from './utils/chartSetup';
 import { createStackedBarChartOptions } from './utils/chartOptions';
+import { chartColors } from './utils/chartColors';
 import { formatShortDate } from '../../utils/formatters';
 import type { ModelDailyUsageEntry } from '../../types/metrics';
 import ChartContainer from '../ui/ChartContainer';
@@ -16,11 +17,12 @@ interface ModelsUsageChartProps {
   modelEntries: ModelDailyUsageEntry[];
   dates: string[];
   totalInteractions: number;
-  variant: 'standard' | 'premium';
+  variant: 'standard' | 'premium' | 'auto';
 }
 
 export default function ModelsUsageChart({ modelEntries, dates, totalInteractions, variant }: ModelsUsageChartProps) {
   const isPremium = variant === 'premium';
+  const isAuto = variant === 'auto';
 
   const { labels, datasets, modelTotals, modelOrder } = useMemo(() => {
     const sortedModels = [...modelEntries].sort((a, b) => b.total - a.total);
@@ -35,6 +37,9 @@ export default function ModelsUsageChart({ modelEntries, dates, totalInteraction
     const modelIndexMap = new Map(modelsWithoutUnknown.map((m, i) => [m, i]));
 
     const getModelColor = (model: string): string => {
+      if (isAuto || model === 'auto') {
+        return chartColors.violet.solid;
+      }
       if (model === 'unknown') {
         return UNKNOWN_COLOR;
       }
@@ -56,7 +61,7 @@ export default function ModelsUsageChart({ modelEntries, dates, totalInteraction
         backgroundColor: color,
         borderColor: color,
         borderWidth: 1,
-        stack: isPremium ? 'premium-models' : 'standard-models'
+        stack: isAuto ? 'auto-models' : isPremium ? 'premium-models' : 'standard-models'
       };
     });
 
@@ -66,9 +71,10 @@ export default function ModelsUsageChart({ modelEntries, dates, totalInteraction
       modelTotals,
       modelOrder
     };
-  }, [modelEntries, dates, isPremium]);
+  }, [modelEntries, dates, isPremium, isAuto]);
 
   const insights = useMemo(() => {
+    if (isAuto) return null;
     if (!totalInteractions || !modelOrder.length) return null;
 
     const shares = modelOrder.map(m => ({
@@ -119,7 +125,7 @@ export default function ModelsUsageChart({ modelEntries, dates, totalInteraction
     paragraphs.push(`Top model share summary: ${summary}${shares.length > 5 ? ', ...' : ''}.`);
 
     return { title, variant: insightVariant, paragraphs, showDocLink };
-  }, [modelTotals, modelOrder, totalInteractions, isPremium]);
+  }, [modelTotals, modelOrder, totalInteractions, isPremium, isAuto]);
 
   const chartData = { labels, datasets };
 
@@ -139,18 +145,19 @@ export default function ModelsUsageChart({ modelEntries, dates, totalInteraction
 
   return (
     <ChartContainer
-      title={`${isPremium ? 'Premium' : 'Standard'} Models Daily Usage`}
+      title={isAuto ? 'Auto Model Daily Usage' : `${isPremium ? 'Premium' : 'Standard'} Models Daily Usage`}
+      description={isAuto ? 'Daily interactions routed through Copilot Auto mode.' : undefined}
       isEmpty={dates.length === 0 || datasets.length === 0}
-      emptyState={`No ${isPremium ? 'premium' : 'standard'} model usage data available`}
+      emptyState={`No ${isAuto ? 'auto' : isPremium ? 'premium' : 'standard'} model usage data available`}
       summaryStats={[
-        { value: datasets.length, label: 'Models', colorClass: isPremium ? 'text-purple-600' : 'text-blue-600' },
-        { value: totalInteractions, label: 'Total Interactions', colorClass: isPremium ? 'text-red-600' : 'text-green-600' },
+        { value: datasets.length, label: isAuto ? 'Auto Models' : 'Models', colorClass: isAuto ? 'text-violet-600' : isPremium ? 'text-purple-600' : 'text-blue-600' },
+        { value: totalInteractions, label: 'Total Interactions', colorClass: isAuto ? 'text-purple-600' : isPremium ? 'text-red-600' : 'text-green-600' },
       ]}
       chartHeight="h-96"
       footer={
         <>
           <p className="text-xs text-gray-600 mb-4">
-            Counts aggregate user initiated interactions across all features per {isPremium ? 'premium' : 'standard'} model per day.
+            Counts aggregate user initiated interactions across all features per {isAuto ? 'auto' : isPremium ? 'premium' : 'standard'} model per day.
           </p>
           {insights && (
             <InsightsCard title={insights.title} variant={insights.variant}>

--- a/src/components/charts/UserSummaryChart.tsx
+++ b/src/components/charts/UserSummaryChart.tsx
@@ -12,6 +12,7 @@ interface UserSummaryChartProps {
   usedAgent: boolean;
   usedCli: boolean;
   usedCodingAgent: boolean;
+  usedAutoMode: boolean;
   ideChartData?: ChartData<'pie'>;
   languageChartData?: ChartData<'pie'>;
   modelChartData?: ChartData<'pie'>;
@@ -27,6 +28,7 @@ export default function UserSummaryChart({
   usedAgent,
   usedCli,
   usedCodingAgent,
+  usedAutoMode,
   ideChartData,
   languageChartData,
   modelChartData,
@@ -58,7 +60,12 @@ export default function UserSummaryChart({
               Cloud Agent
             </span>
           )}
-          {!usedChat && !usedAgent && !usedCli && !usedCodingAgent && (
+          {usedAutoMode && (
+            <span className="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-violet-100 text-violet-800">
+              Auto Mode
+            </span>
+          )}
+          {!usedChat && !usedAgent && !usedCli && !usedCodingAgent && !usedAutoMode && (
             <span className="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-gray-100 text-gray-800">
               Completion Only
             </span>

--- a/src/components/ui/ChartContainer.tsx
+++ b/src/components/ui/ChartContainer.tsx
@@ -29,6 +29,10 @@ export interface ChartContainerProps {
   chartHeight?: string;
 }
 
+function formatStatValue(value: string | number): string | number {
+  return typeof value === 'number' && !Number.isFinite(value) ? 'N/A' : value;
+}
+
 export default function ChartContainer({
   title,
   description,
@@ -66,7 +70,7 @@ export default function ChartContainer({
               {stats.map((stat, index) => (
                 <div key={index} className="text-sm text-gray-600 print:text-[10px] print:leading-tight">
                   <span className="font-medium">{stat.label}:</span>{' '}
-                  <span className={stat.color}>{stat.value}</span>
+                  <span className={stat.color}>{formatStatValue(stat.value)}</span>
                 </div>
               ))}
             </div>
@@ -80,7 +84,7 @@ export default function ChartContainer({
           {summaryStats.map((stat, index) => (
             <div key={index} className="text-center min-w-[100px] print:min-w-[70px]">
               <div className={`text-2xl font-bold print:text-base ${stat.colorClass || 'text-gray-900'}`}>
-                {stat.value}
+                {formatStatValue(stat.value)}
               </div>
               <div className="text-sm text-gray-600 print:text-[10px]">{stat.label}</div>
               {stat.sublabel && <div className="text-xs text-gray-500 print:text-[9px]">{stat.sublabel}</div>}

--- a/src/domain/__tests__/metricsAggregator.test.ts
+++ b/src/domain/__tests__/metricsAggregator.test.ts
@@ -111,17 +111,38 @@ describe('metricsAggregator', () => {
         used_cli: true,
       });
 
-      const { aggregated } = aggregateMetrics([agentUser, chatUser, cliUser]);
+      const autoUser = createBasicMetric({
+        user_id: 4,
+        used_agent: false,
+        used_chat: true,
+        used_cli: false,
+        totals_by_model_feature: [
+          {
+            model: 'auto',
+            feature: 'agent_edit',
+            user_initiated_interaction_count: 0,
+            code_generation_activity_count: 1,
+            code_acceptance_activity_count: 0,
+            loc_added_sum: 1,
+            loc_deleted_sum: 1,
+            loc_suggested_to_add_sum: 0,
+            loc_suggested_to_delete_sum: 0,
+          },
+        ],
+      });
 
-      expect(aggregated.stats.uniqueUsers).toBe(3);
+      const { aggregated } = aggregateMetrics([agentUser, chatUser, cliUser, autoUser]);
+
+      expect(aggregated.stats.uniqueUsers).toBe(4);
       expect(aggregated.stats.agentUsers).toBe(1);
-      expect(aggregated.stats.chatUsers).toBe(1);
+      expect(aggregated.stats.chatUsers).toBe(2);
       expect(aggregated.stats.cliUsers).toBe(1);
 
       const summaries = aggregated.userSummaries;
       expect(summaries.find(u => u.user_id === 1)?.used_agent).toBe(true);
       expect(summaries.find(u => u.user_id === 2)?.used_chat).toBe(true);
       expect(summaries.find(u => u.user_id === 3)?.used_cli).toBe(true);
+      expect(summaries.find(u => u.user_id === 4)?.used_auto_mode).toBe(true);
     });
 
     it('should accumulate user flags across multiple days (OR logic)', () => {
@@ -242,6 +263,97 @@ describe('metricsAggregator', () => {
 
       expect(aggregated.modelUsageData).toBeDefined();
       expect(aggregated.modelUsageData.length).toBeGreaterThan(0);
+    });
+
+    it('should compute Auto mode adoption trend from auto model usage', () => {
+      const autoFeature = {
+        model: 'auto',
+        feature: 'chat_panel',
+        user_initiated_interaction_count: 5,
+        code_generation_activity_count: 0,
+        code_acceptance_activity_count: 0,
+        loc_added_sum: 0,
+        loc_deleted_sum: 0,
+        loc_suggested_to_add_sum: 0,
+        loc_suggested_to_delete_sum: 0,
+      };
+
+      const day1User1 = createBasicMetric({
+        user_id: 1,
+        day: '2024-01-15',
+        totals_by_model_feature: [autoFeature],
+      });
+      const day1User2 = createBasicMetric({
+        user_id: 2,
+        day: '2024-01-15',
+        totals_by_model_feature: [autoFeature],
+      });
+      const day2User1 = createBasicMetric({
+        user_id: 1,
+        day: '2024-01-16',
+        totals_by_model_feature: [autoFeature],
+      });
+
+      const { aggregated } = aggregateMetrics([day1User1, day1User2, day2User1]);
+
+      expect(aggregated.modelBreakdownData.autoModeAdoptionTrend).toEqual([
+        {
+          date: '2024-01-15',
+          newUsers: 2,
+          returningUsers: 0,
+          totalActiveUsers: 2,
+          cumulativeUsers: 2,
+        },
+        {
+          date: '2024-01-16',
+          newUsers: 0,
+          returningUsers: 1,
+          totalActiveUsers: 1,
+          cumulativeUsers: 2,
+        },
+      ]);
+      expect(aggregated.modelBreakdownData.premiumModels.some(entry => entry.model === 'auto')).toBe(false);
+      expect(aggregated.modelBreakdownData.premiumTotal).toBe(0);
+    });
+
+    it('should count Auto model activity even when user initiated interactions are zero', () => {
+      const metric = createBasicMetric({
+        user_id: 1,
+        day: '2024-01-15',
+        totals_by_model_feature: [
+          {
+            model: 'auto',
+            feature: 'agent_edit',
+            user_initiated_interaction_count: 0,
+            code_generation_activity_count: 1,
+            code_acceptance_activity_count: 0,
+            loc_added_sum: 1,
+            loc_deleted_sum: 1,
+            loc_suggested_to_add_sum: 0,
+            loc_suggested_to_delete_sum: 0,
+          },
+        ],
+      });
+
+      const { aggregated } = aggregateMetrics([metric]);
+
+      expect(aggregated.modelBreakdownData.autoModels).toEqual([
+        {
+          model: 'auto',
+          total: 1,
+          dailyData: { '2024-01-15': 1 },
+        },
+      ]);
+      expect(aggregated.modelBreakdownData.autoModeAdoptionTrend).toEqual([
+        {
+          date: '2024-01-15',
+          newUsers: 1,
+          returningUsers: 0,
+          totalActiveUsers: 1,
+          cumulativeUsers: 1,
+        },
+      ]);
+      expect(aggregated.userSummaries[0].used_auto_mode).toBe(true);
     });
 
     it('should process feature adoption data when provided', () => {

--- a/src/domain/calculators/modelBreakdownCalculator.ts
+++ b/src/domain/calculators/modelBreakdownCalculator.ts
@@ -1,4 +1,4 @@
-import type { ModelBreakdownData, ModelDailyUsageEntry } from '../../types/metrics';
+import type { AutoModeAdoptionTrendEntry, ModelBreakdownData, ModelDailyUsageEntry } from '../../types/metrics';
 import { KNOWN_MODELS } from '../modelConfig';
 
 interface ModelAccEntry {
@@ -10,6 +10,8 @@ export interface ModelBreakdownAccumulator {
   modelClassification: Record<string, boolean>;
   premiumModels: Map<string, ModelAccEntry>;
   standardModels: Map<string, ModelAccEntry>;
+  autoModels: Map<string, ModelAccEntry>;
+  autoModeUsersByDate: Map<string, Set<number>>;
   premiumTotal: number;
   standardTotal: number;
   unknownTotal: number;
@@ -29,6 +31,8 @@ export function createModelBreakdownAccumulator(): ModelBreakdownAccumulator {
     modelClassification,
     premiumModels: new Map(),
     standardModels: new Map(),
+    autoModels: new Map(),
+    autoModeUsersByDate: new Map(),
     premiumTotal: 0,
     standardTotal: 0,
     unknownTotal: 0,
@@ -39,36 +43,60 @@ export function createModelBreakdownAccumulator(): ModelBreakdownAccumulator {
 export function accumulateModelBreakdown(
   accumulator: ModelBreakdownAccumulator,
   date: string,
+  userId: number,
   modelFeature: {
     model: string;
     user_initiated_interaction_count: number;
+    code_generation_activity_count: number;
+    code_acceptance_activity_count: number;
   }
 ): void {
-  const count = modelFeature.user_initiated_interaction_count || 0;
-  if (!count) return;
+  const interactionCount = modelFeature.user_initiated_interaction_count || 0;
+  const activityCount = (modelFeature.code_generation_activity_count || 0) + (modelFeature.code_acceptance_activity_count || 0);
+  const normalizedModel = modelFeature.model.trim().toLowerCase();
+
+  if (normalizedModel === 'auto' && (interactionCount > 0 || activityCount > 0)) {
+    accumulator.allDates.add(date);
+    if (!accumulator.autoModeUsersByDate.has(date)) {
+      accumulator.autoModeUsersByDate.set(date, new Set());
+    }
+    accumulator.autoModeUsersByDate.get(date)!.add(userId);
+
+    if (!accumulator.autoModels.has(normalizedModel)) {
+      accumulator.autoModels.set(normalizedModel, { total: 0, dailyData: new Map() });
+    }
+    const entry = accumulator.autoModels.get(normalizedModel)!;
+    const autoUsageCount = interactionCount > 0 ? interactionCount : activityCount;
+    entry.total += autoUsageCount;
+    entry.dailyData.set(date, (entry.dailyData.get(date) || 0) + autoUsageCount);
+    return;
+  }
+
+  if (!interactionCount) {
+    return;
+  }
 
   accumulator.allDates.add(date);
-  const normalizedModel = modelFeature.model.trim().toLowerCase();
   const classification = accumulator.modelClassification[normalizedModel];
 
   if (classification === true) {
-    accumulator.premiumTotal += count;
+    accumulator.premiumTotal += interactionCount;
     if (!accumulator.premiumModels.has(normalizedModel)) {
       accumulator.premiumModels.set(normalizedModel, { total: 0, dailyData: new Map() });
     }
     const entry = accumulator.premiumModels.get(normalizedModel)!;
-    entry.total += count;
-    entry.dailyData.set(date, (entry.dailyData.get(date) || 0) + count);
+    entry.total += interactionCount;
+    entry.dailyData.set(date, (entry.dailyData.get(date) || 0) + interactionCount);
   } else if (classification === false) {
-    accumulator.standardTotal += count;
+    accumulator.standardTotal += interactionCount;
     if (!accumulator.standardModels.has(normalizedModel)) {
       accumulator.standardModels.set(normalizedModel, { total: 0, dailyData: new Map() });
     }
     const entry = accumulator.standardModels.get(normalizedModel)!;
-    entry.total += count;
-    entry.dailyData.set(date, (entry.dailyData.get(date) || 0) + count);
+    entry.total += interactionCount;
+    entry.dailyData.set(date, (entry.dailyData.get(date) || 0) + interactionCount);
   } else {
-    accumulator.unknownTotal += count;
+    accumulator.unknownTotal += interactionCount;
   }
 }
 
@@ -90,6 +118,36 @@ function buildModelEntries(
     .sort((a, b) => b.total - a.total);
 }
 
+function computeAutoModeAdoptionTrend(
+  dates: string[],
+  usersByDate: Map<string, Set<number>>
+): AutoModeAdoptionTrendEntry[] {
+  const seenBefore = new Set<number>();
+
+  return dates.map((date) => {
+    const users = usersByDate.get(date) ?? new Set<number>();
+    let newUsers = 0;
+    let returningUsers = 0;
+
+    for (const userId of users) {
+      if (seenBefore.has(userId)) {
+        returningUsers++;
+      } else {
+        newUsers++;
+        seenBefore.add(userId);
+      }
+    }
+
+    return {
+      date,
+      newUsers,
+      returningUsers,
+      totalActiveUsers: newUsers + returningUsers,
+      cumulativeUsers: seenBefore.size,
+    };
+  });
+}
+
 export function computeModelBreakdownData(
   accumulator: ModelBreakdownAccumulator
 ): ModelBreakdownData {
@@ -100,6 +158,8 @@ export function computeModelBreakdownData(
   return {
     premiumModels: buildModelEntries(accumulator.premiumModels),
     standardModels: buildModelEntries(accumulator.standardModels),
+    autoModels: buildModelEntries(accumulator.autoModels),
+    autoModeAdoptionTrend: computeAutoModeAdoptionTrend(dates, accumulator.autoModeUsersByDate),
     dates,
     premiumTotal: accumulator.premiumTotal,
     standardTotal: accumulator.standardTotal,

--- a/src/domain/metricsAggregator.ts
+++ b/src/domain/metricsAggregator.ts
@@ -144,6 +144,17 @@ function createUserSummaryAccumulator(): UserSummaryAccumulator {
   };
 }
 
+function hasAutoModeActivity(metric: CopilotMetrics): boolean {
+  return metric.totals_by_model_feature.some(modelFeature => {
+    const activityCount =
+      modelFeature.user_initiated_interaction_count +
+      modelFeature.code_generation_activity_count +
+      modelFeature.code_acceptance_activity_count;
+
+    return modelFeature.model.trim().toLowerCase() === 'auto' && activityCount > 0;
+  });
+}
+
 function accumulateUserSummary(
   accumulator: UserSummaryAccumulator,
   metric: CopilotMetrics
@@ -167,6 +178,7 @@ function accumulateUserSummary(
       used_chat: false,
       used_cli: false,
       used_copilot_coding_agent: false,
+      used_auto_mode: false,
       flags: [],
     });
     accumulator.userActiveDays.set(userId, new Set());
@@ -184,6 +196,7 @@ function accumulateUserSummary(
   userSummary.used_chat = userSummary.used_chat || metric.used_chat;
   userSummary.used_cli = userSummary.used_cli || metric.used_cli;
   userSummary.used_copilot_coding_agent = userSummary.used_copilot_coding_agent || metric.used_copilot_coding_agent;
+  userSummary.used_auto_mode = userSummary.used_auto_mode || hasAutoModeActivity(metric);
   accumulator.userActiveDays.get(userId)!.add(date);
 }
 
@@ -282,7 +295,7 @@ export function aggregateMetrics(
         modelFeature.user_initiated_interaction_count
       );
 
-      accumulateModelBreakdown(modelBreakdownAccumulator, date, modelFeature);
+      accumulateModelBreakdown(modelBreakdownAccumulator, date, userId, modelFeature);
     }
 
     const featureImpacts: Array<{ feature: string; locAdded: number; locDeleted: number }> = [];

--- a/src/types/metrics.ts
+++ b/src/types/metrics.ts
@@ -123,6 +123,7 @@ export interface UserSummary {
   used_chat: boolean;
   used_cli: boolean;
   used_copilot_coding_agent: boolean;
+  used_auto_mode?: boolean;
   flags: UserFlag[];
 }
 
@@ -180,9 +181,19 @@ export interface ModelDailyUsageEntry {
   dailyData: Record<string, number>;
 }
 
+export interface AutoModeAdoptionTrendEntry {
+  date: string;
+  newUsers: number;
+  returningUsers: number;
+  totalActiveUsers: number;
+  cumulativeUsers: number;
+}
+
 export interface ModelBreakdownData {
   premiumModels: ModelDailyUsageEntry[];
   standardModels: ModelDailyUsageEntry[];
+  autoModels?: ModelDailyUsageEntry[];
+  autoModeAdoptionTrend?: AutoModeAdoptionTrendEntry[];
   dates: string[];
   premiumTotal: number;
   standardTotal: number;


### PR DESCRIPTION
## Summary

Adds dedicated Auto Mode model usage and adoption visibility across model and user views.

| Commit | Change |
|--------|--------|
| `feat: add auto mode usage insights` | Adds Auto model daily usage and Auto Mode adoption trend charts, tracks Auto Mode as a user feature tag, keeps Auto usage separate from premium model totals, and covers Auto activity edge cases with regression tests. |

## Validation

- `npm run build && npm run lint && npm run test:run`