### PR TITLE
fix: restore adoption trend line overlays

### DIFF
--- a/src/components/charts/utils/adoptionTrendChart.test.ts
+++ b/src/components/charts/utils/adoptionTrendChart.test.ts
@@ -69,7 +69,18 @@ describe('createAdoptionTrendChartConfig', () => {
 
     expect(chartData.datasets).toHaveLength(4);
     expect(chartData.datasets[0].label).toBe('New Auto Users');
-    expect(chartData.datasets[3].label).toBe('Retention Rate');
+    expect(chartData.datasets[2]).toMatchObject({
+      label: 'Cumulative Users',
+      type: 'line',
+      borderDash: [5, 3],
+      yAxisID: 'y1',
+    });
+    expect(chartData.datasets[3]).toMatchObject({
+      label: 'Retention Rate',
+      type: 'line',
+      borderDash: [5, 3],
+      yAxisID: 'y2',
+    });
     expect(retentionRates).toEqual([33.3, null]);
 
     const tooltipLines = options.plugins.tooltip.callbacks.afterBody([{ dataIndex: 1 }]);

--- a/src/components/charts/utils/adoptionTrendChart.ts
+++ b/src/components/charts/utils/adoptionTrendChart.ts
@@ -155,7 +155,9 @@ export function createAdoptionTrendChartConfig(config: AdoptionTrendChartConfig)
         labels.cumulativeUsers,
         data.map(d => d.cumulativeUsers),
         {
+          type: 'line',
           borderWidth: 3,
+          borderDash: [5, 3],
           fill: false,
           tension: 0.4,
           pointRadius: 3,
@@ -166,6 +168,7 @@ export function createAdoptionTrendChartConfig(config: AdoptionTrendChartConfig)
         }
       ),
       createLineDataset(chartColors.amber.solid, labels.retentionRate, retentionRates, {
+        type: 'line',
         borderWidth: 2,
         borderDash: [5, 3],
         fill: false,


### PR DESCRIPTION
## Why

This change fixes the adoption trend chart regression where cumulative users and retention rate were rendered as bars, making the chart hard to read. It restores those trend metrics as dotted line overlays so daily user bars remain readable.

| Commit | Change |
|--------|--------|
| `fix: restore adoption trend line overlays` | Restored cumulative users and retention rate to dotted line datasets and added regression coverage for the mixed chart wiring. |