### PR TITLE
docs: split git workflow skill references

### DIFF
--- a/.github/skills/git-workflow/SKILL.md
+++ b/.github/skills/git-workflow/SKILL.md
@@ -10,87 +10,27 @@ description: >
 # Git Workflow
 
 Manage the git workflow for this project. Follow these conventions strictly.
+Classify the requested workflow, then read only the matching reference file(s).
 
-## Branch Naming
+## Routing
 
-Create descriptive branch names using category prefixes:
+| User intent | Load |
+| --- | --- |
+| Create branch or commits | `reference/branch-and-commit.md` |
+| Push committed changes without PR creation | `reference/branch-and-commit.md` |
+| Create a new PR | `reference/pr-creation.md`; also load `reference/branch-and-commit.md` if creating or checking commits |
+| Push follow-up commits to an existing PR | `reference/pr-follow-up.md`; also load `reference/branch-and-commit.md` if creating or amending commits |
+| PR was merged or cleanup requested | `reference/post-merge-cleanup.md` |
 
-- `feat/short-description` — new features
-- `fix/short-description` — bug fixes
-- `refactor/short-description` — code restructuring
-- `chore/short-description` — maintenance, deps, config
-- `security/short-description` — security fixes
-- `ui/short-description` — UI/UX changes
-- `improve/short-description` — improvements and optimizations
+For "push changes" requests, check whether the current branch already has an
+open PR. If it does, use the PR follow-up route; otherwise, use the standalone
+push route.
 
-## Commit Conventions
+Do not load every reference file by default. Load the smallest set that covers
+the user's request.
 
-Each commit must be **atomic** — one logical change per commit.
+## Always apply
 
-Commit message format: `prefix: short imperative description`
-
-Prefixes: `fix:`, `feat:`, `refactor:`, `chore:`, `ci:`, `docs:`, `test:`
-
-Use `feat!:` or `fix!:` for breaking changes.
-
-Rules:
-- One logical change per commit — do not bundle unrelated changes
-- Keep the subject line under 72 characters
-- No period at the end of the subject line
-- Always include this trailer at the end of every commit message:
-  `Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>`
-
-Before creating any commit, review staged changes with `git diff --cached` to ensure only intended changes are included.
-
-## PR Creation and Updates
-
-After all commits are ready and pushed:
-
-1. Push the branch: `git push -u origin <branch-name>`
-2. Create a PR with `gh pr create`
-3. PR body must begin with a `## Why` section:
-   - write 1-2 concise sentences explaining why the change was made
-   - base the motivation on the session context and the user's prompting
-   - focus on reviewer context and intent, not implementation details
-4. After `## Why`, PR body must include a **summary table** of all commits:
-
-```markdown
-## Why
-
-This change addresses <reason from the session or user request>. It helps reviewers understand <intended outcome or context>.
-
-| Commit | Change |
-|--------|--------|
-| `fix:` description | What was fixed and why |
-| `feat:` description | What was added |
-```
-
-Do not add a separate validation or testing block for routine build, lint, or test commands. Those checks are expected to run before PR creation and add noise to the description.
-
-## PR Follow-Up Pushes
-
-When a branch already has an open PR and you push additional commits:
-
-1. Read the current PR body with `gh pr view --json body -q .body` and use that exact content as the base for your update. Do not generate a fresh PR description from scratch.
-2. Push the branch updates.
-3. Refresh the PR description with `gh pr edit` so it reflects the latest state of the branch.
-4. Treat the PR body as a surgical update, not a full rewrite:
-   - preserve existing sections such as `## Why`, summary prose, and other reviewer context
-   - refresh `## Why` only when the new commits materially change the motivation or reviewer context
-   - update the **summary table** to include new commits
-   - remove or rewrite outdated entries when the implementation changed
-   - mention review feedback fixes in the description when the new commits address PR comments
-5. If the PR body does not already contain a summary table, add one without removing the rest of the description.
-6. Do not add a routine validation or testing block when updating the PR body.
-7. Before running `gh pr edit`, verify the updated body still contains the important sections from the original PR description.
-
-Never leave the PR description stale after pushing fixes to an existing PR.
-
-## Post-Merge Cleanup
-
-When told a PR is merged:
-
-1. `git checkout main`
-2. `git pull origin main`
-3. Delete the merged branch locally: `git branch -d <branch-name>`
-4. Confirm the local main is up to date
+- Follow the loaded reference instructions strictly.
+- If the user's request spans multiple workflow phases, load each corresponding
+  reference file just before that phase.

