### PR TITLE
Neutralize model usage billing copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Visualize GitHub Copilot usage metrics from your organization. Upload metrics ND
 - User breakdowns: unique users, chat users, agent users, CLI users, completion-only users
 - Interactive charts for usage patterns and trends
 - Drill down into individual user activity with feature adoption radar charts
-- Model usage and premium request analysis
+- Model usage analysis
 - CLI adoption trends, sessions, and token usage
 - IDE and VS Code extension version analysis
 - Statistics by programming language and Copilot feature

--- a/docs/project-overview.md
+++ b/docs/project-overview.md
@@ -10,7 +10,7 @@ A **client-side single-page analytics dashboard** for exploring **GitHub Copilot
 
 The app runs entirely in the browser — uploaded metrics files are parsed client-side and never sent to a backend.
 
-Key analysis dimensions: **user**, **IDE**, **language**, **feature**, **model**, and premium/standard model usage.
+Key analysis dimensions: **user**, **IDE**, **language**, **feature**, and **model** usage.
 
 ---
 
@@ -84,11 +84,11 @@ flowchart LR
 
 ### 4.2. Aggregation
 
-`metricsAggregator.ts` orchestrates all calculators in `src/domain/calculators/` to produce the `AggregatedMetrics` object. This includes user summaries, daily time series, language/IDE/model breakdowns, premium/standard model usage, feature adoption, and LOC impact by mode. See the calculator files for specifics.
+`metricsAggregator.ts` orchestrates all calculators in `src/domain/calculators/` to produce the `AggregatedMetrics` object. This includes user summaries, daily time series, language/IDE/model breakdowns, model usage analysis, feature adoption, and LOC impact by mode. See the calculator files for specifics.
 
 ### 4.3. Views
 
-`ViewRouter` (`src/components/layout/ViewRouter.tsx`) maps the current `ViewMode` to the appropriate component. Views include: overview dashboard, users list, user details, languages, IDEs, Copilot impact, premium model usage, adoption, and model details.
+`ViewRouter` (`src/components/layout/ViewRouter.tsx`) maps the current `ViewMode` to the appropriate component. Views include: overview dashboard, users list, user details, languages, IDEs, Copilot impact, model usage analysis, adoption, and model details.
 
 Charts use **Chart.js** via **react-chartjs-2**, wrapped in a `ChartContainer` component for consistent styling.
 

--- a/src/components/charts/DailyPremiumBaseChart.tsx
+++ b/src/components/charts/DailyPremiumBaseChart.tsx
@@ -4,16 +4,14 @@ import { useMemo } from 'react';
 import { TooltipItem } from 'chart.js';
 import { Bar } from 'react-chartjs-2';
 import { registerChartJS } from './utils/chartSetup';
-import { createStackedBarChartOptions } from './utils/chartOptions';
+import { createBaseChartOptions } from './utils/chartOptions';
 import { createBarDataset } from './utils/chartStyles';
 import { chartColors } from './utils/chartColors';
-import { createStackedTotalWithShareFooter } from './utils/tooltipFooters';
 import { formatShortDate, generateDateRange } from '../../utils/formatters';
 import { padSeriesWithDefaults } from '../../utils/timeSeries';
 import type { DailyModelUsageData } from '../../domain/calculators/metricCalculators';
 import type { ModelBreakdownData } from '../../types/metrics';
 import ChartContainer from '../ui/ChartContainer';
-import InsightsCard from '../ui/InsightsCard';
 
 registerChartJS();
 
