### PR TITLE
docs: add PR why guidance

### DIFF
--- a/.github/skills/git-workflow/SKILL.md
+++ b/.github/skills/git-workflow/SKILL.md
@@ -48,14 +48,24 @@ After all commits are ready and pushed:
 
 1. Push the branch: `git push -u origin <branch-name>`
 2. Create a PR with `gh pr create`
-3. PR body must include a **summary table** of all commits:
+3. PR body must begin with a `## Why` section:
+   - write 1-2 concise sentences explaining why the change was made
+   - base the motivation on the session context and the user's prompting
+   - focus on reviewer context and intent, not implementation details
+4. After `## Why`, PR body must include a **summary table** of all commits:
 
 ```markdown
+## Why
+
+This change addresses <reason from the session or user request>. It helps reviewers understand <intended outcome or context>.
+
 | Commit | Change |
 |--------|--------|
 | `fix:` description | What was fixed and why |
 | `feat:` description | What was added |
 ```
+
+Do not add a separate validation or testing block for routine build, lint, or test commands. Those checks are expected to run before PR creation and add noise to the description.
 
 ## PR Follow-Up Pushes
 
@@ -65,12 +75,14 @@ When a branch already has an open PR and you push additional commits:
 2. Push the branch updates.
 3. Refresh the PR description with `gh pr edit` so it reflects the latest state of the branch.
 4. Treat the PR body as a surgical update, not a full rewrite:
-   - preserve existing sections such as summary prose, validation steps, and other reviewer context
+   - preserve existing sections such as `## Why`, summary prose, and other reviewer context
+   - refresh `## Why` only when the new commits materially change the motivation or reviewer context
    - update the **summary table** to include new commits
    - remove or rewrite outdated entries when the implementation changed
    - mention review feedback fixes in the description when the new commits address PR comments
 5. If the PR body does not already contain a summary table, add one without removing the rest of the description.
-6. Before running `gh pr edit`, verify the updated body still contains the important sections from the original PR description.
+6. Do not add a routine validation or testing block when updating the PR body.
+7. Before running `gh pr edit`, verify the updated body still contains the important sections from the original PR description.
 
 Never leave the PR description stale after pushing fixes to an existing PR.
 


### PR DESCRIPTION
## Why

This change makes generated PR descriptions explain the motivation behind the work up front, based on the session and user request. It helps reviewers understand why a change exists before reading the commit summary.

| Commit | Change |
|--------|--------|
| `docs: add PR why guidance` | Added git-workflow skill guidance for a leading `## Why` section, preserved the commit summary table, and discouraged routine validation/testing blocks in PR bodies. |