### PR TITLE
Simplify user activity summary

### DIFF
--- a/src/components/UserDetailsView.tsx
+++ b/src/components/UserDetailsView.tsx
@@ -139,8 +139,6 @@ export default function UserDetailsView({ userDetails, userSummary, userLogin, u
   };
 
   const totalCliPrompts = userDetails.days.reduce((sum, day) => sum + (day.totals_by_cli?.prompt_count ?? 0), 0);
-  const totalStandardModelRequests = userDetails.totalStandardModelRequests;
-  const totalPremiumModelRequests = userDetails.totalPremiumModelRequests;
   const daysActive = userSummary.days_active;
   const usedAgent = userSummary.used_agent;
   const usedChat = userSummary.used_chat;
@@ -513,21 +511,6 @@ export default function UserDetailsView({ userDetails, userSummary, userLogin, u
         </svg>
       ),
     }] : []),
-    {
-      value: totalStandardModelRequests,
-      label: 'Standard Model Requests',
-      accent: 'amber' as const,
-    },
-    {
-      value: totalPremiumModelRequests,
-      label: 'Premium Model Requests',
-      accent: 'rose' as const,
-    },
-    {
-      value: daysActive,
-      label: 'Days Active',
-      accent: 'indigo' as const,
-    },
   ];
 
 
@@ -582,14 +565,20 @@ export default function UserDetailsView({ userDetails, userSummary, userLogin, u
       {/* Summary Stats */}
       <DashboardStatsCardGroup
         className="mb-6"
-        columns={{ base: 1, md: hasFlags ? 4 : 3 }}
+        columns={{ base: 1 }}
         gapClassName="gap-4"
         items={summaryCards}
       />
 
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
         <div className="lg:col-span-2">
-          <ActivityCalendar days={userDetails.days} reportStartDay={userDetails.reportStartDay} reportEndDay={userDetails.reportEndDay} onDayClick={handleDayClick} />
+          <ActivityCalendar
+            days={userDetails.days}
+            reportStartDay={userDetails.reportStartDay}
+            reportEndDay={userDetails.reportEndDay}
+            title={`Activity Calendar (${daysActive} active ${daysActive === 1 ? 'day' : 'days'})`}
+            onDayClick={handleDayClick}
+          />
         </div>
         <div className="lg:col-span-1">
           <FeatureAdoptionRadarChart

--- a/src/components/ui/ActivityCalendar.tsx
+++ b/src/components/ui/ActivityCalendar.tsx
@@ -7,10 +7,11 @@ interface ActivityCalendarProps {
   days: UserDayData[];
   reportStartDay: string;
   reportEndDay: string;
+  title?: string;
   onDayClick: (date: string, dayData?: UserDayData) => void;
 }
 
-export default function ActivityCalendar({ days, reportStartDay, reportEndDay, onDayClick }: ActivityCalendarProps) {
+export default function ActivityCalendar({ days, reportStartDay, reportEndDay, title = 'Activity Calendar', onDayClick }: ActivityCalendarProps) {
   const startDate = new Date(reportStartDay);
   const endDate = new Date(reportEndDay);
 
@@ -105,7 +106,7 @@ export default function ActivityCalendar({ days, reportStartDay, reportEndDay, o
 
   return (
     <div className="bg-white rounded-md border border-[#d1d9e0] p-6">
-      <h3 className="text-lg font-semibold text-gray-900 mb-4">Activity Calendar</h3>
+      <h3 className="text-lg font-semibold text-gray-900 mb-4">{title}</h3>
       
       <div className="space-y-2">
         {/* Day headers */}


### PR DESCRIPTION
## Why

This change reduces duplicate summary information in the user details view by moving the active-day count into the Activity Calendar heading. It keeps the top summary area focused on actionable flags while preserving the activity context near the calendar itself.

| Commit | Change |
|--------|--------|
| `fix: simplify user activity summary` | Removes the standard model requests, premium model requests, and days active cards, then passes the active-day count into the Activity Calendar title. |