### PR TITLE
Support CLI LOC and cloud agent report fields

### DIFF
--- a/src/components/charts/ClientActivityChart.tsx
+++ b/src/components/charts/ClientActivityChart.tsx
@@ -58,6 +58,11 @@ interface CliFeatureTotals {
   locSuggestedToDelete: number;
 }
 
+interface CliDayTotals extends CliFeatureTotals {
+  promptCount: number;
+  interactionCount: number;
+}
+
 const IDE_COLORS: Record<string, string> = {
   'vscode': '#007ACC',
   'visual_studio': '#5C2D91',
@@ -109,9 +114,16 @@ function getCliFeatureTotals(day: UserDayData): CliFeatureTotals {
   }, createEmptyCliFeatureTotals());
 }
 
-function getCliInteractionCount(day: UserDayData): number {
-  const featureInteractions = getCliFeatureTotals(day).interactions;
-  return featureInteractions > 0 ? featureInteractions : day.totals_by_cli?.prompt_count ?? 0;
+function getCliDayTotals(day: UserDayData): CliDayTotals {
+  const featureTotals = getCliFeatureTotals(day);
+  const promptCount = day.totals_by_cli?.prompt_count ?? 0;
+  const interactionCount = featureTotals.interactions > 0 ? featureTotals.interactions : promptCount;
+
+  return {
+    ...featureTotals,
+    promptCount,
+    interactionCount,
+  };
 }
 
 /**
@@ -130,23 +142,8 @@ export default function ClientActivityChart({
 }: ClientActivityChartProps) {
   const [isPluginTableExpanded, setIsPluginTableExpanded] = useState(false);
 
-  const cliTotals = useMemo(() => (
-    days.reduce((acc, day) => {
-      if (day.totals_by_cli) {
-        acc.promptCount += day.totals_by_cli.prompt_count;
-      }
-
-      const featureTotals = getCliFeatureTotals(day);
-      acc.interactions += featureTotals.interactions;
-      acc.generations += featureTotals.generations;
-      acc.acceptances += featureTotals.acceptances;
-      acc.locAdded += featureTotals.locAdded;
-      acc.locDeleted += featureTotals.locDeleted;
-      acc.locSuggestedToAdd += featureTotals.locSuggestedToAdd;
-      acc.locSuggestedToDelete += featureTotals.locSuggestedToDelete;
-
-      return acc;
-    }, {
+  const { cliTotals, cliTotalsByDay } = useMemo(() => {
+    const totals = {
       promptCount: 0,
       interactions: 0,
       generations: 0,
@@ -155,8 +152,25 @@ export default function ClientActivityChart({
       locDeleted: 0,
       locSuggestedToAdd: 0,
       locSuggestedToDelete: 0,
-    })
-  ), [days]);
+    };
+    const byDay = new Map<string, CliDayTotals>();
+
+    for (const day of days) {
+      const dayTotals = getCliDayTotals(day);
+      byDay.set(day.day, dayTotals);
+
+      totals.promptCount += dayTotals.promptCount;
+      totals.interactions += dayTotals.interactions;
+      totals.generations += dayTotals.generations;
+      totals.acceptances += dayTotals.acceptances;
+      totals.locAdded += dayTotals.locAdded;
+      totals.locDeleted += dayTotals.locDeleted;
+      totals.locSuggestedToAdd += dayTotals.locSuggestedToAdd;
+      totals.locSuggestedToDelete += dayTotals.locSuggestedToDelete;
+    }
+
+    return { cliTotals: totals, cliTotalsByDay: byDay };
+  }, [days]);
 
   const barChartData = useMemo(() => {
     const allIDEs = Array.from(
@@ -183,11 +197,10 @@ export default function ClientActivityChart({
     }).filter(dataset => dataset.data.some(value => value > 0));
 
     // Add CLI dataset if any day has CLI data
-    const hasCliData = days.some(day => getCliInteractionCount(day) > 0);
+    const hasCliData = Array.from(cliTotalsByDay.values()).some(dayTotals => dayTotals.interactionCount > 0);
     if (hasCliData) {
       const cliData = allDays.map(dayStr => {
-        const dayData = dayMap.get(dayStr);
-        return dayData ? getCliInteractionCount(dayData) : 0;
+        return cliTotalsByDay.get(dayStr)?.interactionCount ?? 0;
       });
       datasets.push({
         label: 'Copilot CLI',
@@ -202,7 +215,7 @@ export default function ClientActivityChart({
       labels: allDays.map(day => formatShortDate(day)),
       datasets: datasets,
     };
-  }, [days, reportStartDay, reportEndDay]);
+  }, [cliTotalsByDay, days, reportStartDay, reportEndDay]);
 
   const barChartOptions: ChartOptions<'bar'> = useMemo(() => ({
     responsive: true,

--- a/src/components/charts/ClientActivityChart.tsx
+++ b/src/components/charts/ClientActivityChart.tsx
@@ -48,6 +48,16 @@ interface ClientActivityChartProps {
   }[];
 }
 
+interface CliFeatureTotals {
+  interactions: number;
+  generations: number;
+  acceptances: number;
+  locAdded: number;
+  locDeleted: number;
+  locSuggestedToAdd: number;
+  locSuggestedToDelete: number;
+}
+
 const IDE_COLORS: Record<string, string> = {
   'vscode': '#007ACC',
   'visual_studio': '#5C2D91',
@@ -67,6 +77,43 @@ const FALLBACK_COLORS = [
   '#F97316', '#06B6D4', '#84CC16', '#EC4899', '#14B8A6'
 ];
 
+function isCliFeature(feature: string): boolean {
+  return feature === 'copilot_cli' || feature === 'cli_agent';
+}
+
+function createEmptyCliFeatureTotals(): CliFeatureTotals {
+  return {
+    interactions: 0,
+    generations: 0,
+    acceptances: 0,
+    locAdded: 0,
+    locDeleted: 0,
+    locSuggestedToAdd: 0,
+    locSuggestedToDelete: 0,
+  };
+}
+
+function getCliFeatureTotals(day: UserDayData): CliFeatureTotals {
+  return day.totals_by_feature.reduce((acc, feature) => {
+    if (!isCliFeature(feature.feature)) return acc;
+
+    acc.interactions += feature.user_initiated_interaction_count;
+    acc.generations += feature.code_generation_activity_count;
+    acc.acceptances += feature.code_acceptance_activity_count;
+    acc.locAdded += feature.loc_added_sum;
+    acc.locDeleted += feature.loc_deleted_sum;
+    acc.locSuggestedToAdd += feature.loc_suggested_to_add_sum;
+    acc.locSuggestedToDelete += feature.loc_suggested_to_delete_sum;
+
+    return acc;
+  }, createEmptyCliFeatureTotals());
+}
+
+function getCliInteractionCount(day: UserDayData): number {
+  const featureInteractions = getCliFeatureTotals(day).interactions;
+  return featureInteractions > 0 ? featureInteractions : day.totals_by_cli?.prompt_count ?? 0;
+}
+
 /**
  * ClientActivityChart
  * Reusable section displaying a daily interactions stacked bar chart (by IDE/CLI) plus
@@ -82,6 +129,34 @@ export default function ClientActivityChart({
   cliVersions,
 }: ClientActivityChartProps) {
   const [isPluginTableExpanded, setIsPluginTableExpanded] = useState(false);
+
+  const cliTotals = useMemo(() => (
+    days.reduce((acc, day) => {
+      if (day.totals_by_cli) {
+        acc.promptCount += day.totals_by_cli.prompt_count;
+      }
+
+      const featureTotals = getCliFeatureTotals(day);
+      acc.interactions += featureTotals.interactions;
+      acc.generations += featureTotals.generations;
+      acc.acceptances += featureTotals.acceptances;
+      acc.locAdded += featureTotals.locAdded;
+      acc.locDeleted += featureTotals.locDeleted;
+      acc.locSuggestedToAdd += featureTotals.locSuggestedToAdd;
+      acc.locSuggestedToDelete += featureTotals.locSuggestedToDelete;
+
+      return acc;
+    }, {
+      promptCount: 0,
+      interactions: 0,
+      generations: 0,
+      acceptances: 0,
+      locAdded: 0,
+      locDeleted: 0,
+      locSuggestedToAdd: 0,
+      locSuggestedToDelete: 0,
+    })
+  ), [days]);
 
   const barChartData = useMemo(() => {
     const allIDEs = Array.from(
@@ -108,11 +183,11 @@ export default function ClientActivityChart({
     }).filter(dataset => dataset.data.some(value => value > 0));
 
     // Add CLI dataset if any day has CLI data
-    const hasCliData = days.some(d => d.totals_by_cli && d.totals_by_cli.prompt_count > 0);
+    const hasCliData = days.some(day => getCliInteractionCount(day) > 0);
     if (hasCliData) {
       const cliData = allDays.map(dayStr => {
         const dayData = dayMap.get(dayStr);
-        return dayData?.totals_by_cli?.prompt_count || 0;
+        return dayData ? getCliInteractionCount(dayData) : 0;
       });
       datasets.push({
         label: 'Copilot CLI',
@@ -167,7 +242,8 @@ export default function ClientActivityChart({
     }
   }), []);
 
-  const hasCliData = days.some(d => d.totals_by_cli && d.totals_by_cli.prompt_count > 0);
+  const hasCliData = cliTotals.promptCount > 0 || cliTotals.interactions > 0;
+  const cliInteractionCount = cliTotals.interactions > 0 ? cliTotals.interactions : cliTotals.promptCount;
   const hasCliVersions = cliVersions && cliVersions.length > 0;
   const isEmpty = ideAggregates.length === 0 && !hasCliData && !hasCliVersions;
 
@@ -206,16 +282,7 @@ export default function ClientActivityChart({
               </tr>
             ))}
             {(() => {
-              const cliTotals = days.reduce((acc, day) => {
-                if (day.totals_by_cli) {
-                  acc.request_count += day.totals_by_cli.request_count;
-                  acc.session_count += day.totals_by_cli.session_count;
-                  acc.prompt_count += day.totals_by_cli.prompt_count;
-                }
-                return acc;
-              }, { request_count: 0, session_count: 0, prompt_count: 0 });
-
-              if (cliTotals.prompt_count === 0) return null;
+              if (!hasCliData) return null;
               return (
                 <tr>
                   <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
@@ -224,13 +291,13 @@ export default function ClientActivityChart({
                       <span>Copilot CLI</span>
                     </div>
                   </td>
-                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 text-right">{cliTotals.prompt_count.toLocaleString()}</td>
-                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 text-right">—</td>
-                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 text-right">—</td>
-                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 text-right">—</td>
-                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 text-right">—</td>
-                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 text-right">—</td>
-                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 text-right">—</td>
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 text-right">{cliInteractionCount.toLocaleString()}</td>
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 text-right">{cliTotals.generations.toLocaleString()}</td>
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 text-right">{cliTotals.acceptances.toLocaleString()}</td>
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 text-right">{cliTotals.locAdded.toLocaleString()}</td>
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 text-right">{cliTotals.locDeleted.toLocaleString()}</td>
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 text-right">{cliTotals.locSuggestedToAdd.toLocaleString()}</td>
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 text-right">{cliTotals.locSuggestedToDelete.toLocaleString()}</td>
                 </tr>
               );
             })()}

--- a/src/components/ui/DayDetailsModal.tsx
+++ b/src/components/ui/DayDetailsModal.tsx
@@ -15,6 +15,10 @@ interface DayDetailsModalProps {
   userLogin?: string;
 }
 
+function isCliFeature(feature: string): boolean {
+  return feature === 'copilot_cli' || feature === 'cli_agent';
+}
+
 export default function DayDetailsModal({ isOpen, onClose, date, dayMetrics, userLogin }: DayDetailsModalProps) {
   if (!isOpen) return null;
 
@@ -28,6 +32,33 @@ export default function DayDetailsModal({ isOpen, onClose, date, dayMetrics, use
   };
 
   const hasData = !!dayMetrics;
+  const cliFeatureTotals = dayMetrics?.totals_by_feature.reduce((acc, feature) => {
+    if (!isCliFeature(feature.feature)) return acc;
+
+    acc.interactions += feature.user_initiated_interaction_count;
+    acc.generations += feature.code_generation_activity_count;
+    acc.acceptances += feature.code_acceptance_activity_count;
+    acc.locAdded += feature.loc_added_sum;
+    acc.locDeleted += feature.loc_deleted_sum;
+
+    return acc;
+  }, {
+    interactions: 0,
+    generations: 0,
+    acceptances: 0,
+    locAdded: 0,
+    locDeleted: 0,
+  }) ?? {
+    interactions: 0,
+    generations: 0,
+    acceptances: 0,
+    locAdded: 0,
+    locDeleted: 0,
+  };
+  const hasCliActivity = (dayMetrics?.totals_by_cli?.prompt_count ?? 0) > 0 || cliFeatureTotals.interactions > 0;
+  const cliInteractionCount = cliFeatureTotals.interactions > 0
+    ? cliFeatureTotals.interactions
+    : dayMetrics?.totals_by_cli?.prompt_count ?? 0;
 
   return (
     <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
@@ -146,37 +177,40 @@ export default function DayDetailsModal({ isOpen, onClose, date, dayMetrics, use
                           <tr>
                             <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Client</th>
                             <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Interactions</th>
-                            <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Generation</th>
-                            <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Acceptance</th>
-                            <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">LOC Added</th>
-                            <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Plugin Version</th>
-                          </tr>
-                        </thead>
+                             <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Generation</th>
+                             <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Acceptance</th>
+                             <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">LOC Added</th>
+                             <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">LOC Deleted</th>
+                             <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Plugin Version</th>
+                           </tr>
+                         </thead>
                         <tbody className="bg-white divide-y divide-gray-200">
                           {visibleItems.map((ide, idx) => (
                             <tr key={idx} className="hover:bg-gray-50">
                               <td className="px-4 py-3 text-sm font-medium text-gray-900">{formatIDEName(ide.ide)}</td>
                               <td className="px-4 py-3 text-sm text-gray-900 text-right">{ide.user_initiated_interaction_count.toLocaleString()}</td>
-                              <td className="px-4 py-3 text-sm text-gray-900 text-right">{ide.code_generation_activity_count.toLocaleString()}</td>
-                              <td className="px-4 py-3 text-sm text-gray-900 text-right">{ide.code_acceptance_activity_count.toLocaleString()}</td>
-                              <td className="px-4 py-3 text-sm text-gray-900 text-right">{ide.loc_added_sum.toLocaleString()}</td>
-                              <td className="px-4 py-3 text-sm text-gray-900 text-right">
-                                {ide.last_known_plugin_version ? 
-                                  `${ide.last_known_plugin_version.plugin} v${ide.last_known_plugin_version.plugin_version}` : 
+                               <td className="px-4 py-3 text-sm text-gray-900 text-right">{ide.code_generation_activity_count.toLocaleString()}</td>
+                               <td className="px-4 py-3 text-sm text-gray-900 text-right">{ide.code_acceptance_activity_count.toLocaleString()}</td>
+                               <td className="px-4 py-3 text-sm text-gray-900 text-right">{ide.loc_added_sum.toLocaleString()}</td>
+                               <td className="px-4 py-3 text-sm text-gray-900 text-right">{ide.loc_deleted_sum.toLocaleString()}</td>
+                               <td className="px-4 py-3 text-sm text-gray-900 text-right">
+                                 {ide.last_known_plugin_version ? 
+                                   `${ide.last_known_plugin_version.plugin} v${ide.last_known_plugin_version.plugin_version}` : 
                                   'Unknown'
                                 }
                               </td>
-                            </tr>
-                          ))}
-                          {dayMetrics.totals_by_cli && dayMetrics.totals_by_cli.prompt_count > 0 && (
+                             </tr>
+                           ))}
+                          {hasCliActivity && (
                             <tr className="hover:bg-gray-50">
                               <td className="px-4 py-3 text-sm font-medium text-gray-900">Copilot CLI</td>
-                              <td className="px-4 py-3 text-sm text-gray-900 text-right">{dayMetrics.totals_by_cli.prompt_count.toLocaleString()}</td>
-                              <td className="px-4 py-3 text-sm text-gray-500 text-right">—</td>
-                              <td className="px-4 py-3 text-sm text-gray-500 text-right">—</td>
-                              <td className="px-4 py-3 text-sm text-gray-500 text-right">—</td>
+                              <td className="px-4 py-3 text-sm text-gray-900 text-right">{cliInteractionCount.toLocaleString()}</td>
+                              <td className="px-4 py-3 text-sm text-gray-900 text-right">{cliFeatureTotals.generations.toLocaleString()}</td>
+                              <td className="px-4 py-3 text-sm text-gray-900 text-right">{cliFeatureTotals.acceptances.toLocaleString()}</td>
+                              <td className="px-4 py-3 text-sm text-gray-900 text-right">{cliFeatureTotals.locAdded.toLocaleString()}</td>
+                              <td className="px-4 py-3 text-sm text-gray-900 text-right">{cliFeatureTotals.locDeleted.toLocaleString()}</td>
                               <td className="px-4 py-3 text-sm text-gray-900 text-right">
-                                {dayMetrics.totals_by_cli.last_known_cli_version ?
+                                {dayMetrics.totals_by_cli?.last_known_cli_version ?
                                   `v${dayMetrics.totals_by_cli.last_known_cli_version.cli_version}` :
                                   'Unknown'
                                 }

--- a/src/components/ui/DayDetailsModal.tsx
+++ b/src/components/ui/DayDetailsModal.tsx
@@ -101,7 +101,7 @@ export default function DayDetailsModal({ isOpen, onClose, date, dayMetrics, use
               <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
                 <div className="bg-blue-50 rounded-lg p-4">
                   <div className="text-2xl font-bold text-blue-600">
-                    {(dayMetrics.user_initiated_interaction_count + (dayMetrics.totals_by_cli?.prompt_count ?? 0)).toLocaleString()}
+                    {(dayMetrics.user_initiated_interaction_count + cliInteractionCount).toLocaleString()}
                   </div>
                   <div className="text-sm font-medium text-blue-800">Interactions</div>
                 </div>

--- a/src/domain/__tests__/metricsAggregator.test.ts
+++ b/src/domain/__tests__/metricsAggregator.test.ts
@@ -408,6 +408,42 @@ describe('metricsAggregator', () => {
       expect(aggregated.featureAdoptionData.advancedUsers).toBe(1);
     });
 
+    it('should count cloud-agent-only users from the new cloud-agent flag', () => {
+      const metric = createBasicMetric({
+        used_chat: false,
+        used_agent: false,
+        used_cli: false,
+        used_copilot_coding_agent: false,
+        used_copilot_cloud_agent: true,
+        totals_by_feature: [],
+      });
+
+      const { aggregated } = aggregateMetrics([metric]);
+
+      expect(aggregated.stats.codingAgentUsers).toBe(1);
+      expect(aggregated.featureAdoptionData.codingAgentUsers).toBe(1);
+      expect(aggregated.featureAdoptionData.advancedUsers).toBe(1);
+      expect(aggregated.userSummaries[0].used_copilot_coding_agent).toBe(true);
+    });
+
+    it('should prefer the new cloud-agent flag over the legacy coding-agent flag', () => {
+      const metric = createBasicMetric({
+        used_chat: false,
+        used_agent: false,
+        used_cli: false,
+        used_copilot_coding_agent: true,
+        used_copilot_cloud_agent: false,
+        totals_by_feature: [],
+      });
+
+      const { aggregated } = aggregateMetrics([metric]);
+
+      expect(aggregated.stats.codingAgentUsers).toBe(0);
+      expect(aggregated.stats.completionOnlyUsers).toBe(1);
+      expect(aggregated.featureAdoptionData.codingAgentUsers).toBe(0);
+      expect(aggregated.userSummaries[0].used_copilot_coding_agent).toBe(false);
+    });
+
     it('should exclude CLI users from completion-only counts when only used_cli marks CLI usage', () => {
       const metric = createBasicMetric({
         used_cli: true,

--- a/src/domain/__tests__/metricsParser.test.ts
+++ b/src/domain/__tests__/metricsParser.test.ts
@@ -212,6 +212,74 @@ describe('metricsParser', () => {
 
       expect(result).not.toBeNull();
       expect(result?.used_copilot_coding_agent).toBe(false);
+      expect(result?.used_copilot_cloud_agent).toBe(false);
+    });
+
+    it('should prefer used_copilot_cloud_agent over legacy used_copilot_coding_agent', () => {
+      const line = JSON.stringify({
+        report_start_day: '2024-01-01',
+        report_end_day: '2024-01-31',
+        day: '2024-01-15',
+        enterprise_id: 'test-enterprise',
+        user_id: 123,
+        user_login: 'testuser',
+        user_initiated_interaction_count: 10,
+        code_generation_activity_count: 5,
+        code_acceptance_activity_count: 3,
+        loc_added_sum: 100,
+        loc_deleted_sum: 20,
+        loc_suggested_to_add_sum: 150,
+        loc_suggested_to_delete_sum: 30,
+        totals_by_ide: [],
+        totals_by_feature: [],
+        totals_by_language_feature: [],
+        totals_by_language_model: [],
+        totals_by_model_feature: [],
+        used_agent: false,
+        used_chat: true,
+        used_cli: false,
+        used_copilot_coding_agent: true,
+        used_copilot_cloud_agent: false,
+      });
+
+      const result = parseMetricsLine(line);
+
+      expect(result).not.toBeNull();
+      expect(result?.used_copilot_coding_agent).toBe(false);
+      expect(result?.used_copilot_cloud_agent).toBe(false);
+    });
+
+    it('should fallback to legacy used_copilot_coding_agent when cloud-agent flag is missing', () => {
+      const line = JSON.stringify({
+        report_start_day: '2024-01-01',
+        report_end_day: '2024-01-31',
+        day: '2024-01-15',
+        enterprise_id: 'test-enterprise',
+        user_id: 123,
+        user_login: 'testuser',
+        user_initiated_interaction_count: 10,
+        code_generation_activity_count: 5,
+        code_acceptance_activity_count: 3,
+        loc_added_sum: 100,
+        loc_deleted_sum: 20,
+        loc_suggested_to_add_sum: 150,
+        loc_suggested_to_delete_sum: 30,
+        totals_by_ide: [],
+        totals_by_feature: [],
+        totals_by_language_feature: [],
+        totals_by_language_model: [],
+        totals_by_model_feature: [],
+        used_agent: false,
+        used_chat: true,
+        used_cli: false,
+        used_copilot_coding_agent: true,
+      });
+
+      const result = parseMetricsLine(line);
+
+      expect(result).not.toBeNull();
+      expect(result?.used_copilot_coding_agent).toBe(true);
+      expect(result?.used_copilot_cloud_agent).toBe(true);
     });
 
     it('should normalize language names in parsed language arrays', () => {

--- a/src/domain/calculators/__tests__/impactCalculator.test.ts
+++ b/src/domain/calculators/__tests__/impactCalculator.test.ts
@@ -6,6 +6,7 @@ import {
   computeAgentImpactData,
   computeCodeCompletionImpactData,
   computeEditModeImpactData,
+  computeCliImpactData,
   computeJoinedImpactData,
   type FeatureImpactInput,
 } from '../impactCalculator';
@@ -66,6 +67,40 @@ describe('impactCalculator', () => {
       expect(results[0].locDeleted).toBe(15);
     });
 
+    it('should route copilot_cli to CLI impact', () => {
+      const accumulator = createImpactAccumulator();
+      ensureImpactDates(accumulator, '2024-01-15');
+
+      const features: FeatureImpactInput[] = [
+        { feature: 'copilot_cli', locAdded: 100, locDeleted: 20 },
+      ];
+
+      accumulateFeatureImpacts(accumulator, '2024-01-15', 1, features);
+
+      const results = computeCliImpactData(accumulator);
+
+      expect(results).toHaveLength(1);
+      expect(results[0].locAdded).toBe(100);
+      expect(results[0].locDeleted).toBe(20);
+      expect(results[0].userCount).toBe(1);
+    });
+
+    it('should continue routing legacy cli_agent to CLI impact', () => {
+      const accumulator = createImpactAccumulator();
+      ensureImpactDates(accumulator, '2024-01-15');
+
+      const features: FeatureImpactInput[] = [
+        { feature: 'cli_agent', locAdded: 50, locDeleted: 10 },
+      ];
+
+      accumulateFeatureImpacts(accumulator, '2024-01-15', 1, features);
+
+      const results = computeCliImpactData(accumulator);
+
+      expect(results[0].locAdded).toBe(50);
+      expect(results[0].locDeleted).toBe(10);
+    });
+
     it('should handle multiple feature categories in single accumulation', () => {
       const accumulator = createImpactAccumulator();
       ensureImpactDates(accumulator, '2024-01-15');
@@ -99,7 +134,7 @@ describe('impactCalculator', () => {
         { feature: 'chat_panel_edit_mode', locAdded: 30, locDeleted: 5 },
         { feature: 'chat_inline', locAdded: 20, locDeleted: 3 },
         { feature: 'chat_panel_agent_mode', locAdded: 40, locDeleted: 8 },
-        { feature: 'cli_agent', locAdded: 10, locDeleted: 2 },
+        { feature: 'copilot_cli', locAdded: 10, locDeleted: 2 },
         { feature: 'chat_panel_plan_mode', locAdded: 15, locDeleted: 3 },
       ];
 

--- a/src/domain/calculators/__tests__/userDetailCalculator.test.ts
+++ b/src/domain/calculators/__tests__/userDetailCalculator.test.ts
@@ -337,8 +337,8 @@ describe('userDetailCalculator', () => {
     });
   });
 
-  describe('adaptDaysAsMetrics — used_cli passthrough via dailyCliImpact', () => {
-    it('should produce non-empty dailyCliImpact when CLI data includes cli_agent feature', () => {
+  describe('adaptDaysAsMetrics - used_cli passthrough via dailyCliImpact', () => {
+    it('should produce non-empty dailyCliImpact when CLI data includes copilot_cli feature', () => {
       const acc = createUserDetailAccumulator();
       acc.reportStartDay = '2024-01-01';
       acc.reportEndDay = '2024-01-31';
@@ -352,7 +352,7 @@ describe('userDetailCalculator', () => {
         },
         totals_by_feature: [
           {
-            feature: 'cli_agent',
+            feature: 'copilot_cli',
             user_initiated_interaction_count: 5,
             code_generation_activity_count: 3,
             code_acceptance_activity_count: 2,
@@ -372,7 +372,7 @@ describe('userDetailCalculator', () => {
       expect(result!.dailyCliImpact[0].locDeleted).toBe(20);
     });
 
-    it('should produce empty dailyCliImpact when no cli_agent feature is present', () => {
+    it('should produce empty dailyCliImpact when no CLI feature is present', () => {
       const acc = createUserDetailAccumulator();
       acc.reportStartDay = '2024-01-01';
       acc.reportEndDay = '2024-01-31';
@@ -395,7 +395,6 @@ describe('userDetailCalculator', () => {
       accumulateUserDetail(acc, metric);
 
       const result = computeSingleUserDetailedMetrics(acc, 1);
-      // No cli_agent feature → dailyCliImpact entries should all have zero LOC
       const cliWithLoc = result!.dailyCliImpact.filter(d => d.locAdded > 0 || d.locDeleted > 0);
       expect(cliWithLoc).toHaveLength(0);
     });

--- a/src/domain/calculators/impactCalculator.ts
+++ b/src/domain/calculators/impactCalculator.ts
@@ -34,7 +34,12 @@ const JOINED_FEATURES = [
   'agent_edit',
   'chat_panel_plan_mode',
   'cli_agent',
+  'copilot_cli',
 ];
+
+function isCliFeature(feature: string): boolean {
+  return feature === 'copilot_cli' || feature === 'cli_agent';
+}
 
 export function createImpactAccumulator(): ImpactAccumulator {
   return {
@@ -157,7 +162,7 @@ export function accumulateFeatureImpacts(
       );
     }
 
-    if (feature === 'cli_agent' && hasLoc) {
+    if (isCliFeature(feature) && hasLoc) {
       accumulateToMap(
         accumulator.dailyCliImpact,
         date,

--- a/src/domain/calculators/statsCalculator.ts
+++ b/src/domain/calculators/statsCalculator.ts
@@ -1,4 +1,5 @@
 import { CopilotMetrics, MetricsStats } from '../../types/metrics';
+import { resolveCopilotCloudAgentUsage } from '../copilotCloudAgentUsage';
 
 export interface UserUsageStats {
   userUsageMap: Map<number, { used_chat: boolean; used_agent: boolean; used_cli: boolean; used_copilot_coding_agent: boolean }>;
@@ -154,7 +155,7 @@ export function calculateStatsFromMetrics(
   accumulator.reportEndDay = metrics[0].report_end_day;
 
   for (const metric of metrics) {
-    accumulateUserUsage(accumulator, metric.user_id, metric.used_chat, metric.used_agent, metric.used_cli, metric.used_copilot_coding_agent);
+    accumulateUserUsage(accumulator, metric.user_id, metric.used_chat, metric.used_agent, metric.used_cli, resolveCopilotCloudAgentUsage(metric));
 
     for (const ideTotal of metric.totals_by_ide) {
       accumulateIdeUser(accumulator, ideTotal.ide, metric.user_id);

--- a/src/domain/copilotCloudAgentUsage.ts
+++ b/src/domain/copilotCloudAgentUsage.ts
@@ -1,0 +1,5 @@
+import type { CopilotMetrics } from '../types/metrics';
+
+export function resolveCopilotCloudAgentUsage(metric: Pick<CopilotMetrics, 'used_copilot_coding_agent' | 'used_copilot_cloud_agent'>): boolean {
+  return metric.used_copilot_cloud_agent ?? metric.used_copilot_coding_agent ?? false;
+}

--- a/src/domain/featureTranslations.ts
+++ b/src/domain/featureTranslations.ts
@@ -12,6 +12,7 @@ export const featureTranslations: Record<string, string> = {
   'chat_inline': 'Chat: Inline',
   'agent_edit': 'Agent Edit',
   'cli_agent': 'CLI Agent',
+  'copilot_cli': 'Copilot CLI',
 };
 
 /**

--- a/src/domain/metricsAggregator.ts
+++ b/src/domain/metricsAggregator.ts
@@ -158,7 +158,8 @@ function hasAutoModeActivity(metric: CopilotMetrics): boolean {
 
 function accumulateUserSummary(
   accumulator: UserSummaryAccumulator,
-  metric: CopilotMetrics
+  metric: CopilotMetrics,
+  usedCopilotCloudAgent: boolean
 ): void {
   const userId = metric.user_id;
   const date = metric.day;
@@ -186,7 +187,6 @@ function accumulateUserSummary(
   }
 
   const userSummary = accumulator.userMap.get(userId)!;
-  const usedCopilotCloudAgent = resolveCopilotCloudAgentUsage(metric);
   userSummary.total_user_initiated_interactions += metric.user_initiated_interaction_count;
   userSummary.total_code_generation_activities += metric.code_generation_activity_count;
   userSummary.total_code_acceptance_activities += metric.code_acceptance_activity_count;
@@ -245,7 +245,7 @@ export function aggregateMetrics(
     const userId = metric.user_id;
     const usedCopilotCloudAgent = resolveCopilotCloudAgentUsage(metric);
 
-    accumulateUserSummary(userSummaryAccumulator, metric);
+    accumulateUserSummary(userSummaryAccumulator, metric, usedCopilotCloudAgent);
     accumulateUserDetail(userDetailAccumulator, metric);
 
     accumulateUserUsage(statsAccumulator, userId, metric.used_chat, metric.used_agent, metric.used_cli, usedCopilotCloudAgent);

--- a/src/domain/metricsAggregator.ts
+++ b/src/domain/metricsAggregator.ts
@@ -8,6 +8,7 @@ import {
   DailyLanguageChartData,
   ModelBreakdownData,
 } from '../types/metrics';
+import { resolveCopilotCloudAgentUsage } from './copilotCloudAgentUsage';
 import {
   createStatsAccumulator,
   accumulateUserUsage,
@@ -185,6 +186,7 @@ function accumulateUserSummary(
   }
 
   const userSummary = accumulator.userMap.get(userId)!;
+  const usedCopilotCloudAgent = resolveCopilotCloudAgentUsage(metric);
   userSummary.total_user_initiated_interactions += metric.user_initiated_interaction_count;
   userSummary.total_code_generation_activities += metric.code_generation_activity_count;
   userSummary.total_code_acceptance_activities += metric.code_acceptance_activity_count;
@@ -195,7 +197,7 @@ function accumulateUserSummary(
   userSummary.used_agent = userSummary.used_agent || metric.used_agent;
   userSummary.used_chat = userSummary.used_chat || metric.used_chat;
   userSummary.used_cli = userSummary.used_cli || metric.used_cli;
-  userSummary.used_copilot_coding_agent = userSummary.used_copilot_coding_agent || metric.used_copilot_coding_agent;
+  userSummary.used_copilot_coding_agent = userSummary.used_copilot_coding_agent || usedCopilotCloudAgent;
   userSummary.used_auto_mode = userSummary.used_auto_mode || hasAutoModeActivity(metric);
   accumulator.userActiveDays.get(userId)!.add(date);
 }
@@ -241,11 +243,12 @@ export function aggregateMetrics(
 
     const date = metric.day;
     const userId = metric.user_id;
+    const usedCopilotCloudAgent = resolveCopilotCloudAgentUsage(metric);
 
     accumulateUserSummary(userSummaryAccumulator, metric);
     accumulateUserDetail(userDetailAccumulator, metric);
 
-    accumulateUserUsage(statsAccumulator, userId, metric.used_chat, metric.used_agent, metric.used_cli, metric.used_copilot_coding_agent);
+    accumulateUserUsage(statsAccumulator, userId, metric.used_chat, metric.used_agent, metric.used_cli, usedCopilotCloudAgent);
 
     accumulateEngagement(engagementAccumulator, date, userId);
 
@@ -301,7 +304,7 @@ export function aggregateMetrics(
     const featureImpacts: Array<{ feature: string; locAdded: number; locDeleted: number }> = [];
 
     accumulateCliAdoption(featureAdoptionAccumulator, userId, metric.used_cli);
-    accumulateCodingAgentAdoption(featureAdoptionAccumulator, userId, metric.used_copilot_coding_agent);
+    accumulateCodingAgentAdoption(featureAdoptionAccumulator, userId, usedCopilotCloudAgent);
     accumulateCliUsage(cliUsageAccumulator, date, userId, metric);
 
     for (const feature of metric.totals_by_feature) {

--- a/src/domain/metricsParser.ts
+++ b/src/domain/metricsParser.ts
@@ -1,5 +1,6 @@
 import { CopilotMetrics } from '../types/metrics';
 import { StringPool, internMetricStrings } from '../utils/stringPool';
+import { resolveCopilotCloudAgentUsage } from './copilotCloudAgentUsage';
 import { normalizeLanguage } from './languageNormalizer';
 
 function normalizeMetricLanguages(metric: CopilotMetrics): void {
@@ -59,7 +60,9 @@ export function parseMetricsLine(line: string, pool?: StringPool): CopilotMetric
     // We rely on upstream schema conformity; at runtime we only soft-validated key fields
     const metric = parsedRaw as unknown as CopilotMetrics;
     metric.used_cli = metric.used_cli ?? false;
-    metric.used_copilot_coding_agent = metric.used_copilot_coding_agent ?? false;
+    const usedCopilotCloudAgent = resolveCopilotCloudAgentUsage(metric);
+    metric.used_copilot_coding_agent = usedCopilotCloudAgent;
+    metric.used_copilot_cloud_agent = usedCopilotCloudAgent;
 
     // Normalize language names to canonical form
     normalizeMetricLanguages(metric);

--- a/src/types/metrics.ts
+++ b/src/types/metrics.ts
@@ -77,6 +77,7 @@ export interface CopilotMetrics {
   used_chat: boolean;
   used_cli: boolean;
   used_copilot_coding_agent: boolean;
+  used_copilot_cloud_agent?: boolean;
   totals_by_cli?: {
     session_count: number;
     request_count: number;


### PR DESCRIPTION
## Summary

Updates report handling for the newer CLI and Copilot Cloud Agent fields, including UI and sample data support.

| Commit | Change |
|--------|--------|
| `fix: recognize copilot_cli impact` | Treats `copilot_cli` feature totals as CLI impact data while preserving legacy `cli_agent` support. |
| `fix: show CLI LOC in client activity` | Shows CLI generation, acceptance, and LOC added/deleted in User Details client activity tables using feature totals. |
| `fix: prefer cloud agent usage flag` | Adds `used_copilot_cloud_agent` support and prefers it over deprecated `used_copilot_coding_agent`, with legacy fallback. |
| `chore: update sample report schema` | Refreshes sample NDJSON data to use `copilot_cli` feature rows and include `used_copilot_cloud_agent`. |
| `fix: address CLI review feedback` | Addresses review feedback by reusing per-day CLI totals, aligning modal summary interactions, and resolving cloud-agent usage once per metric. |

## Validation

- `npm run build && npm run lint && npm run test:run`