--- a/.github/skills/git-workflow/reference/branch-and-commit.md
+++ b/.github/skills/git-workflow/reference/branch-and-commit.md
@@ -1,0 +1,44 @@
+# Branch and commit workflow
+
+Use this reference when creating branches or commits.
+
+## Branch naming
+
+Create descriptive branch names using category prefixes:
+
+- `feat/short-description` - new features
+- `fix/short-description` - bug fixes
+- `refactor/short-description` - code restructuring
+- `chore/short-description` - maintenance, deps, config
+- `security/short-description` - security fixes
+- `ui/short-description` - UI/UX changes
+- `improve/short-description` - improvements and optimizations
+
+## Commit conventions
+
+Each commit must be atomic: one logical change per commit. Do not bundle
+unrelated changes.
+
+Commit message format: `prefix: short imperative description`
+
+Allowed prefixes: `fix:`, `feat:`, `refactor:`, `chore:`, `ci:`, `docs:`,
+`test:`
+
+Use `feat!:` or `fix!:` for breaking changes.
+
+Rules:
+
+- Keep the subject line under 72 characters.
+- Do not end the subject line with a period.
+- Always include this trailer at the end of every commit message:
+  `Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>`
+- If an existing commit is missing the required trailer, amend it before PR
+  creation or follow-up pushes.
+- Before creating any commit, review staged changes with `git diff --cached` to
+  ensure only intended changes are included.
+
+## Standalone push
+
+If the user asks only to push committed changes and no PR update or creation is
+needed, push the current branch with `git push` or `git push -u origin
+<branch-name>` when no upstream is configured.

--- a/.github/skills/git-workflow/reference/post-merge-cleanup.md
+++ b/.github/skills/git-workflow/reference/post-merge-cleanup.md
@@ -1,0 +1,8 @@
+# Post-merge cleanup workflow
+
+Use this reference when told a PR is merged.
+
+1. `git checkout main`
+2. `git pull origin main`
+3. Delete the merged branch locally: `git branch -d <branch-name>`
+4. Confirm the local main is up to date.

--- a/.github/skills/git-workflow/reference/pr-creation.md
+++ b/.github/skills/git-workflow/reference/pr-creation.md
@@ -1,0 +1,28 @@
+# PR creation workflow
+
+Use this reference after all intended commits are ready.
+
+1. Push the branch: `git push -u origin <branch-name>`.
+2. Create a PR with `gh pr create`.
+3. Use a concise PR title based on the commit messages, fix messages, or the
+   user's requested title.
+4. Make the PR body begin with a `## Why` section:
+   - Write 1-2 concise sentences explaining why the change was made.
+   - Base the motivation on the session context and the user's prompting.
+   - Focus on reviewer context and intent, not implementation details.
+5. After `## Why`, include a summary table of all commits.
+
+```markdown
+## Why
+
+This change addresses <reason from the session or user request>. It helps reviewers understand <intended outcome or context>.
+
+| Commit | Change |
+|--------|--------|
+| `fix:` description | What was fixed and why |
+| `feat:` description | What was added |
+```
+
+Do not add a separate validation or testing block for routine build, lint, or
+test commands. Those checks are expected to run before PR creation and add noise
+to the description.

--- a/.github/skills/git-workflow/reference/pr-follow-up.md
+++ b/.github/skills/git-workflow/reference/pr-follow-up.md
@@ -1,0 +1,27 @@
+# PR follow-up workflow
+
+Use this reference when a branch already has an open PR and you push additional
+commits.
+
+1. Read the current PR body with `gh pr view --json body -q .body` and use that
+   exact content as the base for your update. Do not generate a fresh PR
+   description from scratch.
+2. Push the branch updates.
+3. Refresh the PR description with `gh pr edit` so it reflects the latest state
+   of the branch.
+4. Treat the PR body as a surgical update, not a full rewrite:
+   - Preserve existing sections such as `## Why`, summary prose, and other
+     reviewer context.
+   - Refresh `## Why` only when the new commits materially change the motivation
+     or reviewer context.
+   - Update the summary table to include new commits.
+   - Remove or rewrite outdated entries when the implementation changed.
+   - Mention review feedback fixes in the description when the new commits
+     address PR comments.
+5. If the PR body does not already contain a summary table, add one without
+   removing the rest of the description.
+6. Do not add a routine validation or testing block when updating the PR body.
+7. Before running `gh pr edit`, verify the updated body still contains the
+   important sections from the original PR description.
+
+Never leave the PR description stale after pushing fixes to an existing PR.


### PR DESCRIPTION
## Why

This change makes the `git-workflow` skill more token efficient by turning `SKILL.md` into a compact progressive-loading router. It preserves the existing git workflow conventions while moving task-specific details into reference files that are loaded only when needed.

| Commit | Change |
|--------|--------|
| `docs: split git workflow skill references` | Split branch/commit, PR creation, PR follow-up, and post-merge cleanup instructions into focused reference files while keeping `SKILL.md` compact. |