### PR TITLE
Simplify model usage billing view

### DIFF
--- a/src/components/ModelDetailsView.tsx
+++ b/src/components/ModelDetailsView.tsx
@@ -2,7 +2,6 @@
 
 import React, { useMemo } from 'react';
 import ModelsUsageChart from './charts/ModelsUsageChart';
-import DailyPremiumBaseChart from './charts/DailyPremiumBaseChart';
 import AutoModeAdoptionTrendChart from './charts/AutoModeAdoptionTrendChart';
 import type { ModelBreakdownData } from '../types/metrics';
 import { ViewPanel } from './ui';
@@ -25,132 +24,20 @@ export default function ModelDetailsView({ modelBreakdownData }: ModelDetailsVie
     [modelBreakdownData.premiumModels]
   );
 
+  const modelEntries = useMemo(
+    () => [...modelBreakdownData.standardModels, ...premiumModelEntries],
+    [modelBreakdownData.standardModels, premiumModelEntries]
+  );
+
   const autoTotal = useMemo(
     () => autoModelEntries.reduce((sum, entry) => sum + entry.total, 0),
     [autoModelEntries]
   );
 
-  const premiumTotalWithoutAuto = useMemo(
-    () => premiumModelEntries.reduce((sum, entry) => sum + entry.total, 0),
-    [premiumModelEntries]
+  const modelTotal = useMemo(
+    () => modelEntries.reduce((sum, entry) => sum + entry.total, 0),
+    [modelEntries]
   );
-
-  const premiumBreakdownWithoutAuto = useMemo(
-    () => ({
-      ...modelBreakdownData,
-      premiumModels: premiumModelEntries,
-      premiumTotal: premiumTotalWithoutAuto,
-    }),
-    [modelBreakdownData, premiumModelEntries, premiumTotalWithoutAuto]
-  );
-
-  const premiumUtilization = useMemo(() => {
-    const { standardTotal, unknownTotal } = modelBreakdownData;
-    const premiumTotal = premiumTotalWithoutAuto;
-
-    const trackedTotal = premiumTotal + standardTotal;
-    const numberFormatter = new Intl.NumberFormat();
-
-    const summaryLines: string[] = [
-      `Premium interactions: ${numberFormatter.format(premiumTotal)}`,
-      `Standard interactions: ${numberFormatter.format(standardTotal)}`
-    ];
-
-    if (unknownTotal > 0) {
-      summaryLines.push(`Unclassified interactions: ${numberFormatter.format(unknownTotal)}`);
-    }
-
-    if (trackedTotal === 0) {
-      const paragraphs = unknownTotal > 0
-        ? [
-            'Model activity is currently attributed to models that are not mapped in the catalog. Add them to surface premium versus standard insights.'
-          ]
-        : ['No premium or standard model activity has been recorded for this reporting window yet.'];
-
-      return {
-        variant: 'blue' as const,
-        paragraphs,
-        summaryLines,
-        note: 'Each Copilot seat includes at least 300 Premium Request Units (≈$12 of value) that expire monthly.'
-      };
-    }
-
-    const premiumShare = trackedTotal === 0 ? 0 : premiumTotal / trackedTotal;
-    const shareLabel = `${(premiumShare * 100).toFixed(1)}%`;
-    const ratio = standardTotal > 0 ? premiumTotal / standardTotal : Number.POSITIVE_INFINITY;
-    const ratioLabel = Number.isFinite(ratio) ? `${ratio.toFixed(2)}x` : 'all premium usage';
-
-    summaryLines.push(`Premium share of tracked usage: ${shareLabel}`);
-    summaryLines.push(`Premium-to-standard ratio: ${ratioLabel}`);
-
-    const standardLead = standardTotal - premiumTotal;
-    const premiumLead = premiumTotal - standardTotal;
-
-    const paragraphs: string[] = [];
-    let variant: 'green' | 'red' | 'orange' | 'purple';
-
-    if (premiumShare < 0.2) {
-      variant = 'red';
-      paragraphs.push(
-        `Premium models account for only ${shareLabel} of tracked interactions. Included PRUs are likely expiring unused each month. Which is a missed opportunity and unutilized value.`
-      );
-      paragraphs.push(
-        `Standard models processed ${numberFormatter.format(standardLead)} more requests, signaling an awareness or entitlement gap for Premium Models access. There is room to utilize more of the included (prepaid) PRUs.`
-      );
-    } else if (premiumShare < 0.35) {
-      variant = 'orange';
-      paragraphs.push(
-        `Premium models represent ${shareLabel} of usage. Consider nudging teams on premium value or checking whether they exhaust PRUs early in the month.`
-      );
-      if (premiumLead > 0) {
-        paragraphs.push(
-          `Premium requests already outpace standard by ${numberFormatter.format(premiumLead)} interactions—monitor that monthly bundles stay sufficient.`
-        );
-      } else {
-        paragraphs.push(
-          `Standard usage leads by ${numberFormatter.format(standardLead)} interactions, leaving meaningful premium headroom before monthly resets.`
-        );
-      }
-    } else if (premiumShare <= 0.6) {
-      variant = 'green';
-      paragraphs.push(
-        `Premium share at ${shareLabel} points to a healthy balance between premium and standard model usage.`
-      );
-      if (premiumLead >= 0) {
-        paragraphs.push(
-          `Premium requests exceed standard by ${numberFormatter.format(premiumLead)} interactions while staying within a sustainable balance.`
-        );
-      } else {
-        paragraphs.push(
-          `Standard models still lead by ${numberFormatter.format(standardLead)} interactions, suggesting the opportunity to further increase included Premium Model requests usage.`
-        );
-      }
-    } else {
-      variant = 'purple';
-      paragraphs.push(
-        `Premium models now drive ${shareLabel} of tracked interactions, indicating teams lean heavily on higher-value models.`
-      );
-      if (premiumLead > 0) {
-        paragraphs.push(
-          `Premium volume is ${numberFormatter.format(premiumLead)} interactions above Standard Models. Confirm monthly PRU bundles (baseline 300 per user) are sufficient or plan for add-ons.`
-        );
-      } else {
-        paragraphs.push(
-          `Standard usage trails premium by ${numberFormatter.format(Math.abs(standardLead))} interactions—watch for signals that teams might hit PRU limits mid-month.`
-        );
-      }
-    }
-
-    return {
-      variant,
-      paragraphs,
-      summaryLines,
-      note:
-        unknownTotal > 0
-          ? `There are ${numberFormatter.format(unknownTotal)} interactions from models that are not yet tagged as premium or standard.`
-          : undefined
-    };
-  }, [modelBreakdownData, premiumTotalWithoutAuto]);
 
   return (
     <ViewPanel
@@ -162,7 +49,7 @@ export default function ModelDetailsView({ modelBreakdownData }: ModelDetailsVie
     >
       <div className="space-y-6">
         <div className="rounded-md border border-blue-200 bg-blue-50 px-4 py-3 text-sm text-blue-900">
-          Starting 1st of June, GitHub Copilot is switching to a usage-based billing model.{' '}
+          GitHub Copilot has moved to usage-based billing.{' '}
           <a
             href="https://github.blog/news-insights/company-news/github-copilot-is-moving-to-usage-based-billing/"
             target="_blank"
@@ -171,45 +58,11 @@ export default function ModelDetailsView({ modelBreakdownData }: ModelDetailsVie
           >
             Read the announcement.
           </a>{' '}
-          Premium vs standard model separation will no longer be applicable after the transition.
+          Premium vs standard model separation is no longer applicable.
         </div>
-        {premiumUtilization && (
-          <div className="border border-gray-200 rounded-md bg-white">
-            <div className="px-4 py-3 border-b border-gray-200">
-              <h4 className="text-sm font-semibold text-gray-900">Premium Request Utilization</h4>
-            </div>
-            <div className="px-4 py-4 space-y-3 text-sm text-gray-900">
-              {premiumUtilization.paragraphs.map((paragraph, index) => (
-                <p key={index}>{paragraph}</p>
-              ))}
-              {premiumUtilization.summaryLines.length > 0 && (
-                <dl className="mt-2 grid grid-cols-1 gap-1 border-t border-gray-100 pt-3">
-                  {premiumUtilization.summaryLines.map((line, index) => {
-                    const [label, value] = line.split(': ');
-                    return value ? (
-                      <div key={index} className="flex justify-between gap-4">
-                        <dt className="text-gray-500">{label}</dt>
-                        <dd className="font-medium tabular-nums text-right">{value}</dd>
-                      </div>
-                    ) : (
-                      <div key={index} className="text-gray-700">{line}</div>
-                    );
-                  })}
-                </dl>
-              )}
-              {premiumUtilization.note && (
-                <p className="border-t border-gray-100 pt-3 text-xs text-gray-500">
-                  {premiumUtilization.note}
-                </p>
-              )}
-            </div>
-          </div>
-        )}
-        <DailyPremiumBaseChart modelBreakdownData={premiumBreakdownWithoutAuto} />
+        <ModelsUsageChart modelEntries={modelEntries} dates={modelBreakdownData.dates} totalInteractions={modelTotal} variant="all" />
         <ModelsUsageChart modelEntries={autoModelEntries} dates={modelBreakdownData.dates} totalInteractions={autoTotal} variant="auto" />
         <AutoModeAdoptionTrendChart data={autoModeAdoptionTrend} />
-        <ModelsUsageChart modelEntries={modelBreakdownData.standardModels} dates={modelBreakdownData.dates} totalInteractions={modelBreakdownData.standardTotal} variant="standard" />
-        <ModelsUsageChart modelEntries={premiumModelEntries} dates={modelBreakdownData.dates} totalInteractions={premiumTotalWithoutAuto} variant="premium" />
       </div>
     </ViewPanel>
   );

--- a/src/components/charts/ModelsUsageChart.tsx
+++ b/src/components/charts/ModelsUsageChart.tsx
@@ -20,13 +20,14 @@ interface ModelsUsageChartProps {
   modelEntries: ModelDailyUsageEntry[];
   dates: string[];
   totalInteractions: number;
-  variant: 'standard' | 'premium' | 'auto' | 'cli';
+  variant: 'standard' | 'premium' | 'auto' | 'cli' | 'all';
 }
 
 export default function ModelsUsageChart({ modelEntries, dates, totalInteractions, variant }: ModelsUsageChartProps) {
   const isPremium = variant === 'premium';
   const isAuto = variant === 'auto';
   const isCli = variant === 'cli';
+  const isAll = variant === 'all';
 
   const { labels, datasets, modelTotals, modelOrder } = useMemo(() => {
     const sortedModels = sortBySelector(modelEntries, e => e.total, 'desc');
@@ -64,7 +65,7 @@ export default function ModelsUsageChart({ modelEntries, dates, totalInteraction
     const datasets = sortedModels.map((entry) => {
       const color = getModelColor(entry.model);
       return createBarDataset(color, entry.model, dates.map(d => entry.dailyData[d] || 0), {
-        stack: isAuto ? 'auto-models' : isCli ? 'cli-models' : isPremium ? 'premium-models' : 'standard-models'
+        stack: isAuto ? 'auto-models' : isCli ? 'cli-models' : isAll ? 'models' : isPremium ? 'premium-models' : 'standard-models'
       });
     });
 
@@ -74,7 +75,7 @@ export default function ModelsUsageChart({ modelEntries, dates, totalInteraction
       modelTotals,
       modelOrder
     };
-  }, [modelEntries, dates, isPremium, isAuto, isCli]);
+  }, [modelEntries, dates, isPremium, isAuto, isCli, isAll]);
 
   const insights = useMemo(() => {
     if (!isPremium) return null;
@@ -134,15 +135,26 @@ export default function ModelsUsageChart({ modelEntries, dates, totalInteraction
     ? 'CLI Models Daily Usage'
     : isAuto
       ? 'Auto Model Daily Usage'
-      : `${isPremium ? 'Premium' : 'Standard'} Models Daily Usage`;
+      : isAll
+        ? 'Models Daily Usage'
+        : `${isPremium ? 'Premium' : 'Standard'} Models Daily Usage`;
   const chartDescription = isCli
     ? 'Daily Copilot CLI user-initiated interactions grouped by model.'
     : isAuto
       ? 'Daily interactions routed through Copilot Auto mode.'
-      : undefined;
-  const variantLabel = isCli ? 'CLI' : isAuto ? 'Auto' : isPremium ? 'Premium' : 'Standard';
-  const primaryColorClass = isCli ? 'text-pink-600' : isAuto ? 'text-violet-600' : isPremium ? 'text-purple-600' : 'text-blue-600';
-  const totalColorClass = isCli ? 'text-pink-600' : isAuto ? 'text-purple-600' : isPremium ? 'text-red-600' : 'text-green-600';
+      : isAll
+        ? 'Daily user-initiated interactions grouped by model.'
+        : undefined;
+  const variantLabel = isCli ? 'CLI' : isAuto ? 'Auto' : isAll ? 'Tracked' : isPremium ? 'Premium' : 'Standard';
+  const primaryColorClass = isCli ? 'text-pink-600' : isAuto ? 'text-violet-600' : isAll ? 'text-indigo-600' : isPremium ? 'text-purple-600' : 'text-blue-600';
+  const totalColorClass = isCli ? 'text-pink-600' : isAuto ? 'text-purple-600' : isAll ? 'text-indigo-600' : isPremium ? 'text-red-600' : 'text-green-600';
+  const emptyState = isCli
+    ? 'No CLI model usage data available'
+    : isAuto
+      ? 'No auto model usage data available'
+      : isAll
+        ? 'No model usage data available'
+        : `No ${isPremium ? 'premium' : 'standard'} model usage data available`;
 
   const chartData = { labels, datasets };
 
@@ -161,7 +173,7 @@ export default function ModelsUsageChart({ modelEntries, dates, totalInteraction
       title={chartTitle}
       description={chartDescription}
       isEmpty={dates.length === 0 || datasets.length === 0}
-      emptyState={`No ${isCli ? 'CLI' : isAuto ? 'auto' : isPremium ? 'premium' : 'standard'} model usage data available`}
+      emptyState={emptyState}
       summaryStats={[
         { value: datasets.length, label: isAuto ? 'Auto Models' : `${variantLabel} Models`, colorClass: primaryColorClass },
         { value: totalInteractions, label: 'Total Interactions', colorClass: totalColorClass },
@@ -172,7 +184,9 @@ export default function ModelsUsageChart({ modelEntries, dates, totalInteraction
           <p className="text-xs text-gray-600 mb-4">
             {isCli
               ? 'Counts aggregate user-initiated interactions for the Copilot CLI feature per model per day.'
-              : `Counts aggregate user-initiated interactions across all features per ${isAuto ? 'auto' : isPremium ? 'premium' : 'standard'} model per day.`}
+              : isAll
+                ? 'Counts aggregate user-initiated interactions across all tracked models per day.'
+                : `Counts aggregate user-initiated interactions across all features per ${isAuto ? 'auto' : isPremium ? 'premium' : 'standard'} model per day.`}
           </p>
           {insights && (
             <InsightsCard title={insights.title} variant={insights.variant}>

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -121,15 +121,6 @@ export function formatSignedNumber(value: number): string {
 }
 
 /**
- * Format PRU (Premium Request Units) value.
- * @param value - PRU value
- * @returns Formatted PRU string
- */
-export function formatPRU(value: number): string {
-  return formatNumber(value, 2);
-}
-
-/**
  * Round a number to specified decimal places.
  * @param value - Number to round
  * @param decimals - Number of decimal places (default: 2)


### PR DESCRIPTION
## Why

GitHub Copilot has moved to usage-based billing, so the Model Usage view should no longer emphasize the old premium versus standard billing split. This updates the view to present model usage together and removes obsolete PRU-specific messaging.

| Commit | Change |
|--------|--------|
| `refactor: simplify model usage billing view` | Removes obsolete PRU utilization UI, updates the billing notice, merges standard and premium model charts, and drops the unused PRU formatter. |