### PR TITLE
Add neutral model usage contract

### DIFF
--- a/src/components/charts/DailyPremiumBaseChart.tsx
+++ b/src/components/charts/DailyPremiumBaseChart.tsx
@@ -63,6 +63,7 @@ export default function DailyPremiumBaseChart({
       const dailyUsageByDate = new Map((dailyModelUsageData ?? []).map(d => [d.date, d]));
       const paddedUsage = padSeriesWithDefaults(dates, dailyUsageByDate, date => ({
         date,
+        modelInteractions: 0,
         pruModels: 0,
         standardModels: 0,
         unknownModels: 0,

--- a/src/domain/__tests__/metricsAggregator.test.ts
+++ b/src/domain/__tests__/metricsAggregator.test.ts
@@ -252,6 +252,60 @@ describe('metricsAggregator', () => {
 
       expect(aggregated.modelUsageData).toBeDefined();
       expect(aggregated.modelUsageData.length).toBeGreaterThan(0);
+      expect(aggregated.modelUsageData[0].modelInteractions).toBe(
+        aggregated.modelUsageData[0].pruModels
+        + aggregated.modelUsageData[0].standardModels
+        + aggregated.modelUsageData[0].unknownModels
+      );
+    });
+
+    it('should expose neutral model totals alongside legacy model buckets', () => {
+      const metric = createBasicMetric({
+        totals_by_model_feature: [
+          {
+            model: 'gpt-4o',
+            feature: 'code_completion',
+            user_initiated_interaction_count: 10,
+            code_generation_activity_count: 0,
+            code_acceptance_activity_count: 0,
+            loc_added_sum: 0,
+            loc_deleted_sum: 0,
+            loc_suggested_to_add_sum: 0,
+            loc_suggested_to_delete_sum: 0,
+          },
+          {
+            model: 'gpt-5',
+            feature: 'code_completion',
+            user_initiated_interaction_count: 7,
+            code_generation_activity_count: 0,
+            code_acceptance_activity_count: 0,
+            loc_added_sum: 0,
+            loc_deleted_sum: 0,
+            loc_suggested_to_add_sum: 0,
+            loc_suggested_to_delete_sum: 0,
+          },
+          {
+            model: 'unknown',
+            feature: 'code_completion',
+            user_initiated_interaction_count: 3,
+            code_generation_activity_count: 0,
+            code_acceptance_activity_count: 0,
+            loc_added_sum: 0,
+            loc_deleted_sum: 0,
+            loc_suggested_to_add_sum: 0,
+            loc_suggested_to_delete_sum: 0,
+          },
+        ],
+      });
+
+      const { aggregated } = aggregateMetrics([metric]);
+      const { modelBreakdownData } = aggregated;
+
+      expect(modelBreakdownData.modelTotal).toBe(20);
+      expect(modelBreakdownData.modelTotal).toBe(
+        modelBreakdownData.premiumTotal + modelBreakdownData.standardTotal + modelBreakdownData.unknownTotal
+      );
+      expect(modelBreakdownData.allModels.map(entry => entry.model)).toEqual(['gpt-4o', 'gpt-5', 'unknown']);
     });
 
     it('should compute Auto mode adoption trend from auto model usage', () => {

--- a/src/domain/calculators/__tests__/modelBreakdownCalculator.test.ts
+++ b/src/domain/calculators/__tests__/modelBreakdownCalculator.test.ts
@@ -21,6 +21,8 @@ describe('modelBreakdownCalculator', () => {
       expect(acc.standardTotal).toBe(0);
       expect(acc.cliTotal).toBe(0);
       expect(acc.unknownTotal).toBe(0);
+      expect(acc.modelTotal).toBe(0);
+      expect(acc.allModels.size).toBe(0);
       expect(acc.premiumModels.size).toBe(0);
       expect(acc.standardModels.size).toBe(0);
     });
@@ -71,6 +73,8 @@ describe('modelBreakdownCalculator', () => {
       const acc = createModelBreakdownAccumulator();
       accumulateModelBreakdown(acc, '2024-01-15', 1, makeModelFeature('unknown'));
       expect(acc.unknownTotal).toBe(10);
+      expect(acc.modelTotal).toBe(10);
+      expect(acc.allModels.get('unknown')?.total).toBe(10);
       expect(acc.premiumTotal).toBe(0);
       expect(acc.standardTotal).toBe(0);
     });
@@ -79,6 +83,8 @@ describe('modelBreakdownCalculator', () => {
       const acc = createModelBreakdownAccumulator();
       accumulateModelBreakdown(acc, '2024-01-15', 1, makeModelFeature(''));
       expect(acc.unknownTotal).toBe(10);
+      expect(acc.modelTotal).toBe(10);
+      expect(acc.allModels.get('unknown')?.total).toBe(10);
       expect(acc.premiumTotal).toBe(0);
       expect(acc.standardTotal).toBe(0);
     });
@@ -156,6 +162,24 @@ describe('modelBreakdownCalculator', () => {
       expect(data.dates).toEqual(['2024-01-15', '2024-01-16']);
       expect(data.premiumTotal).toBe(10);
       expect(data.standardTotal).toBe(10);
+      expect(data.modelTotal).toBe(data.premiumTotal + data.standardTotal + data.unknownTotal);
+      expect(data.allModels.map(entry => entry.model)).toEqual(['gpt-5', 'gpt-4o']);
+    });
+
+    it('should include unknown models in neutral model totals and entries', () => {
+      const acc = createModelBreakdownAccumulator();
+      accumulateModelBreakdown(acc, '2024-01-15', 1, makeModelFeature('gpt-5', 'code_completion', 10));
+      accumulateModelBreakdown(acc, '2024-01-15', 1, makeModelFeature('gpt-4o', 'code_completion', 20));
+      accumulateModelBreakdown(acc, '2024-01-15', 1, makeModelFeature('unknown', 'code_completion', 5));
+      const data = computeModelBreakdownData(acc);
+
+      expect(data.modelTotal).toBe(35);
+      expect(data.modelTotal).toBe(data.premiumTotal + data.standardTotal + data.unknownTotal);
+      expect(data.allModels).toEqual([
+        { model: 'gpt-4o', total: 20, dailyData: { '2024-01-15': 20 } },
+        { model: 'gpt-5', total: 10, dailyData: { '2024-01-15': 10 } },
+        { model: 'unknown', total: 5, dailyData: { '2024-01-15': 5 } },
+      ]);
     });
   });
 });

--- a/src/domain/calculators/__tests__/modelUsageCalculator.test.ts
+++ b/src/domain/calculators/__tests__/modelUsageCalculator.test.ts
@@ -21,6 +21,7 @@ describe('modelUsageCalculator', () => {
       expect(results[0].standardModels).toBe(100);
       expect(results[0].pruModels).toBe(50);
       expect(results[0].unknownModels).toBe(10);
+      expect(results[0].modelInteractions).toBe(160);
     });
 
     it('should classify normalized aliases in the premium bucket', () => {
@@ -95,6 +96,7 @@ describe('modelUsageCalculator', () => {
       const results = computeDailyModelUsageData(accumulator);
 
       expect(results[0].unknownModels).toBe(15); // 10 + 5
+      expect(results[0].modelInteractions).toBe(15);
     });
 
     it('should classify unrecognized model names as premium by default', () => {

--- a/src/domain/calculators/__tests__/userDetailCalculator.test.ts
+++ b/src/domain/calculators/__tests__/userDetailCalculator.test.ts
@@ -35,6 +35,7 @@ describe('userDetailCalculator', () => {
       const state = acc.users.get(1)!;
       expect(state.totalStandardModelRequests).toBe(20);
       expect(state.totalPremiumModelRequests).toBe(0);
+      expect(state.totalModelRequests).toBe(20);
     });
 
     it('should count unknown models as premium', () => {
@@ -55,6 +56,7 @@ describe('userDetailCalculator', () => {
       const state = acc.users.get(1)!;
       expect(state.totalStandardModelRequests).toBe(0);
       expect(state.totalPremiumModelRequests).toBe(10);
+      expect(state.totalModelRequests).toBe(10);
     });
 
     it('should count empty model names as premium', () => {
@@ -75,6 +77,7 @@ describe('userDetailCalculator', () => {
       const state = acc.users.get(1)!;
       expect(state.totalStandardModelRequests).toBe(0);
       expect(state.totalPremiumModelRequests).toBe(5);
+      expect(state.totalModelRequests).toBe(5);
     });
 
     it('should classify normalized aliases as premium', () => {
@@ -95,6 +98,46 @@ describe('userDetailCalculator', () => {
       const state = acc.users.get(1)!;
       expect(state.totalStandardModelRequests).toBe(0);
       expect(state.totalPremiumModelRequests).toBe(7);
+      expect(state.totalModelRequests).toBe(7);
+    });
+
+    it('should expose neutral total model requests as the legacy bucket sum', () => {
+      const acc = createUserDetailAccumulator();
+      acc.reportStartDay = '2024-01-01';
+      acc.reportEndDay = '2024-01-31';
+
+      accumulateUserDetail(acc, createMetric({
+        totals_by_model_feature: [
+          {
+            model: 'gpt-4o',
+            feature: 'code_completion',
+            user_initiated_interaction_count: 20,
+            code_generation_activity_count: 0,
+            code_acceptance_activity_count: 0,
+            loc_added_sum: 0,
+            loc_deleted_sum: 0,
+            loc_suggested_to_add_sum: 0,
+            loc_suggested_to_delete_sum: 0,
+          },
+          {
+            model: 'unknown',
+            feature: 'code_completion',
+            user_initiated_interaction_count: 5,
+            code_generation_activity_count: 0,
+            code_acceptance_activity_count: 0,
+            loc_added_sum: 0,
+            loc_deleted_sum: 0,
+            loc_suggested_to_add_sum: 0,
+            loc_suggested_to_delete_sum: 0,
+          },
+        ],
+      }));
+
+      const result = computeSingleUserDetailedMetrics(acc, 1);
+      expect(result!.totalModelRequests).toBe(25);
+      expect(result!.totalModelRequests).toBe(
+        result!.totalStandardModelRequests + result!.totalPremiumModelRequests
+      );
     });
   });
 

--- a/src/domain/calculators/modelBreakdownCalculator.ts
+++ b/src/domain/calculators/modelBreakdownCalculator.ts
@@ -11,11 +11,13 @@ interface ModelAccEntry {
 }
 
 export interface ModelBreakdownAccumulator {
+  allModels: Map<string, ModelAccEntry>;
   premiumModels: Map<string, ModelAccEntry>;
   standardModels: Map<string, ModelAccEntry>;
   autoModels: Map<string, ModelAccEntry>;
   cliModels: Map<string, ModelAccEntry>;
   autoModeUsersByDate: Map<string, Set<number>>;
+  modelTotal: number;
   premiumTotal: number;
   standardTotal: number;
   cliTotal: number;
@@ -25,11 +27,13 @@ export interface ModelBreakdownAccumulator {
 
 export function createModelBreakdownAccumulator(): ModelBreakdownAccumulator {
   return {
+    allModels: new Map(),
     premiumModels: new Map(),
     standardModels: new Map(),
     autoModels: new Map(),
     cliModels: new Map(),
     autoModeUsersByDate: new Map(),
+    modelTotal: 0,
     premiumTotal: 0,
     standardTotal: 0,
     cliTotal: 0,
@@ -91,6 +95,8 @@ export function accumulateModelBreakdown(
   }
 
   accumulator.allDates.add(date);
+  accumulator.modelTotal += interactionCount;
+  accumulateModelEntry(accumulator.allModels, normalizedModel || 'unknown', date, interactionCount);
 
   if (bucket === 'premium') {
     accumulator.premiumTotal += interactionCount;
@@ -140,12 +146,14 @@ export function computeModelBreakdownData(
   );
 
   return {
+    allModels: buildModelEntries(accumulator.allModels),
     premiumModels: buildModelEntries(accumulator.premiumModels),
     standardModels: buildModelEntries(accumulator.standardModels),
     autoModels: buildModelEntries(accumulator.autoModels),
     cliModels: buildModelEntries(accumulator.cliModels),
     autoModeAdoptionTrend: computeAutoModeAdoptionTrend(dates, accumulator.autoModeUsersByDate),
     dates,
+    modelTotal: accumulator.modelTotal,
     premiumTotal: accumulator.premiumTotal,
     standardTotal: accumulator.standardTotal,
     cliTotal: accumulator.cliTotal,

--- a/src/domain/calculators/modelUsageCalculator.ts
+++ b/src/domain/calculators/modelUsageCalculator.ts
@@ -4,6 +4,7 @@ import { compareByDateAsc } from './statsCalculators';
 
 export interface DailyModelUsageData {
   date: string;
+  modelInteractions: number;
   pruModels: number;
   standardModels: number;
   unknownModels: number;
@@ -82,6 +83,7 @@ export function computeDailyModelUsageData(
   return Array.from(accumulator.dailyModelUsage.entries())
     .map(([date, data]) => ({
       date,
+      modelInteractions: data.pruModels + data.standardModels + data.unknownModels,
       pruModels: data.pruModels,
       standardModels: data.standardModels,
       unknownModels: data.unknownModels,

--- a/src/domain/calculators/userDetailCalculator.ts
+++ b/src/domain/calculators/userDetailCalculator.ts
@@ -67,6 +67,7 @@ interface CliVersionEntry {
 }
 
 interface UserAccState {
+  totalModelRequests: number;
   totalStandardModelRequests: number;
   totalPremiumModelRequests: number;
   featureMap: Map<string, FeatureAgg>;
@@ -96,6 +97,7 @@ function getOrCreateUserState(accumulator: UserDetailAccumulator, userId: number
   let state = accumulator.users.get(userId);
   if (!state) {
     state = {
+      totalModelRequests: 0,
       totalStandardModelRequests: 0,
       totalPremiumModelRequests: 0,
       featureMap: new Map(),
@@ -175,6 +177,7 @@ export function accumulateUserDetail(
 
   for (const mf of metric.totals_by_model_feature) {
     const { bucket } = classifyModelRequest(mf.model);
+    state.totalModelRequests += mf.user_initiated_interaction_count;
     if (bucket === 'standard') {
       state.totalStandardModelRequests += mf.user_initiated_interaction_count;
     } else {
@@ -327,6 +330,7 @@ export function computeSingleUserDetailedMetrics(
   );
 
   return {
+    totalModelRequests: state.totalModelRequests,
     totalStandardModelRequests: state.totalStandardModelRequests,
     totalPremiumModelRequests: state.totalPremiumModelRequests,
     featureAggregates: Array.from(state.featureMap.values()),

--- a/src/types/aggregatedMetrics.ts
+++ b/src/types/aggregatedMetrics.ts
@@ -7,6 +7,7 @@ import type {
 } from '../domain/calculators/metricCalculators';
 
 export interface UserDetailedMetrics {
+  totalModelRequests: number;
   totalStandardModelRequests: number;
   totalPremiumModelRequests: number;
   featureAggregates: Array<{

--- a/src/types/metrics.ts
+++ b/src/types/metrics.ts
@@ -188,12 +188,14 @@ export interface AutoModeAdoptionTrendEntry {
 }
 
 export interface ModelBreakdownData {
+  allModels: ModelDailyUsageEntry[];
   premiumModels: ModelDailyUsageEntry[];
   standardModels: ModelDailyUsageEntry[];
   autoModels?: ModelDailyUsageEntry[];
   cliModels?: ModelDailyUsageEntry[];
   autoModeAdoptionTrend?: AutoModeAdoptionTrendEntry[];
   dates: string[];
+  modelTotal: number;
   premiumTotal: number;
   standardTotal: number;
   cliTotal?: number;


### PR DESCRIPTION
## Why

GitHub Copilot usage reporting is moving away from billing-based premium/base separation, but existing consumers still depend on the legacy bucket contract. This adds a neutral aggregation contract alongside those legacy fields so later UI and documentation cleanup can migrate safely without breaking current behavior.

| Commit | Change |
|--------|--------|
| `feat: add neutral model usage contract` | Adds neutral model totals and entries derived from the existing model aggregation paths, keeps legacy premium/standard/unknown fields intact, and covers the compatibility invariants in targeted tests. |

## Compatibility notes

- `ModelBreakdownData.allModels` and `ModelBreakdownData.modelTotal` sit alongside `premiumModels`, `standardModels`, `premiumTotal`, `standardTotal`, and `unknownTotal`.
- `DailyModelUsageData.modelInteractions` is derived from the existing daily bucket totals.
- `UserDetailedMetrics.totalModelRequests` mirrors the existing per-user premium/standard bucket sum.
- Removed user flag and PRU insight modules from `main` are not restored.