### PR TITLE
Add CLI model usage chart and footer attribution

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -15,6 +15,18 @@ export default function Home() {
         <div className={`px-4 sm:px-6 lg:px-8 pb-6 print:px-0 print:mx-0 ${hasData ? 'py-6 lg:pt-12' : 'py-6'}`}>
           <AppHeader />
           <ViewRouter />
+          <footer className="mt-12 pb-4 text-center text-xs text-gray-400 print:hidden">
+            &copy;{' '}
+            <a
+              href="https://github.com/asizikov"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="hover:text-gray-600 underline underline-offset-2 transition-colors"
+            >
+              Anton Sizikov
+            </a>
+            {' '}&mdash; Solutions Engineer @ GitHub
+          </footer>
         </div>
       </div>
     </div>

--- a/src/components/CLIAdoptionView.tsx
+++ b/src/components/CLIAdoptionView.tsx
@@ -6,13 +6,17 @@ import CLIAdoptionTrendChart from './charts/CLIAdoptionTrendChart';
 import CLIUsersChart from './charts/CLIUsersChart';
 import CLISessionChart from './charts/CLISessionChart';
 import CLITokensChart from './charts/CLITokensChart';
-import type { MetricsStats } from '../types/metrics';
+import ModelsUsageChart from './charts/ModelsUsageChart';
+import type { MetricsStats, ModelDailyUsageEntry } from '../types/metrics';
 import type { DailyCliSessionData, DailyCliTokenData, DailyCliAdoptionTrend } from '../domain/calculators/metricCalculators';
 interface CLIAdoptionViewProps {
   stats: MetricsStats;
   dailyCliSessionData: DailyCliSessionData[];
   dailyCliTokenData: DailyCliTokenData[];
   dailyCliAdoptionTrend: DailyCliAdoptionTrend[];
+  cliModelEntries: ModelDailyUsageEntry[];
+  cliModelDates: string[];
+  cliModelTotal: number;
 }
 
 export default function CLIAdoptionView({
@@ -20,6 +24,9 @@ export default function CLIAdoptionView({
   dailyCliSessionData,
   dailyCliTokenData,
   dailyCliAdoptionTrend,
+  cliModelEntries,
+  cliModelDates,
+  cliModelTotal,
 }: CLIAdoptionViewProps) {
   const cliShare = stats.uniqueUsers > 0
     ? Math.round((stats.cliUsers / stats.uniqueUsers) * 1000) / 10
@@ -42,6 +49,7 @@ export default function CLIAdoptionView({
       <CLIUsersChart data={dailyCliSessionData} />
       <CLISessionChart data={dailyCliSessionData} />
       <CLITokensChart data={dailyCliTokenData} />
+      <ModelsUsageChart modelEntries={cliModelEntries} dates={cliModelDates} totalInteractions={cliModelTotal} variant="cli" />
     </ViewPanel>
   );
 }

--- a/src/components/charts/CLITokensChart.tsx
+++ b/src/components/charts/CLITokensChart.tsx
@@ -42,6 +42,7 @@ export default function CLITokensChart({ data }: CLITokensChartProps) {
         ...createBarDataset(chartColors.amber.solid, 'Prompt Tokens', data.map(d => d.promptTokens), {
           yAxisID: 'y',
           stack: 'tokens',
+          order: 2,
         }),
       },
       {
@@ -49,6 +50,7 @@ export default function CLITokensChart({ data }: CLITokensChartProps) {
         ...createBarDataset(chartColors.red.solid, 'Output Tokens', data.map(d => d.outputTokens), {
           yAxisID: 'y',
           stack: 'tokens',
+          order: 2,
         }),
       },
       {
@@ -62,6 +64,7 @@ export default function CLITokensChart({ data }: CLITokensChartProps) {
           pointHoverRadius: 4,
           spanGaps: true,
           yAxisID: 'y1',
+          order: 1,
         }),
       },
     ],

--- a/src/components/charts/ClientActivityChart.tsx
+++ b/src/components/charts/ClientActivityChart.tsx
@@ -4,6 +4,7 @@ import { Bar } from 'react-chartjs-2';
 import type { ChartOptions, TooltipItem } from 'chart.js';
 import { registerChartJS } from './utils/chartSetup';
 import { getIDEIcon, formatIDEName, CopilotIcon } from '../icons/IDEIcons';
+import { isCliFeature } from '../../domain/featureCategories';
 import { formatShortDate } from '../../utils/formatters';
 import ChartContainer from '../ui/ChartContainer';
 import type { UserDayData } from '../../types/metrics';
@@ -81,10 +82,6 @@ const FALLBACK_COLORS = [
   '#3B82F6', '#10B981', '#F59E0B', '#EF4444', '#8B5CF6',
   '#F97316', '#06B6D4', '#84CC16', '#EC4899', '#14B8A6'
 ];
-
-function isCliFeature(feature: string): boolean {
-  return feature === 'copilot_cli' || feature === 'cli_agent';
-}
 
 function createEmptyCliFeatureTotals(): CliFeatureTotals {
   return {

--- a/src/components/charts/ModelsUsageChart.tsx
+++ b/src/components/charts/ModelsUsageChart.tsx
@@ -17,12 +17,13 @@ interface ModelsUsageChartProps {
   modelEntries: ModelDailyUsageEntry[];
   dates: string[];
   totalInteractions: number;
-  variant: 'standard' | 'premium' | 'auto';
+  variant: 'standard' | 'premium' | 'auto' | 'cli';
 }
 
 export default function ModelsUsageChart({ modelEntries, dates, totalInteractions, variant }: ModelsUsageChartProps) {
   const isPremium = variant === 'premium';
   const isAuto = variant === 'auto';
+  const isCli = variant === 'cli';
 
   const { labels, datasets, modelTotals, modelOrder } = useMemo(() => {
     const sortedModels = [...modelEntries].sort((a, b) => b.total - a.total);
@@ -39,6 +40,11 @@ export default function ModelsUsageChart({ modelEntries, dates, totalInteraction
     const getModelColor = (model: string): string => {
       if (isAuto || model === 'auto') {
         return chartColors.violet.solid;
+      }
+      if (isCli) {
+        const adjustedIndex = modelIndexMap.get(model) ?? 0;
+        const hue = (315 + adjustedIndex * 42) % 360;
+        return `hsl(${hue}, 70%, 55%)`;
       }
       if (model === 'unknown') {
         return UNKNOWN_COLOR;
@@ -61,7 +67,7 @@ export default function ModelsUsageChart({ modelEntries, dates, totalInteraction
         backgroundColor: color,
         borderColor: color,
         borderWidth: 1,
-        stack: isAuto ? 'auto-models' : isPremium ? 'premium-models' : 'standard-models'
+        stack: isAuto ? 'auto-models' : isCli ? 'cli-models' : isPremium ? 'premium-models' : 'standard-models'
       };
     });
 
@@ -71,10 +77,10 @@ export default function ModelsUsageChart({ modelEntries, dates, totalInteraction
       modelTotals,
       modelOrder
     };
-  }, [modelEntries, dates, isPremium, isAuto]);
+  }, [modelEntries, dates, isPremium, isAuto, isCli]);
 
   const insights = useMemo(() => {
-    if (isAuto) return null;
+    if (isAuto || isCli) return null;
     if (!totalInteractions || !modelOrder.length) return null;
 
     const shares = modelOrder.map(m => ({
@@ -125,7 +131,21 @@ export default function ModelsUsageChart({ modelEntries, dates, totalInteraction
     paragraphs.push(`Top model share summary: ${summary}${shares.length > 5 ? ', ...' : ''}.`);
 
     return { title, variant: insightVariant, paragraphs, showDocLink };
-  }, [modelTotals, modelOrder, totalInteractions, isPremium, isAuto]);
+  }, [modelTotals, modelOrder, totalInteractions, isPremium, isAuto, isCli]);
+
+  const chartTitle = isCli
+    ? 'CLI Models Daily Usage'
+    : isAuto
+      ? 'Auto Model Daily Usage'
+      : `${isPremium ? 'Premium' : 'Standard'} Models Daily Usage`;
+  const chartDescription = isCli
+    ? 'Daily Copilot CLI user-initiated interactions grouped by model.'
+    : isAuto
+      ? 'Daily interactions routed through Copilot Auto mode.'
+      : undefined;
+  const variantLabel = isCli ? 'CLI' : isAuto ? 'Auto' : isPremium ? 'Premium' : 'Standard';
+  const primaryColorClass = isCli ? 'text-pink-600' : isAuto ? 'text-violet-600' : isPremium ? 'text-purple-600' : 'text-blue-600';
+  const totalColorClass = isCli ? 'text-pink-600' : isAuto ? 'text-purple-600' : isPremium ? 'text-red-600' : 'text-green-600';
 
   const chartData = { labels, datasets };
 
@@ -145,19 +165,21 @@ export default function ModelsUsageChart({ modelEntries, dates, totalInteraction
 
   return (
     <ChartContainer
-      title={isAuto ? 'Auto Model Daily Usage' : `${isPremium ? 'Premium' : 'Standard'} Models Daily Usage`}
-      description={isAuto ? 'Daily interactions routed through Copilot Auto mode.' : undefined}
+      title={chartTitle}
+      description={chartDescription}
       isEmpty={dates.length === 0 || datasets.length === 0}
-      emptyState={`No ${isAuto ? 'auto' : isPremium ? 'premium' : 'standard'} model usage data available`}
+      emptyState={`No ${isCli ? 'CLI' : isAuto ? 'auto' : isPremium ? 'premium' : 'standard'} model usage data available`}
       summaryStats={[
-        { value: datasets.length, label: isAuto ? 'Auto Models' : 'Models', colorClass: isAuto ? 'text-violet-600' : isPremium ? 'text-purple-600' : 'text-blue-600' },
-        { value: totalInteractions, label: 'Total Interactions', colorClass: isAuto ? 'text-purple-600' : isPremium ? 'text-red-600' : 'text-green-600' },
+        { value: datasets.length, label: isAuto ? 'Auto Models' : `${variantLabel} Models`, colorClass: primaryColorClass },
+        { value: totalInteractions, label: 'Total Interactions', colorClass: totalColorClass },
       ]}
       chartHeight="h-96"
       footer={
         <>
           <p className="text-xs text-gray-600 mb-4">
-            Counts aggregate user initiated interactions across all features per {isAuto ? 'auto' : isPremium ? 'premium' : 'standard'} model per day.
+            {isCli
+              ? 'Counts aggregate user initiated interactions for the Copilot CLI feature per model per day.'
+              : `Counts aggregate user initiated interactions across all features per ${isAuto ? 'auto' : isPremium ? 'premium' : 'standard'} model per day.`}
           </p>
           {insights && (
             <InsightsCard title={insights.title} variant={insights.variant}>

--- a/src/components/charts/ModelsUsageChart.tsx
+++ b/src/components/charts/ModelsUsageChart.tsx
@@ -5,7 +5,7 @@ import { TooltipItem } from 'chart.js';
 import { Bar } from 'react-chartjs-2';
 import { registerChartJS } from './utils/chartSetup';
 import { createStackedBarChartOptions } from './utils/chartOptions';
-import { chartColors } from './utils/chartColors';
+import { chartColors, getSequentialColor } from './utils/chartColors';
 import { formatShortDate } from '../../utils/formatters';
 import type { ModelDailyUsageEntry } from '../../types/metrics';
 import ChartContainer from '../ui/ChartContainer';
@@ -43,8 +43,7 @@ export default function ModelsUsageChart({ modelEntries, dates, totalInteraction
       }
       if (isCli) {
         const adjustedIndex = modelIndexMap.get(model) ?? 0;
-        const hue = (315 + adjustedIndex * 42) % 360;
-        return `hsl(${hue}, 70%, 55%)`;
+        return getSequentialColor(adjustedIndex + 7);
       }
       if (model === 'unknown') {
         return UNKNOWN_COLOR;
@@ -178,8 +177,8 @@ export default function ModelsUsageChart({ modelEntries, dates, totalInteraction
         <>
           <p className="text-xs text-gray-600 mb-4">
             {isCli
-              ? 'Counts aggregate user initiated interactions for the Copilot CLI feature per model per day.'
-              : `Counts aggregate user initiated interactions across all features per ${isAuto ? 'auto' : isPremium ? 'premium' : 'standard'} model per day.`}
+              ? 'Counts aggregate user-initiated interactions for the Copilot CLI feature per model per day.'
+              : `Counts aggregate user-initiated interactions across all features per ${isAuto ? 'auto' : isPremium ? 'premium' : 'standard'} model per day.`}
           </p>
           {insights && (
             <InsightsCard title={insights.title} variant={insights.variant}>

--- a/src/components/layout/ViewRouter.tsx
+++ b/src/components/layout/ViewRouter.tsx
@@ -216,6 +216,9 @@ const ViewRouter: React.FC = () => {
           dailyCliSessionData={dailyCliSessionData}
           dailyCliTokenData={dailyCliTokenData}
           dailyCliAdoptionTrend={dailyCliAdoptionTrend}
+          cliModelEntries={modelBreakdownData.cliModels ?? []}
+          cliModelDates={modelBreakdownData.dates}
+          cliModelTotal={modelBreakdownData.cliTotal ?? 0}
         />
       );
 

--- a/src/components/layout/ViewRouter.tsx
+++ b/src/components/layout/ViewRouter.tsx
@@ -217,7 +217,11 @@ const ViewRouter: React.FC = () => {
           dailyCliTokenData={dailyCliTokenData}
           dailyCliAdoptionTrend={dailyCliAdoptionTrend}
           cliModelEntries={modelBreakdownData.cliModels ?? []}
-          cliModelDates={modelBreakdownData.dates}
+          cliModelDates={
+            dailyCliSessionData.length > 0
+              ? dailyCliSessionData.map((entry) => entry.date)
+              : modelBreakdownData.dates
+          }
           cliModelTotal={modelBreakdownData.cliTotal ?? 0}
         />
       );

--- a/src/components/ui/DayDetailsModal.tsx
+++ b/src/components/ui/DayDetailsModal.tsx
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import type { UserDayData } from '../../types/metrics';
+import { isCliFeature } from '../../domain/featureCategories';
 import { translateFeature } from '../../domain/featureTranslations';
 import { formatIDEName } from '../icons/IDEIcons';
 import ExpandableTableSection from './ExpandableTableSection';
@@ -13,10 +14,6 @@ interface DayDetailsModalProps {
   date: string;
   dayMetrics?: UserDayData;
   userLogin?: string;
-}
-
-function isCliFeature(feature: string): boolean {
-  return feature === 'copilot_cli' || feature === 'cli_agent';
 }
 
 export default function DayDetailsModal({ isOpen, onClose, date, dayMetrics, userLogin }: DayDetailsModalProps) {

--- a/src/domain/__tests__/metricsAggregator.test.ts
+++ b/src/domain/__tests__/metricsAggregator.test.ts
@@ -378,6 +378,97 @@ describe('metricsAggregator', () => {
       expect(aggregated.featureAdoptionData.totalUsers).toBeGreaterThan(0);
     });
 
+    it('should aggregate daily CLI model usage from model feature totals', () => {
+      const day1 = createBasicMetric({
+        user_id: 1,
+        day: '2024-01-15',
+        totals_by_model_feature: [
+          {
+            model: 'gpt-5.4',
+            feature: 'copilot_cli',
+            user_initiated_interaction_count: 15,
+            code_generation_activity_count: 8,
+            code_acceptance_activity_count: 8,
+            loc_added_sum: 209,
+            loc_deleted_sum: 50,
+            loc_suggested_to_add_sum: 0,
+            loc_suggested_to_delete_sum: 0,
+          },
+          {
+            model: 'claude-sonnet-4.6',
+            feature: 'copilot_cli',
+            user_initiated_interaction_count: 5,
+            code_generation_activity_count: 9,
+            code_acceptance_activity_count: 9,
+            loc_added_sum: 56,
+            loc_deleted_sum: 18,
+            loc_suggested_to_add_sum: 0,
+            loc_suggested_to_delete_sum: 0,
+          },
+          {
+            model: 'gpt-5.4',
+            feature: 'chat_panel_ask_mode',
+            user_initiated_interaction_count: 50,
+            code_generation_activity_count: 0,
+            code_acceptance_activity_count: 0,
+            loc_added_sum: 0,
+            loc_deleted_sum: 0,
+            loc_suggested_to_add_sum: 0,
+            loc_suggested_to_delete_sum: 0,
+          },
+        ],
+      });
+      const day2 = createBasicMetric({
+        user_id: 2,
+        day: '2024-01-16',
+        totals_by_model_feature: [
+          {
+            model: 'gpt-5.4',
+            feature: 'copilot_cli',
+            user_initiated_interaction_count: 3,
+            code_generation_activity_count: 1,
+            code_acceptance_activity_count: 1,
+            loc_added_sum: 12,
+            loc_deleted_sum: 2,
+            loc_suggested_to_add_sum: 0,
+            loc_suggested_to_delete_sum: 0,
+          },
+          {
+            model: 'claude-opus-4.7',
+            feature: 'copilot_cli',
+            user_initiated_interaction_count: 0,
+            code_generation_activity_count: 9,
+            code_acceptance_activity_count: 9,
+            loc_added_sum: 1414,
+            loc_deleted_sum: 1,
+            loc_suggested_to_add_sum: 0,
+            loc_suggested_to_delete_sum: 0,
+          },
+        ],
+      });
+
+      const { aggregated } = aggregateMetrics([day1, day2]);
+
+      expect(aggregated.modelBreakdownData.cliTotal).toBe(23);
+      expect(aggregated.modelBreakdownData.cliModels).toEqual([
+        {
+          model: 'gpt-5.4',
+          total: 18,
+          dailyData: {
+            '2024-01-15': 15,
+            '2024-01-16': 3,
+          },
+        },
+        {
+          model: 'claude-sonnet-4.6',
+          total: 5,
+          dailyData: {
+            '2024-01-15': 5,
+          },
+        },
+      ]);
+    });
+
     it('should count CLI adoption from used_cli without relying on feature rows', () => {
       const metric = createBasicMetric({
         used_cli: true,

--- a/src/domain/calculators/impactCalculator.ts
+++ b/src/domain/calculators/impactCalculator.ts
@@ -1,4 +1,5 @@
 import { CopilotMetrics } from '../../types/metrics';
+import { isCliFeature } from '../featureCategories';
 
 export interface ImpactData {
   date: string;
@@ -36,10 +37,6 @@ const JOINED_FEATURES = [
   'cli_agent',
   'copilot_cli',
 ];
-
-function isCliFeature(feature: string): boolean {
-  return feature === 'copilot_cli' || feature === 'cli_agent';
-}
 
 export function createImpactAccumulator(): ImpactAccumulator {
   return {

--- a/src/domain/calculators/modelBreakdownCalculator.ts
+++ b/src/domain/calculators/modelBreakdownCalculator.ts
@@ -11,9 +11,11 @@ export interface ModelBreakdownAccumulator {
   premiumModels: Map<string, ModelAccEntry>;
   standardModels: Map<string, ModelAccEntry>;
   autoModels: Map<string, ModelAccEntry>;
+  cliModels: Map<string, ModelAccEntry>;
   autoModeUsersByDate: Map<string, Set<number>>;
   premiumTotal: number;
   standardTotal: number;
+  cliTotal: number;
   unknownTotal: number;
   allDates: Set<string>;
 }
@@ -32,12 +34,32 @@ export function createModelBreakdownAccumulator(): ModelBreakdownAccumulator {
     premiumModels: new Map(),
     standardModels: new Map(),
     autoModels: new Map(),
+    cliModels: new Map(),
     autoModeUsersByDate: new Map(),
     premiumTotal: 0,
     standardTotal: 0,
+    cliTotal: 0,
     unknownTotal: 0,
     allDates: new Set(),
   };
+}
+
+function isCliFeature(feature: string): boolean {
+  return feature === 'copilot_cli' || feature === 'cli_agent';
+}
+
+function accumulateModelEntry(
+  modelsMap: Map<string, ModelAccEntry>,
+  model: string,
+  date: string,
+  count: number
+): void {
+  if (!modelsMap.has(model)) {
+    modelsMap.set(model, { total: 0, dailyData: new Map() });
+  }
+  const entry = modelsMap.get(model)!;
+  entry.total += count;
+  entry.dailyData.set(date, (entry.dailyData.get(date) || 0) + count);
 }
 
 export function accumulateModelBreakdown(
@@ -46,6 +68,7 @@ export function accumulateModelBreakdown(
   userId: number,
   modelFeature: {
     model: string;
+    feature: string;
     user_initiated_interaction_count: number;
     code_generation_activity_count: number;
     code_acceptance_activity_count: number;
@@ -55,6 +78,12 @@ export function accumulateModelBreakdown(
   const activityCount = (modelFeature.code_generation_activity_count || 0) + (modelFeature.code_acceptance_activity_count || 0);
   const normalizedModel = modelFeature.model.trim().toLowerCase();
 
+  if (isCliFeature(modelFeature.feature) && interactionCount > 0) {
+    accumulator.allDates.add(date);
+    accumulator.cliTotal += interactionCount;
+    accumulateModelEntry(accumulator.cliModels, normalizedModel, date, interactionCount);
+  }
+
   if (normalizedModel === 'auto' && (interactionCount > 0 || activityCount > 0)) {
     accumulator.allDates.add(date);
     if (!accumulator.autoModeUsersByDate.has(date)) {
@@ -62,13 +91,8 @@ export function accumulateModelBreakdown(
     }
     accumulator.autoModeUsersByDate.get(date)!.add(userId);
 
-    if (!accumulator.autoModels.has(normalizedModel)) {
-      accumulator.autoModels.set(normalizedModel, { total: 0, dailyData: new Map() });
-    }
-    const entry = accumulator.autoModels.get(normalizedModel)!;
     const autoUsageCount = interactionCount > 0 ? interactionCount : activityCount;
-    entry.total += autoUsageCount;
-    entry.dailyData.set(date, (entry.dailyData.get(date) || 0) + autoUsageCount);
+    accumulateModelEntry(accumulator.autoModels, normalizedModel, date, autoUsageCount);
     return;
   }
 
@@ -81,20 +105,10 @@ export function accumulateModelBreakdown(
 
   if (classification === true) {
     accumulator.premiumTotal += interactionCount;
-    if (!accumulator.premiumModels.has(normalizedModel)) {
-      accumulator.premiumModels.set(normalizedModel, { total: 0, dailyData: new Map() });
-    }
-    const entry = accumulator.premiumModels.get(normalizedModel)!;
-    entry.total += interactionCount;
-    entry.dailyData.set(date, (entry.dailyData.get(date) || 0) + interactionCount);
+    accumulateModelEntry(accumulator.premiumModels, normalizedModel, date, interactionCount);
   } else if (classification === false) {
     accumulator.standardTotal += interactionCount;
-    if (!accumulator.standardModels.has(normalizedModel)) {
-      accumulator.standardModels.set(normalizedModel, { total: 0, dailyData: new Map() });
-    }
-    const entry = accumulator.standardModels.get(normalizedModel)!;
-    entry.total += interactionCount;
-    entry.dailyData.set(date, (entry.dailyData.get(date) || 0) + interactionCount);
+    accumulateModelEntry(accumulator.standardModels, normalizedModel, date, interactionCount);
   } else {
     accumulator.unknownTotal += interactionCount;
   }
@@ -159,10 +173,12 @@ export function computeModelBreakdownData(
     premiumModels: buildModelEntries(accumulator.premiumModels),
     standardModels: buildModelEntries(accumulator.standardModels),
     autoModels: buildModelEntries(accumulator.autoModels),
+    cliModels: buildModelEntries(accumulator.cliModels),
     autoModeAdoptionTrend: computeAutoModeAdoptionTrend(dates, accumulator.autoModeUsersByDate),
     dates,
     premiumTotal: accumulator.premiumTotal,
     standardTotal: accumulator.standardTotal,
+    cliTotal: accumulator.cliTotal,
     unknownTotal: accumulator.unknownTotal,
   };
 }

--- a/src/domain/calculators/modelBreakdownCalculator.ts
+++ b/src/domain/calculators/modelBreakdownCalculator.ts
@@ -1,4 +1,5 @@
 import type { AutoModeAdoptionTrendEntry, ModelBreakdownData, ModelDailyUsageEntry } from '../../types/metrics';
+import { isCliFeature } from '../featureCategories';
 import { KNOWN_MODELS } from '../modelConfig';
 
 interface ModelAccEntry {
@@ -42,10 +43,6 @@ export function createModelBreakdownAccumulator(): ModelBreakdownAccumulator {
     unknownTotal: 0,
     allDates: new Set(),
   };
-}
-
-function isCliFeature(feature: string): boolean {
-  return feature === 'copilot_cli' || feature === 'cli_agent';
 }
 
 function accumulateModelEntry(

--- a/src/domain/featureCategories.ts
+++ b/src/domain/featureCategories.ts
@@ -1,0 +1,5 @@
+const CLI_FEATURES = new Set(['copilot_cli', 'cli_agent']);
+
+export function isCliFeature(feature: string): boolean {
+  return CLI_FEATURES.has(feature);
+}

--- a/src/types/metrics.ts
+++ b/src/types/metrics.ts
@@ -194,10 +194,12 @@ export interface ModelBreakdownData {
   premiumModels: ModelDailyUsageEntry[];
   standardModels: ModelDailyUsageEntry[];
   autoModels?: ModelDailyUsageEntry[];
+  cliModels?: ModelDailyUsageEntry[];
   autoModeAdoptionTrend?: AutoModeAdoptionTrendEntry[];
   dates: string[];
   premiumTotal: number;
   standardTotal: number;
+  cliTotal?: number;
   unknownTotal: number;
 }
 


### PR DESCRIPTION
## Why

CLI adoption views now need model-level visibility, including which models drive daily CLI interactions. This also improves chart readability for token usage and adds subtle app attribution in the footer.

| Commit | Change |
|--------|--------|
| `fix: bring CLI average token line forward` | Sets explicit Chart.js dataset draw order so the average tokens per request line appears above the stacked token bars. |
| `feat: add CLI model usage chart` | Aggregates `totals_by_model_feature` CLI rows by model and day, then renders daily CLI model interactions on the CLI Adoption page. |
| `chore: add app footer attribution` | Adds a subtle grey footer with a link to Anton Sizikov's GitHub profile. |