### PR TITLE
Remove user details premium model chart

### DIFF
--- a/src/components/UserDetailsView.tsx
+++ b/src/components/UserDetailsView.tsx
@@ -10,7 +10,6 @@ import { padSeriesWithDefaults } from '../utils/timeSeries';
 import ClientActivityChart from './charts/ClientActivityChart';
 import CLISessionChart from './charts/CLISessionChart';
 import CLITokensChart from './charts/CLITokensChart';
-import DailyPremiumBaseChart from './charts/DailyPremiumBaseChart';
 import FeatureAdoptionRadarChart from './charts/FeatureAdoptionRadarChart';
 import ModeImpactChart from './charts/ModeImpactChart';
 import UserSummaryChart from './charts/UserSummaryChart';
@@ -706,12 +705,6 @@ export default function UserDetailsView({ userDetails, userSummary, userLogin, u
         languageBarChartData={languageBarChartData}
         languageBarChartOptions={languageBarChartOptions}
         />
-
-      <DailyPremiumBaseChart
-        dailyModelUsageData={userDetails.dailyModelUsage}
-        reportStartDay={userDetails.reportStartDay}
-        reportEndDay={userDetails.reportEndDay}
-      />
 
       <UserActivityByModelAndFeatureChart
         modelFeatureAggregates={modelFeatureAggregates}


### PR DESCRIPTION
## Why

This removes the Daily Premium vs Standard Model Usage chart from the user details page as requested, keeping that view focused on per-user activity and model breakdown details.

| Commit | Change |
|--------|--------|
| `fix: remove user details premium model chart` | Removed the DailyPremiumBaseChart from `UserDetailsView` and dropped its unused import. |