### PR TITLE
Improve CLI usage and impact reporting

### DIFF
--- a/src/components/ClientsView.tsx
+++ b/src/components/ClientsView.tsx
@@ -18,9 +18,19 @@ interface IDEViewProps {
   totalUniqueIDEUsers: number;
   cliUsers: number;
   cliSessions: number;
+  cliLocAdded: number;
+  cliLocDeleted: number;
 }
 
-export default function ClientsView({ ideStats, multiIDEUsersCount, totalUniqueIDEUsers, cliUsers, cliSessions }: IDEViewProps) {
+export default function ClientsView({
+  ideStats,
+  multiIDEUsersCount,
+  totalUniqueIDEUsers,
+  cliUsers,
+  cliSessions,
+  cliLocAdded,
+  cliLocDeleted,
+}: IDEViewProps) {
 
   const allClients: IDEStats[] = React.useMemo(() => {
     if (cliUsers <= 0) return ideStats;
@@ -31,13 +41,13 @@ export default function ClientsView({ ideStats, multiIDEUsersCount, totalUniqueI
       totalEngagements: cliSessions,
       totalGenerations: 0,
       totalAcceptances: 0,
-      locAdded: 0,
-      locDeleted: 0,
+      locAdded: cliLocAdded,
+      locDeleted: cliLocDeleted,
       locSuggestedToAdd: 0,
       locSuggestedToDelete: 0,
     };
     return [...ideStats, cliEntry];
-  }, [ideStats, cliUsers, cliSessions]);
+  }, [ideStats, cliUsers, cliSessions, cliLocAdded, cliLocDeleted]);
 
   const {
     sortField: usersSortField,

--- a/src/components/CopilotImpactView.tsx
+++ b/src/components/CopilotImpactView.tsx
@@ -73,10 +73,12 @@ export default function CopilotImpactView({ agentImpactData, codeCompletionImpac
         title="Copilot Edit Mode Impact"
         description="Daily lines of code added and deleted through Copilot's Edit Mode sessions."
         emptyStateMessage="No Edit Mode impact data available."
+        footer={
+          <InsightsCard title="Edit Mode Deprecation" variant="orange">
+            Edit mode is deprecated and will be removed in newer versions of IDE clients.
+          </InsightsCard>
+        }
       />
-      <InsightsCard title="Edit Mode Deprecation" variant="orange">
-        Edit mode is deprecated and will be removed in newer versions of IDE clients.
-      </InsightsCard>
     </ViewPanel>
   );
 }

--- a/src/components/CopilotImpactView.tsx
+++ b/src/components/CopilotImpactView.tsx
@@ -3,6 +3,7 @@
 import React from 'react';
 import ModeImpactChart from './charts/ModeImpactChart';
 import { ViewPanel } from './ui';
+import InsightsCard from './ui/InsightsCard';
 import type { AgentImpactData, CodeCompletionImpactData, ModeImpactData } from '../domain/calculators/metricCalculators';
 interface CopilotImpactViewProps {
   agentImpactData: AgentImpactData[];
@@ -38,10 +39,10 @@ export default function CopilotImpactView({ agentImpactData, codeCompletionImpac
         emptyStateMessage="No agent mode impact data available."
       />
       <ModeImpactChart
-        data={askModeImpactData || []}
-        title="Copilot Ask Mode Impact"
-        description="Daily lines of code added and deleted through Copilot Chat Ask Mode sessions."
-        emptyStateMessage="No Ask Mode impact data available."
+        data={cliImpactData || []}
+        title="Copilot CLI Impact"
+        description="Daily lines of code added and deleted through Copilot CLI sessions."
+        emptyStateMessage="No CLI impact data available."
       />
       <ModeImpactChart
         data={codeCompletionImpactData || []}
@@ -50,10 +51,16 @@ export default function CopilotImpactView({ agentImpactData, codeCompletionImpac
         emptyStateMessage="No code completion impact data available."
       />
       <ModeImpactChart
-        data={editModeImpactData || []}
-        title="Copilot Edit Mode Impact"
-        description="Daily lines of code added and deleted through Copilot's Edit Mode sessions."
-        emptyStateMessage="No Edit Mode impact data available."
+        data={planModeImpactData || []}
+        title="Copilot Plan Mode Impact"
+        description="Daily lines of code added and deleted through Copilot Plan Mode sessions."
+        emptyStateMessage="No Plan Mode impact data available."
+      />
+      <ModeImpactChart
+        data={askModeImpactData || []}
+        title="Copilot Ask Mode Impact"
+        description="Daily lines of code added and deleted through Copilot Chat Ask Mode sessions."
+        emptyStateMessage="No Ask Mode impact data available."
       />
       <ModeImpactChart
         data={inlineModeImpactData || []}
@@ -62,17 +69,14 @@ export default function CopilotImpactView({ agentImpactData, codeCompletionImpac
         emptyStateMessage="No Inline Mode impact data available."
       />
       <ModeImpactChart
-        data={cliImpactData || []}
-        title="Copilot CLI Impact"
-        description="Daily lines of code added and deleted through Copilot CLI sessions."
-        emptyStateMessage="No CLI impact data available."
+        data={editModeImpactData || []}
+        title="Copilot Edit Mode Impact"
+        description="Daily lines of code added and deleted through Copilot's Edit Mode sessions."
+        emptyStateMessage="No Edit Mode impact data available."
       />
-      <ModeImpactChart
-        data={planModeImpactData || []}
-        title="Copilot Plan Mode Impact"
-        description="Daily lines of code added and deleted through Copilot Plan Mode sessions."
-        emptyStateMessage="No Plan Mode impact data available."
-      />
+      <InsightsCard title="Edit Mode Deprecation" variant="orange">
+        Edit mode is deprecated and will be removed in newer versions of IDE clients.
+      </InsightsCard>
     </ViewPanel>
   );
 }

--- a/src/components/UserDetailsView.tsx
+++ b/src/components/UserDetailsView.tsx
@@ -488,6 +488,7 @@ export default function UserDetailsView({ userDetails, userSummary, userLogin, u
       date,
       outputTokens: cli?.token_usage.output_tokens_sum ?? 0,
       promptTokens: cli?.token_usage.prompt_tokens_sum ?? 0,
+      requestCount: cli?.request_count ?? 0,
     })),
     [userDetails.days, userDetails.reportStartDay, userDetails.reportEndDay],
   );
@@ -617,10 +618,10 @@ export default function UserDetailsView({ userDetails, userSummary, userLogin, u
         emptyStateMessage="No combined impact data available."
       />
 
-      {/* Copilot CLI Adoption */}
+      {/* Copilot CLI Usage */}
       {hasCliActivity && (
         <div className="border-t border-gray-200 pt-6">
-          <h3 className="text-lg font-semibold text-gray-900 mb-4">Copilot CLI Adoption</h3>
+          <h3 className="text-lg font-semibold text-gray-900 mb-4">Copilot CLI Usage</h3>
           <div className="space-y-8">
             <CLITokensChart data={dailyCliTokenData} />
             <CLISessionChart data={dailyCliSessionData} />

--- a/src/components/charts/CLITokensChart.tsx
+++ b/src/components/charts/CLITokensChart.tsx
@@ -4,7 +4,7 @@ import { Chart } from 'react-chartjs-2';
 import type { TooltipItem } from 'chart.js';
 import { registerChartJS } from './utils/chartSetup';
 import { createDualAxisChartOptions } from './utils/chartOptions';
-import { createBarDataset } from './utils/chartStyles';
+import { createBarDataset, createLineDataset } from './utils/chartStyles';
 import { chartColors } from './utils/chartColors';
 import { formatShortDate } from '../../utils/formatters';
 import { calculateTotal } from '../../domain/calculators/statsCalculators';
@@ -53,18 +53,16 @@ export default function CLITokensChart({ data }: CLITokensChartProps) {
       },
       {
         type: 'line' as const,
-        label: 'Avg Tokens per Request',
-        data: dailyAverageTokensPerRequest,
-        backgroundColor: chartColors.blue.alpha,
-        borderColor: chartColors.blue.solid,
-        borderWidth: 2,
-        borderDash: [5, 3],
-        fill: false,
-        tension: 0.3,
-        pointRadius: 2,
-        pointHoverRadius: 4,
-        spanGaps: true,
-        yAxisID: 'y1',
+        ...createLineDataset(chartColors.blue.solid, 'Avg Tokens per Request', dailyAverageTokensPerRequest, {
+          backgroundColor: chartColors.blue.alpha,
+          borderWidth: 2,
+          borderDash: [5, 3],
+          tension: 0.3,
+          pointRadius: 2,
+          pointHoverRadius: 4,
+          spanGaps: true,
+          yAxisID: 'y1',
+        }),
       },
     ],
   };

--- a/src/components/charts/CLITokensChart.tsx
+++ b/src/components/charts/CLITokensChart.tsx
@@ -1,9 +1,9 @@
 'use client';
 
-import { Bar } from 'react-chartjs-2';
-import type { ChartOptions } from 'chart.js';
+import { Chart } from 'react-chartjs-2';
+import type { TooltipItem } from 'chart.js';
 import { registerChartJS } from './utils/chartSetup';
-import { createStackedBarChartOptions } from './utils/chartOptions';
+import { createDualAxisChartOptions } from './utils/chartOptions';
 import { createBarDataset } from './utils/chartStyles';
 import { chartColors } from './utils/chartColors';
 import { formatShortDate } from '../../utils/formatters';
@@ -26,22 +26,95 @@ function formatTokenCount(count: number): string {
 export default function CLITokensChart({ data }: CLITokensChartProps) {
   const totalOutput = calculateTotal(data, d => d.outputTokens);
   const totalPrompt = calculateTotal(data, d => d.promptTokens);
+  const totalRequests = calculateTotal(data, d => d.requestCount);
+  const averageTokensPerRequest = totalRequests > 0
+    ? Math.round(((totalPrompt + totalOutput) / totalRequests) * 10) / 10
+    : 0;
+  const dailyAverageTokensPerRequest = data.map(d =>
+    d.requestCount > 0 ? Math.round(((d.promptTokens + d.outputTokens) / d.requestCount) * 10) / 10 : null
+  );
 
   const chartData = {
     labels: data.map(d => formatShortDate(d.date)),
     datasets: [
-      createBarDataset(chartColors.amber.solid, 'Prompt Tokens', data.map(d => d.promptTokens)),
-      createBarDataset(chartColors.red.solid, 'Output Tokens', data.map(d => d.outputTokens)),
+      {
+        type: 'bar' as const,
+        ...createBarDataset(chartColors.amber.solid, 'Prompt Tokens', data.map(d => d.promptTokens), {
+          yAxisID: 'y',
+          stack: 'tokens',
+        }),
+      },
+      {
+        type: 'bar' as const,
+        ...createBarDataset(chartColors.red.solid, 'Output Tokens', data.map(d => d.outputTokens), {
+          yAxisID: 'y',
+          stack: 'tokens',
+        }),
+      },
+      {
+        type: 'line' as const,
+        label: 'Avg Tokens per Request',
+        data: dailyAverageTokensPerRequest,
+        backgroundColor: chartColors.blue.alpha,
+        borderColor: chartColors.blue.solid,
+        borderWidth: 2,
+        borderDash: [5, 3],
+        fill: false,
+        tension: 0.3,
+        pointRadius: 2,
+        pointHoverRadius: 4,
+        spanGaps: true,
+        yAxisID: 'y1',
+      },
     ],
   };
 
-  const options = createStackedBarChartOptions({
-    xAxisLabel: 'Date',
-    yAxisLabel: 'Tokens',
-    yTicksCallback: (value: unknown) => formatTokenCount(Number(value)),
-    xMaxRotation: 45,
-    xAutoSkip: true,
-  }) as ChartOptions<'bar'>;
+  const options = {
+    ...createDualAxisChartOptions({
+      xAxisLabel: 'Date',
+      yAxisLabel: 'Tokens',
+      y1AxisLabel: 'Avg Tokens / Request',
+      tooltipLabelCallback: (context: TooltipItem<'line' | 'bar'>) => {
+        const label = context.dataset.label || '';
+        const value = context.parsed.y;
+        if (value === null) return `${label}: N/A`;
+        if (label === 'Avg Tokens per Request') {
+          return `${label}: ${formatTokenCount(value)}`;
+        }
+        return `${label}: ${formatTokenCount(value)} tokens`;
+      },
+    }),
+    scales: {
+      x: {
+        stacked: true,
+        display: true,
+        title: { display: true, text: 'Date' },
+        ticks: { maxRotation: 45, autoSkip: true },
+      },
+      y: {
+        stacked: true,
+        type: 'linear' as const,
+        display: true,
+        position: 'left' as const,
+        title: { display: true, text: 'Tokens' },
+        beginAtZero: true,
+        ticks: {
+          callback: (value: string | number) => formatTokenCount(Number(value)),
+        },
+      },
+      y1: {
+        type: 'linear' as const,
+        display: true,
+        position: 'right' as const,
+        title: { display: true, text: 'Avg Tokens / Request' },
+        beginAtZero: true,
+        grid: { drawOnChartArea: false },
+        ticks: {
+          callback: (value: string | number) => formatTokenCount(Number(value)),
+        },
+      },
+    },
+  };
 
   return (
     <ChartContainer
@@ -53,10 +126,11 @@ export default function CLITokensChart({ data }: CLITokensChartProps) {
         { value: formatTokenCount(totalPrompt), label: 'Total Prompt Tokens' },
         { value: formatTokenCount(totalOutput), label: 'Total Output Tokens' },
         { value: formatTokenCount(totalPrompt + totalOutput), label: 'Total Tokens' },
+        { value: formatTokenCount(averageTokensPerRequest), label: 'Avg Tokens / Request' },
       ]}
     >
       <div className="h-full">
-        <Bar data={chartData} options={options} />
+        <Chart type="bar" data={chartData} options={options} />
       </div>
     </ChartContainer>
   );

--- a/src/components/charts/ModeImpactChart.tsx
+++ b/src/components/charts/ModeImpactChart.tsx
@@ -2,6 +2,7 @@
 
 import { TooltipItem } from 'chart.js';
 import { Bar } from 'react-chartjs-2';
+import type { ReactNode } from 'react';
 import { registerChartJS } from './utils/chartSetup';
 import { createStackedBarChartOptions, yAxisFormatters } from './utils/chartOptions';
 import { formatShortDate } from '../../utils/formatters';
@@ -20,6 +21,7 @@ interface ModeImpactChartProps {
   deletedColor?: string;
   deletedBorderColor?: string;
   emptyStateMessage?: string;
+  footer?: ReactNode;
 }
 
 const DEFAULT_DELETED_COLOR = 'rgba(248, 113, 113, 0.85)';
@@ -34,6 +36,7 @@ export default function ModeImpactChart({
   deletedColor = DEFAULT_DELETED_COLOR,
   deletedBorderColor = DEFAULT_DELETED_BORDER_COLOR,
   emptyStateMessage = 'No impact data available for this mode',
+  footer,
 }: ModeImpactChartProps) {
   const totalAdded = calculateTotal(data, d => d.locAdded);
   const totalDeleted = calculateTotal(data, d => d.locDeleted);
@@ -106,8 +109,11 @@ export default function ModeImpactChart({
         { label: 'Net Change', value: `${netChange >= 0 ? '+' : ''}${netChange.toLocaleString()}`, color: netChange >= 0 ? 'text-green-600' : 'text-red-600' },
       ]}
       footer={
-        <div className="text-xs text-gray-500 print:text-[10px] print:text-gray-700">
-          Average daily users: {averageDailyUsers}
+        <div className="space-y-4">
+          <div className="text-xs text-gray-500 print:text-[10px] print:text-gray-700">
+            Average daily users: {averageDailyUsers}
+          </div>
+          {footer}
         </div>
       }
     >

--- a/src/components/charts/utils/chartStyles.ts
+++ b/src/components/charts/utils/chartStyles.ts
@@ -1,5 +1,7 @@
 'use client';
 
+import type { ChartDataset } from 'chart.js';
+
 /**
  * Centralized dataset styling presets for Chart.js charts.
  * Reduces duplication across chart components.
@@ -44,7 +46,7 @@ export function createLineDataset(
   color: string,
   label: string,
   data: (number | null)[],
-  options: Partial<typeof lineDatasetDefaults & { fill: boolean }> = {}
+  options: Partial<ChartDataset<'line', (number | null)[]>> = {}
 ) {
   const alphaColor = color.replace('rgb', 'rgba').replace(')', ', 0.1)');
   
@@ -70,7 +72,7 @@ export function createFilledLineDataset(
   color: string,
   label: string,
   data: (number | null)[],
-  options: Partial<typeof filledLineDatasetDefaults> = {}
+  options: Partial<ChartDataset<'line', (number | null)[]>> = {}
 ) {
   return createLineDataset(color, label, data, { fill: true, ...options });
 }

--- a/src/components/layout/ViewRouter.tsx
+++ b/src/components/layout/ViewRouter.tsx
@@ -180,6 +180,8 @@ const ViewRouter: React.FC = () => {
           totalUniqueIDEUsers={totalUniqueIDEUsers}
           cliUsers={stats.cliUsers}
           cliSessions={dailyCliSessionData.reduce((sum, d) => sum + d.sessionCount, 0)}
+          cliLocAdded={cliImpactData.reduce((sum, d) => sum + d.locAdded, 0)}
+          cliLocDeleted={cliImpactData.reduce((sum, d) => sum + d.locDeleted, 0)}
         />
       );
 

--- a/src/domain/calculators/__tests__/cliUsageCalculator.test.ts
+++ b/src/domain/calculators/__tests__/cliUsageCalculator.test.ts
@@ -252,9 +252,11 @@ describe('cliUsageCalculator', () => {
       expect(result[0].date).toBe('2024-01-15');
       expect(result[0].outputTokens).toBe(500);
       expect(result[0].promptTokens).toBe(300);
+      expect(result[0].requestCount).toBe(1);
       expect(result[1].date).toBe('2024-01-16');
       expect(result[1].outputTokens).toBe(200);
       expect(result[1].promptTokens).toBe(100);
+      expect(result[1].requestCount).toBe(1);
     });
 
     it('should aggregate tokens from multiple users on the same day', () => {
@@ -274,6 +276,7 @@ describe('cliUsageCalculator', () => {
       expect(result).toHaveLength(1);
       expect(result[0].outputTokens).toBe(3000);
       expect(result[0].promptTokens).toBe(1300);
+      expect(result[0].requestCount).toBe(2);
     });
   });
 });

--- a/src/domain/calculators/cliUsageCalculator.ts
+++ b/src/domain/calculators/cliUsageCalculator.ts
@@ -12,6 +12,7 @@ export interface DailyCliTokenData {
   date: string;
   outputTokens: number;
   promptTokens: number;
+  requestCount: number;
 }
 
 export interface CliUsageAccumulator {
@@ -24,6 +25,7 @@ export interface CliUsageAccumulator {
   dailyTokens: Map<string, {
     outputTokens: number;
     promptTokens: number;
+    requestCount: number;
   }>;
 }
 
@@ -44,7 +46,7 @@ export function ensureCliDates(accumulator: CliUsageAccumulator, date: string): 
     });
   }
   if (!accumulator.dailyTokens.has(date)) {
-    accumulator.dailyTokens.set(date, { outputTokens: 0, promptTokens: 0 });
+    accumulator.dailyTokens.set(date, { outputTokens: 0, promptTokens: 0, requestCount: 0 });
   }
 }
 
@@ -68,6 +70,7 @@ export function accumulateCliUsage(
   const dt = accumulator.dailyTokens.get(date)!;
   dt.outputTokens += cli.token_usage.output_tokens_sum;
   dt.promptTokens += cli.token_usage.prompt_tokens_sum;
+  dt.requestCount += cli.request_count;
 }
 
 export function computeDailyCliSessionData(
@@ -92,6 +95,7 @@ export function computeDailyCliTokenData(
       date,
       outputTokens: data.outputTokens,
       promptTokens: data.promptTokens,
+      requestCount: data.requestCount,
     }))
     .sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
 }


### PR DESCRIPTION
## Why

This change updates the user-level metrics views to make Copilot CLI activity easier to interpret and align the impact charts with the requested review order. It also surfaces CLI LOC impact in the client tables so CLI activity is not shown with zero code impact.

| Commit | Change |
|--------|--------|
| `feat: add CLI tokens per request trend` | Adds request counts to daily CLI token data, shows an average tokens per request line on the CLI token chart, and renames the user details section to Copilot CLI Usage. |
| `feat: show CLI LOC in client tables` | Passes CLI impact totals into the client analysis view so the Copilot CLI row shows LOC added/deleted in both client tables. |
| `feat: reorder Copilot impact charts` | Reorders impact charts to the requested sequence and adds an Edit Mode deprecation insight. |
| `fix: address PR chart review feedback` | Uses the shared chart line dataset helper and attaches the Edit Mode deprecation insight to the Edit chart footer. |
