### PR TITLE
Fix VS Code plugin version updates

### DIFF
--- a/.github/workflows/update-plugins.yml
+++ b/.github/workflows/update-plugins.yml
@@ -30,8 +30,6 @@ jobs:
 
       - name: Update plugin versions
         run: npm run update:plugins
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Validate updater tests
         run: npm run test:run -- data-utils/update-plugin-versions.test.ts
@@ -58,7 +56,7 @@ jobs:
 
             - **JetBrains**: rolling latest builds from the JetBrains plugin repository.
             - **VS Code** (`vscode.json`): maintains a rolling window of stable releases with
-              release dates (source: `microsoft/vscode-copilot-chat` GitHub releases). Updated
+              release dates (source: VS Code Marketplace `GitHub.copilot-chat`). Updated
               only when the stable release list changes. Preview builds do not trigger a change
               to this file.
 

--- a/data-utils/update-plugin-versions.test.ts
+++ b/data-utils/update-plugin-versions.test.ts
@@ -1,11 +1,9 @@
 import { describe, it, expect } from 'vitest';
 import {
   parseMinorFromTag,
-  findLatestStableRelease,
   collectStableReleases,
   hasVsCodeDataChanged,
   STABLE_RELEASES_WINDOW,
-  type GitHubRelease,
   type VsCodeData,
 } from './update-plugin-versions';
 
@@ -28,69 +26,20 @@ describe('parseMinorFromTag', () => {
   });
 });
 
