### PR TITLE
Remove plan mode impact tracking

### DIFF
--- a/src/components/CopilotImpactView.tsx
+++ b/src/components/CopilotImpactView.tsx
@@ -12,11 +12,10 @@ interface CopilotImpactViewProps {
   inlineModeImpactData: ModeImpactData[];
   askModeImpactData: ModeImpactData[];
   cliImpactData: ModeImpactData[];
-  planModeImpactData: ModeImpactData[];
   joinedImpactData: ModeImpactData[];
 }
 
-export default function CopilotImpactView({ agentImpactData, codeCompletionImpactData, editModeImpactData, inlineModeImpactData, askModeImpactData, cliImpactData, planModeImpactData, joinedImpactData }: CopilotImpactViewProps) {
+export default function CopilotImpactView({ agentImpactData, codeCompletionImpactData, editModeImpactData, inlineModeImpactData, askModeImpactData, cliImpactData, joinedImpactData }: CopilotImpactViewProps) {
   return (
     <ViewPanel
       headerProps={{
@@ -29,7 +28,7 @@ export default function CopilotImpactView({ agentImpactData, codeCompletionImpac
       <ModeImpactChart
         data={joinedImpactData || []}
         title="Combined Copilot Impact"
-        description="Aggregate impact across Code Completion, Ask Mode, Agent Mode, Edit Mode, Plan Mode, Inline Mode, and CLI activities."
+        description="Aggregate impact across Code Completion, Ask Mode, Agent Mode, Edit Mode, Inline Mode, and CLI activities."
         emptyStateMessage="No combined impact data available."
       />
       <ModeImpactChart
@@ -49,12 +48,6 @@ export default function CopilotImpactView({ agentImpactData, codeCompletionImpac
         title="Code Completion Impact"
         description="Daily lines of code added and deleted when developers accept Copilot code completions."
         emptyStateMessage="No code completion impact data available."
-      />
-      <ModeImpactChart
-        data={planModeImpactData || []}
-        title="Copilot Plan Mode Impact"
-        description="Daily lines of code added and deleted through Copilot Plan Mode sessions."
-        emptyStateMessage="No Plan Mode impact data available."
       />
       <ModeImpactChart
         data={askModeImpactData || []}

--- a/src/components/layout/ViewRouter.tsx
+++ b/src/components/layout/ViewRouter.tsx
@@ -124,7 +124,6 @@ const ViewRouter: React.FC = () => {
     inlineModeImpactData,
     askModeImpactData,
     cliImpactData,
-    planModeImpactData,
     joinedImpactData,
     ideStats,
     multiIDEUsersCount,
@@ -194,7 +193,6 @@ const ViewRouter: React.FC = () => {
           inlineModeImpactData={inlineModeImpactData}
           askModeImpactData={askModeImpactData}
           cliImpactData={cliImpactData}
-          planModeImpactData={planModeImpactData}
           joinedImpactData={joinedImpactData}
         />
       );

--- a/src/domain/calculators/__tests__/impactCalculator.test.ts
+++ b/src/domain/calculators/__tests__/impactCalculator.test.ts
@@ -135,7 +135,6 @@ describe('impactCalculator', () => {
         { feature: 'chat_inline', locAdded: 20, locDeleted: 3 },
         { feature: 'chat_panel_agent_mode', locAdded: 40, locDeleted: 8 },
         { feature: 'copilot_cli', locAdded: 10, locDeleted: 2 },
-        { feature: 'chat_panel_plan_mode', locAdded: 15, locDeleted: 3 },
       ];
 
       accumulateFeatureImpacts(accumulator, '2024-01-15', 1, features);
@@ -143,8 +142,8 @@ describe('impactCalculator', () => {
       const results = computeJoinedImpactData(accumulator);
 
       expect(results).toHaveLength(1);
-      expect(results[0].locAdded).toBe(265); // Sum of all
-      expect(results[0].locDeleted).toBe(51); // Sum of all
+      expect(results[0].locAdded).toBe(250); // Sum of all
+      expect(results[0].locDeleted).toBe(48); // Sum of all
     });
 
     it('should exclude non-joined features from joined impact', () => {

--- a/src/domain/calculators/impactCalculator.ts
+++ b/src/domain/calculators/impactCalculator.ts
@@ -22,7 +22,6 @@ export interface ImpactAccumulator {
   dailyInlineModeImpact: Map<string, { locAdded: number; locDeleted: number; userIds: Set<number> }>;
   dailyAskModeImpact: Map<string, { locAdded: number; locDeleted: number; userIds: Set<number> }>;
   dailyCliImpact: Map<string, { locAdded: number; locDeleted: number; userIds: Set<number> }>;
-  dailyPlanModeImpact: Map<string, { locAdded: number; locDeleted: number; userIds: Set<number> }>;
   dailyJoinedImpact: Map<string, { locAdded: number; locDeleted: number; userIds: Set<number> }>;
   allUniqueUsers: Set<number>;
 }
@@ -34,7 +33,6 @@ const JOINED_FEATURES = [
   'chat_inline',
   'chat_panel_agent_mode',
   'agent_edit',
-  'chat_panel_plan_mode',
   'cli_agent',
   'copilot_cli',
 ];
@@ -47,7 +45,6 @@ export function createImpactAccumulator(): ImpactAccumulator {
     dailyInlineModeImpact: new Map(),
     dailyAskModeImpact: new Map(),
     dailyCliImpact: new Map(),
-    dailyPlanModeImpact: new Map(),
     dailyJoinedImpact: new Map(),
     allUniqueUsers: new Set(),
   };
@@ -83,7 +80,6 @@ export function ensureImpactDates(accumulator: ImpactAccumulator, date: string):
   ensureImpactDate(accumulator.dailyInlineModeImpact, date);
   ensureImpactDate(accumulator.dailyAskModeImpact, date);
   ensureImpactDate(accumulator.dailyCliImpact, date);
-  ensureImpactDate(accumulator.dailyPlanModeImpact, date);
   ensureImpactDate(accumulator.dailyJoinedImpact, date);
 }
 
@@ -170,16 +166,6 @@ export function accumulateFeatureImpacts(
       );
     }
 
-    if (feature === 'chat_panel_plan_mode' && hasLoc) {
-      accumulateToMap(
-        accumulator.dailyPlanModeImpact,
-        date,
-        userId,
-        locAdded,
-        locDeleted
-      );
-    }
-
     if (JOINED_FEATURES.includes(feature) && hasLoc) {
       joinedLocAdded += locAdded;
       joinedLocDeleted += locDeleted;
@@ -250,10 +236,6 @@ export function computeCliImpactData(accumulator: ImpactAccumulator): ModeImpact
   return formatImpactMap(accumulator.dailyCliImpact, accumulator.allUniqueUsers.size);
 }
 
-export function computePlanModeImpactData(accumulator: ImpactAccumulator): ModeImpactData[] {
-  return formatImpactMap(accumulator.dailyPlanModeImpact, accumulator.allUniqueUsers.size);
-}
-
 export function computeJoinedImpactData(accumulator: ImpactAccumulator): ModeImpactData[] {
   return formatImpactMap(accumulator.dailyJoinedImpact, accumulator.allUniqueUsers.size);
 }
@@ -312,9 +294,4 @@ export function calculateCodeCompletionImpactFromMetrics(metrics: CopilotMetrics
 export function calculateCliImpactFromMetrics(metrics: CopilotMetrics[]): ModeImpactData[] {
   const accumulator = processMetricsForImpact(metrics);
   return computeCliImpactData(accumulator);
-}
-
-export function calculatePlanModeImpactFromMetrics(metrics: CopilotMetrics[]): ModeImpactData[] {
-  const accumulator = processMetricsForImpact(metrics);
-  return computePlanModeImpactData(accumulator);
 }

--- a/src/domain/calculators/index.ts
+++ b/src/domain/calculators/index.ts
@@ -82,14 +82,12 @@ export {
   computeInlineModeImpactData,
   computeAskModeImpactData,
   computeCliImpactData,
-  computePlanModeImpactData,
   computeJoinedImpactData,
   calculateJoinedImpactFromMetrics,
   calculateEditModeImpactFromMetrics,
   calculateInlineModeImpactFromMetrics,
   calculateAskModeImpactFromMetrics,
   calculateCliImpactFromMetrics,
-  calculatePlanModeImpactFromMetrics,
 } from './impactCalculator';
 
 export {

--- a/src/domain/calculators/metricCalculators.ts
+++ b/src/domain/calculators/metricCalculators.ts
@@ -10,7 +10,6 @@ import {
   calculateAgentImpactFromMetrics,
   calculateCodeCompletionImpactFromMetrics,
   calculateCliImpactFromMetrics,
-  calculatePlanModeImpactFromMetrics,
 } from './impactCalculator';
 
 export type {
@@ -56,5 +55,3 @@ export const calculateAgentImpactData = calculateAgentImpactFromMetrics;
 export const calculateCodeCompletionImpactData = calculateCodeCompletionImpactFromMetrics;
 
 export const calculateCliImpactData = calculateCliImpactFromMetrics;
-
-export const calculatePlanModeImpactData = calculatePlanModeImpactFromMetrics;

--- a/src/domain/metricsAggregator.ts
+++ b/src/domain/metricsAggregator.ts
@@ -63,7 +63,6 @@ import {
   computeInlineModeImpactData,
   computeAskModeImpactData,
   computeCliImpactData,
-  computePlanModeImpactData,
   computeJoinedImpactData,
 
   createIDEStatsAccumulator,
@@ -117,7 +116,6 @@ export interface AggregatedMetrics {
   inlineModeImpactData: ModeImpactData[];
   askModeImpactData: ModeImpactData[];
   cliImpactData: ModeImpactData[];
-  planModeImpactData: ModeImpactData[];
   joinedImpactData: ModeImpactData[];
   ideStats: IDEStatsData[];
   multiIDEUsersCount: number;
@@ -362,7 +360,6 @@ export function aggregateMetrics(
     inlineModeImpactData: computeInlineModeImpactData(impactAccumulator),
     askModeImpactData: computeAskModeImpactData(impactAccumulator),
     cliImpactData: computeCliImpactData(impactAccumulator),
-    planModeImpactData: computePlanModeImpactData(impactAccumulator),
     joinedImpactData: computeJoinedImpactData(impactAccumulator),
     ...computeIDEStatsData(ideStatsAccumulator),
     pluginVersionData: computePluginVersionData(pluginVersionAccumulator),


### PR DESCRIPTION
Plan mode never produces LOC changes, so tracking and displaying its impact seems unnecessary.

P.S. we love the tool, it's been very helpful to track the usage across our org!
## Changes

- **Domain layer**: Remove `dailyPlanModeImpact` from the impact accumulator, its compute/calculate functions, re-exports, and the `chat_panel_plan_mode` entry from `JOINED_FEATURES`
- **UI**: Remove the dedicated Plan Mode Impact chart from `CopilotImpactView` and stop passing `planModeImpactData` through `ViewRouter`. Update the combined impact chart description to no longer reference Plan Mode
- **Tests**: Remove plan mode from joined impact test fixtures and adjust expected totals