@@ -40,25 +38,19 @@ export default function DailyPremiumBaseChart({
   dailyModelUsageData,
   reportStartDay,
   reportEndDay,
-  hideInsights = false,
 }: DailyPremiumBaseChartProps) {
-  const { labels, datasets, dailyPremium, dailyStandard, dailyUnknown, isEmpty } = useMemo(() => {
+  const { labels, datasets, dailyInteractions, isEmpty } = useMemo(() => {
     const dates = modelBreakdownData
       ? modelBreakdownData.dates
       : generateDateRange(reportStartDay, reportEndDay);
 
-    let dailyPremium: number[];
-    let dailyStandard: number[];
-    let dailyUnknown: number[];
+    let dailyInteractions: number[];
 
     if (modelBreakdownData) {
-      dailyPremium = dates.map(d =>
-        modelBreakdownData.premiumModels.reduce((sum, entry) => sum + (entry.dailyData[d] || 0), 0)
-      );
-      dailyStandard = dates.map(d =>
+      dailyInteractions = dates.map(d =>
+        modelBreakdownData.premiumModels.reduce((sum, entry) => sum + (entry.dailyData[d] || 0), 0) +
         modelBreakdownData.standardModels.reduce((sum, entry) => sum + (entry.dailyData[d] || 0), 0)
       );
-      dailyUnknown = dates.map(() => 0);
     } else {
       const dailyUsageByDate = new Map((dailyModelUsageData ?? []).map(d => [d.date, d]));
       const paddedUsage = padSeriesWithDefaults(dates, dailyUsageByDate, date => ({
@@ -68,84 +60,42 @@ export default function DailyPremiumBaseChart({
         unknownModels: 0,
       }));
 
-      dailyPremium = paddedUsage.map(d => d.pruModels);
-      dailyStandard = paddedUsage.map(d => d.standardModels);
-      dailyUnknown = paddedUsage.map(d => d.unknownModels);
+      dailyInteractions = paddedUsage.map(d => d.pruModels + d.standardModels + d.unknownModels);
     }
 
     const datasets = [
-      createBarDataset(chartColors.blue.solid, 'Standard', dailyStandard, { stack: 'premium-base' }),
-      createBarDataset(chartColors.purple.solid, 'Premium', dailyPremium, { stack: 'premium-base' }),
+      createBarDataset(chartColors.blue.solid, 'Model interactions', dailyInteractions),
     ];
-
-    if (dailyUnknown.some(value => value > 0)) {
-      datasets.push(createBarDataset(chartColors.gray.solid, 'Unknown', dailyUnknown, { stack: 'premium-base' }));
-    }
 
     return {
       labels: dates.map(d => formatShortDate(d)),
       datasets,
-      dailyPremium,
-      dailyStandard,
-      dailyUnknown,
+      dailyInteractions,
       isEmpty: dates.length === 0,
     };
   }, [dailyModelUsageData, modelBreakdownData, reportEndDay, reportStartDay]);
 
-  const options = createStackedBarChartOptions({
+  const options = createBaseChartOptions({
     xAxisLabel: 'Date',
     yAxisLabel: 'Interactions',
+    showLegend: false,
     tooltipLabelCallback: (context: TooltipItem<'line' | 'bar'>) => {
       const value = context.parsed.y || 0;
       return `${context.dataset.label}: ${value.toLocaleString()}`;
     },
-    tooltipFooterCallback: createStackedTotalWithShareFooter({
-      shareDatasetLabel: 'Premium',
-      shareLabel: 'Premium share',
-      shareSeparator: ' · ',
-    }),
   });
 
-  const totalPremium = dailyPremium.reduce((s, v) => s + v, 0);
-  const totalStandard = dailyStandard.reduce((s, v) => s + v, 0);
-  const totalUnknown = dailyUnknown.reduce((s, v) => s + v, 0);
-  const totalAll = totalPremium + totalStandard + totalUnknown;
-  const premiumShare = totalAll > 0 ? ((totalPremium / totalAll) * 100).toFixed(1) : '0.0';
-
-  const premiumShareNum = totalAll > 0 ? (totalPremium / totalAll) * 100 : 0;
+  const totalInteractions = dailyInteractions.reduce((sum, value) => sum + value, 0);
 
   return (
     <ChartContainer
-      title="Daily Premium vs Standard Model Usage"
-      description="Stacked daily breakdown highlighting the premium-to-standard ratio over time."
+      title="Daily Model Interactions"
+      description="Daily model interactions across all model buckets."
       isEmpty={isEmpty}
       emptyState="No model usage data available"
       summaryStats={[
-        { value: totalPremium.toLocaleString(), label: 'Premium', colorClass: 'text-purple-600' },
-        { value: totalStandard.toLocaleString(), label: 'Standard', colorClass: 'text-blue-600' },
-        ...(totalUnknown > 0
-          ? [{ value: totalUnknown.toLocaleString(), label: 'Unknown', colorClass: 'text-gray-600' }]
-          : []),
-        { value: `${premiumShare}%`, label: 'Premium Share', colorClass: 'text-gray-700' },
+        { value: totalInteractions.toLocaleString(), label: 'Model interactions', colorClass: 'text-blue-600' },
       ]}
-      footer={!hideInsights && totalAll > 0 ? (
-        premiumShareNum < 50 ? (
-          <InsightsCard title="Premium Adoption Opportunity" variant="orange">
-            <p>
-              Premium models account for only {premiumShare}% of total interactions. These models are more up-to-date and more capable, offering better results for complex tasks.
-            </p>
-            <p className="mt-2">
-              Consider promoting premium model usage across teams to take full advantage of the included Premium Request Units before they expire each month.
-            </p>
-          </InsightsCard>
-        ) : (
-          <InsightsCard title="Healthy Premium Adoption" variant="green">
-            <p>
-              Premium models drive {premiumShare}% of total interactions, indicating teams are actively leveraging the most capable and up-to-date models available.
-            </p>
-          </InsightsCard>
-        )
-      ) : undefined}
     >
       <Bar data={{ labels, datasets }} options={options} />
     </ChartContainer>


### PR DESCRIPTION
## Why

GitHub Copilot has moved to usage-based billing, so the executive summary should not promote premium vs standard model separation or expiring Premium Request Units. This keeps the stage 1 cleanup focused on user-facing copy while preserving existing aggregation contracts for later stages.

| Commit | Change |
|--------|--------|
| `fix: neutralize model usage billing copy` | Replaces the Premium vs Standard chart output with neutral daily model interactions, removes premium-adoption messaging, and updates directly related README/project overview wording. |