### PR TITLE
Add Copilot usage billing notice

### DIFF
--- a/src/components/ModelDetailsView.tsx
+++ b/src/components/ModelDetailsView.tsx
@@ -161,8 +161,20 @@ export default function ModelDetailsView({ modelBreakdownData }: ModelDetailsVie
       contentClassName="space-y-6"
     >
       <div className="space-y-6">
+        <div className="rounded-md border border-blue-200 bg-blue-50 px-4 py-3 text-sm text-blue-900">
+          Starting 1st of June, GitHub Copilot is switching to a usage-based billing model.{' '}
+          <a
+            href="https://github.blog/news-insights/company-news/github-copilot-is-moving-to-usage-based-billing/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="font-medium underline decoration-blue-400 underline-offset-2 hover:text-blue-700"
+          >
+            Read the announcement.
+          </a>{' '}
+          Premium vs Base Models separation will no longer be applicable after the transition.
+        </div>
         <div className="text-sm text-gray-500">
-          Each seat comes with at least 300 Premium Request Units (PRUs) that reset monthly. Comparing premium and standard usage helps ensure those high-value requests are fully utilized before they expire.
+          For reporting windows before the transition, each seat comes with at least 300 Premium Request Units (PRUs) that reset monthly. Comparing premium and standard usage helps ensure those high-value requests are fully utilized before they expire.
         </div>
         {premiumUtilization && (
           <div className="border border-gray-200 rounded-md bg-white">

--- a/src/components/ModelDetailsView.tsx
+++ b/src/components/ModelDetailsView.tsx
@@ -171,7 +171,7 @@ export default function ModelDetailsView({ modelBreakdownData }: ModelDetailsVie
           >
             Read the announcement.
           </a>{' '}
-          Premium vs Base Models separation will no longer be applicable after the transition.
+          Premium vs standard model separation will no longer be applicable after the transition.
         </div>
         <div className="text-sm text-gray-500">
           For reporting windows before the transition, each seat comes with at least 300 Premium Request Units (PRUs) that reset monthly. Comparing premium and standard usage helps ensure those high-value requests are fully utilized before they expire.


### PR DESCRIPTION
## Why

This change gives users timely context that GitHub Copilot is moving to usage-based billing on 1st of June. It clarifies that Premium vs Base Models separation will no longer apply after the transition while keeping existing charts useful for pre-transition reporting windows.

| Commit | Change |
|--------|--------|
| `feat: add Copilot billing notice` | Added a model details info bar with the billing announcement link and updated existing PRU copy to frame it as pre-transition context. |