-describe('findLatestStableRelease', () => {
-  const makeRelease = (
-    tag: string,
-    prerelease: boolean,
-    draft = false,
-  ): GitHubRelease => ({
-    tag_name: tag,
-    prerelease,
-    draft,
-    published_at: '2026-03-06T00:00:00Z',
-    created_at: '2026-03-06T00:00:00Z',
-  });
-
-  it('returns the first non-prerelease non-draft release', () => {
-    const releases: GitHubRelease[] = [
-      makeRelease('v0.39.2026030604', true),
-      makeRelease('v0.38.2', false),
-      makeRelease('v0.38.1', false),
-    ];
-    expect(findLatestStableRelease(releases)?.tag_name).toBe('v0.38.2');
-  });
-
-  it('skips draft releases', () => {
-    const releases: GitHubRelease[] = [
-      makeRelease('v0.38.3', false, true), // draft
-      makeRelease('v0.38.2', false, false),
-    ];
-    expect(findLatestStableRelease(releases)?.tag_name).toBe('v0.38.2');
-  });
-
-  it('returns null when all releases are prerelease', () => {
-    const releases: GitHubRelease[] = [
-      makeRelease('v0.39.001', true),
-      makeRelease('v0.39.002', true),
-    ];
-    expect(findLatestStableRelease(releases)).toBeNull();
-  });
-
-  it('returns null for an empty list', () => {
-    expect(findLatestStableRelease([])).toBeNull();
-  });
-});
-
 describe('collectStableReleases', () => {
   const makeRelease = (
-    tag: string,
-    prerelease: boolean,
-    draft = false,
-    publishedAt = '2026-03-06T00:00:00Z',
-  ): GitHubRelease => ({
-    tag_name: tag,
-    prerelease,
-    draft,
-    published_at: publishedAt,
-    created_at: publishedAt,
+    version: string,
+    lastUpdated = '2026-03-06T00:00:00.123Z',
+  ) => ({
+    version,
+    lastUpdated,
   });
 
-  it('filters out prerelease and draft releases', () => {
-    const releases: GitHubRelease[] = [
-      makeRelease('v0.39.2026030604', true),
-      makeRelease('v0.38.3', false, true), // draft
-      makeRelease('v0.38.2', false),
-      makeRelease('v0.38.1', false),
+  it('filters out timestamp builds from Marketplace versions', () => {
+    const releases = [
+      makeRelease('0.39.2026030604'),
+      makeRelease('0.38.2'),
+      makeRelease('0.38.1'),
     ];
     const result = collectStableReleases(releases, 10);
     expect(result).toHaveLength(2);
@@ -98,47 +47,37 @@ describe('collectStableReleases', () => {
     expect(result[1].version).toBe('0.38.1');
   });
 
-  it('strips the v prefix from tag names', () => {
-    const releases: GitHubRelease[] = [makeRelease('v0.38.2', false)];
-    expect(collectStableReleases(releases, 10)[0].version).toBe('0.38.2');
-  });
-
   it('respects the limit', () => {
-    const releases: GitHubRelease[] = Array.from({ length: 30 }, (_, i) =>
-      makeRelease(`v0.${38 - i}.0`, false),
+    const releases = Array.from({ length: 30 }, (_, i) =>
+      makeRelease(`0.${38 - i}.0`),
     );
     expect(collectStableReleases(releases, 5)).toHaveLength(5);
   });
 
-  it('returns an empty array when all releases are prerelease', () => {
-    const releases: GitHubRelease[] = [makeRelease('v0.39.001', true)];
+  it('returns an empty array when all releases are timestamp builds', () => {
+    const releases = [makeRelease('0.39.2026030604')];
     expect(collectStableReleases(releases, 10)).toHaveLength(0);
   });
 
-  it('uses published_at for releaseDate when available', () => {
-    const releases: GitHubRelease[] = [
-      {
-        tag_name: 'v0.38.2',
-        prerelease: false,
-        draft: false,
-        published_at: '2026-03-06T12:00:00Z',
-        created_at: '2026-03-05T00:00:00Z',
-      },
-    ];
+  it('uses Marketplace lastUpdated for releaseDate without fractional seconds', () => {
+    const releases = [makeRelease('0.38.2', '2026-03-06T12:00:00.987Z')];
     expect(collectStableReleases(releases, 10)[0].releaseDate).toBe('2026-03-06T12:00:00Z');
   });
 
-  it('falls back to created_at when published_at is null', () => {
-    const releases: GitHubRelease[] = [
-      {
-        tag_name: 'v0.38.2',
-        prerelease: false,
-        draft: false,
-        published_at: null,
-        created_at: '2026-03-05T00:00:00Z',
-      },
+  it('matches current Marketplace stable ordering', () => {
+    const releases = [
+      makeRelease('0.48.1', '2026-05-15T22:33:59.763Z'),
+      makeRelease('0.45.1', '2026-04-23T20:05:11.56Z'),
+      makeRelease('0.44.2', '2026-04-20T09:34:44.32Z'),
+      makeRelease('0.43.2026040705', '2026-04-07T11:18:40.72Z'),
+      makeRelease('0.43.0', '2026-04-07T11:38:19.68Z'),
     ];
-    expect(collectStableReleases(releases, 10)[0].releaseDate).toBe('2026-03-05T00:00:00Z');
+    expect(collectStableReleases(releases, 10)).toEqual([
+      { version: '0.48.1', releaseDate: '2026-05-15T22:33:59Z' },
+      { version: '0.45.1', releaseDate: '2026-04-23T20:05:11Z' },
+      { version: '0.44.2', releaseDate: '2026-04-20T09:34:44Z' },
+      { version: '0.43.0', releaseDate: '2026-04-07T11:38:19Z' },
+    ]);
   });
 
   it('STABLE_RELEASES_WINDOW is exported and is a positive number', () => {

--- a/data-utils/update-plugin-versions.ts
+++ b/data-utils/update-plugin-versions.ts
@@ -14,6 +14,23 @@ interface JetBrainsUpdate {
   cdate: string; // epoch millis as string
 }
 
+interface MarketplaceVersion {
+  version: string;
+  lastUpdated: string;
+}
+
+interface MarketplaceExtension {
+  versions?: MarketplaceVersion[];
+}
+
+interface MarketplaceResult {
+  extensions?: MarketplaceExtension[];
+}
+
+interface MarketplaceResponse {
+  results?: MarketplaceResult[];
+}
+
 export interface StableRelease {
   version: string;
   releaseDate: string;
@@ -26,14 +43,6 @@ export interface VsCodeData {
   stableReleases: StableRelease[];
 }
 
-export interface GitHubRelease {
-  tag_name: string;
-  prerelease: boolean;
-  draft: boolean;
-  published_at: string | null;
-  created_at: string;
-}
-
 async function fetchJson<T>(url: string, options?: RequestInit): Promise<T> {
   const res = await fetch(url, options);
   if (!res.ok) {
@@ -43,7 +52,7 @@ async function fetchJson<T>(url: string, options?: RequestInit): Promise<T> {
 }
 
 /**
- * Parse the minor version number from a GitHub tag like "v0.38.2" or "0.38.0".
+ * Parse the minor version number from a version like "v0.38.2" or "0.38.0".
  * Returns null if the tag does not match the expected format.
  */
 export function parseMinorFromTag(tag: string): number | null {
@@ -52,24 +61,24 @@ export function parseMinorFromTag(tag: string): number | null {
   return parseInt(match[2], 10);
 }
 
-/**
- * Find the most-recently published stable (non-prerelease, non-draft) release.
- */
-export function findLatestStableRelease(releases: GitHubRelease[]): GitHubRelease | null {
-  return releases.find((r) => !r.prerelease && !r.draft) ?? null;
+function normalizeIsoTimestamp(timestamp: string): string {
+  return timestamp.replace(/\.\d{1,7}Z$/, 'Z');
 }
 
-/**
- * Collect up to `limit` stable (non-prerelease, non-draft) releases from a
- * GitHub releases list (newest-first order) and map them to StableRelease records.
- */
-export function collectStableReleases(releases: GitHubRelease[], limit: number): StableRelease[] {
-  return releases
-    .filter((r) => !r.prerelease && !r.draft)
+function isStableVsCodeVersion(version: string): boolean {
+  return /^\d+\.\d+\.\d+$/.test(version) && !/^\d+\.\d+\.20\d{8}$/.test(version);
+}
+
+export function collectStableReleases(
+  versions: MarketplaceVersion[],
+  limit: number,
+): StableRelease[] {
+  return versions
+    .filter((item) => isStableVsCodeVersion(item.version))
     .slice(0, limit)
-    .map((r) => ({
-      version: r.tag_name.replace(/^v/, ''),
-      releaseDate: (r.published_at ?? r.created_at).replace(/\.\d{3}Z$/, 'Z'),
+    .map((item) => ({
+      version: item.version,
+      releaseDate: normalizeIsoTimestamp(item.lastUpdated),
     }));
 }
 
@@ -101,32 +110,37 @@ async function fetchJetBrainsVersions(): Promise<SimpleVersionInfo[]> {
     .slice(0, MAX);
 }
 
-async function fetchVsCodeData(githubToken?: string): Promise<VsCodeData> {
-  const baseUrl =
-    'https://api.github.com/repos/microsoft/vscode-copilot-chat/releases?per_page=100';
+async function fetchVsCodeData(): Promise<VsCodeData> {
+  const marketplaceUrl =
+    'https://marketplace.visualstudio.com/_apis/public/gallery/extensionquery?api-version=7.2-preview.1';
+  const includeVersionsFlag = 1;
 
-  const headers: HeadersInit = {
-    Accept: 'application/vnd.github.v3+json',
-    'User-Agent': 'copilot-user-level-statistics-viewer',
-  };
-  if (githubToken) {
-    (headers as Record<string, string>)['Authorization'] = `Bearer ${githubToken}`;
-  }
+  const data = await fetchJson<MarketplaceResponse>(marketplaceUrl, {
+    method: 'POST',
+    headers: {
+      Accept: 'application/json;api-version=7.2-preview.1;excludeUrls=true',
+      'Content-Type': 'application/json',
+      'User-Agent': 'copilot-user-level-statistics-viewer',
+    },
+    body: JSON.stringify({
+      filters: [
+        {
+          criteria: [
+            {
+              filterType: 7,
+              value: 'GitHub.copilot-chat',
+            },
+          ],
+        },
+      ],
+      flags: includeVersionsFlag,
+    }),
+  });
 
-  const allReleases: GitHubRelease[] = [];
-  const maxPages = 5;
-  for (let page = 1; page <= maxPages; page++) {
-    const url = `${baseUrl}&page=${page}`;
-    const batch = await fetchJson<GitHubRelease[]>(url, { headers });
-    allReleases.push(...batch);
-
-    const stableCount = allReleases.filter((r) => !r.prerelease && !r.draft).length;
-    if (stableCount >= STABLE_RELEASES_WINDOW || batch.length < 100) break;
-  }
-
-  const stableReleases = collectStableReleases(allReleases, STABLE_RELEASES_WINDOW);
+  const versions = data.results?.[0]?.extensions?.[0]?.versions ?? [];
+  const stableReleases = collectStableReleases(versions, STABLE_RELEASES_WINDOW);
   if (stableReleases.length === 0) {
-    throw new Error('No stable release found in microsoft/vscode-copilot-chat releases');
+    throw new Error('No stable release found in VS Code Marketplace for GitHub.copilot-chat');
   }
 
   const stableMinor = parseMinorFromTag(stableReleases[0].version);
@@ -146,11 +160,9 @@ async function main(): Promise<void> {
     const __dirnameLocal = path.dirname(__filename);
     const outputDir = path.join(__dirnameLocal, '..', 'public', 'data');
 
-    const githubToken = process.env.GITHUB_TOKEN;
-
     const [jbVersions, incomingVsCode] = await Promise.all([
       fetchJetBrainsVersions(),
-      fetchVsCodeData(githubToken),
+      fetchVsCodeData(),
     ]);
 
     // JetBrains — always update with latest rolling list

--- a/public/data/vscode.json
+++ b/public/data/vscode.json
@@ -1,87 +1,87 @@
 {
-  "stableMinor": 43,
-  "previewMinor": 44,
-  "updatedAt": "2026-04-07T11:32:46Z",
+  "stableMinor": 48,
+  "previewMinor": 49,
+  "updatedAt": "2026-05-15T22:33:59Z",
   "stableReleases": [
     {
+      "version": "0.48.1",
+      "releaseDate": "2026-05-15T22:33:59Z"
+    },
+    {
+      "version": "0.45.1",
+      "releaseDate": "2026-04-23T20:05:11Z"
+    },
+    {
+      "version": "0.44.2",
+      "releaseDate": "2026-04-20T09:34:44Z"
+    },
+    {
+      "version": "0.44.1",
+      "releaseDate": "2026-04-16T15:32:06Z"
+    },
+    {
       "version": "0.43.0",
-      "releaseDate": "2026-04-07T11:32:46Z"
+      "releaseDate": "2026-04-07T11:38:19Z"
     },
     {
       "version": "0.42.3",
-      "releaseDate": "2026-04-02T08:24:32Z"
+      "releaseDate": "2026-04-02T08:30:15Z"
     },
     {
       "version": "0.42.2",
-      "releaseDate": "2026-03-31T22:27:25Z"
+      "releaseDate": "2026-03-31T22:32:51Z"
     },
     {
       "version": "0.42.1",
-      "releaseDate": "2026-03-31T17:32:47Z"
+      "releaseDate": "2026-03-31T17:37:41Z"
     },
     {
       "version": "0.42.0",
-      "releaseDate": "2026-03-31T11:52:16Z"
+      "releaseDate": "2026-03-31T12:00:34Z"
     },
     {
       "version": "0.41.2",
-      "releaseDate": "2026-03-27T09:00:24Z"
+      "releaseDate": "2026-03-27T09:05:18Z"
     },
     {
       "version": "0.41.1",
-      "releaseDate": "2026-03-24T22:53:45Z"
+      "releaseDate": "2026-03-24T22:59:17Z"
     },
     {
       "version": "0.41.0",
-      "releaseDate": "2026-03-24T14:59:36Z"
+      "releaseDate": "2026-03-24T15:04:19Z"
     },
     {
       "version": "0.40.1",
-      "releaseDate": "2026-03-18T04:18:20Z"
+      "releaseDate": "2026-03-18T04:23:15Z"
     },
     {
       "version": "0.40.0",
-      "releaseDate": "2026-03-17T22:59:26Z"
+      "releaseDate": "2026-03-17T23:03:15Z"
     },
     {
       "version": "0.39.2",
-      "releaseDate": "2026-03-17T15:58:36Z"
+      "releaseDate": "2026-03-17T16:01:33Z"
     },
     {
       "version": "0.39.1",
-      "releaseDate": "2026-03-13T19:25:08Z"
+      "releaseDate": "2026-03-13T19:29:22Z"
     },
     {
       "version": "0.39.0",
-      "releaseDate": "2026-03-09T09:18:06Z"
+      "releaseDate": "2026-03-09T09:21:02Z"
     },
     {
       "version": "0.38.2",
-      "releaseDate": "2026-03-06T23:48:26Z"
+      "releaseDate": "2026-03-06T23:52:07Z"
     },
     {
       "version": "0.38.1",
-      "releaseDate": "2026-03-05T16:26:11Z"
+      "releaseDate": "2026-03-05T16:29:13Z"
     },
     {
       "version": "0.38.0",
-      "releaseDate": "2026-03-04T18:28:29Z"
-    },
-    {
-      "version": "0.37.9",
-      "releaseDate": "2026-02-26T23:42:20Z"
-    },
-    {
-      "version": "0.37.8",
-      "releaseDate": "2026-02-20T22:59:32Z"
-    },
-    {
-      "version": "0.37.7",
-      "releaseDate": "2026-02-19T23:13:06Z"
-    },
-    {
-      "version": "0.37.6",
-      "releaseDate": "2026-02-12T20:14:17Z"
+      "releaseDate": "2026-03-04T18:31:11Z"
     }
   ]
 }


### PR DESCRIPTION
## Why

This change fixes the VS Code Copilot Chat plugin updater because the previous GitHub releases source lagged behind the Marketplace version shown to users. It keeps the generated client version metadata aligned with the Marketplace feed used for `GitHub.copilot-chat`.

| Commit | Change |
|--------|--------|
| `fix: use marketplace for VS Code plugin versions` | Switched VS Code plugin version collection to the VS Code Marketplace API, refreshed `vscode.json` to stable minor 48, and updated the updater tests/workflow copy for the new source. |