### PR TITLE
refactor: use neutral model breakdown in UI

### DIFF
--- a/src/components/ModelDetailsView.tsx
+++ b/src/components/ModelDetailsView.tsx
@@ -11,6 +11,8 @@ interface ModelDetailsViewProps {
 }
 
 export default function ModelDetailsView({ modelBreakdownData }: ModelDetailsViewProps) {
+  const modelEntries = modelBreakdownData.allModels;
+  const modelTotal = modelBreakdownData.modelTotal;
   const autoModels = modelBreakdownData.autoModels ?? [];
   const autoModeAdoptionTrend = modelBreakdownData.autoModeAdoptionTrend ?? [];
 
@@ -19,24 +21,9 @@ export default function ModelDetailsView({ modelBreakdownData }: ModelDetailsVie
     [autoModels]
   );
 
-  const premiumModelEntries = useMemo(
-    () => modelBreakdownData.premiumModels.filter(entry => entry.model !== 'auto'),
-    [modelBreakdownData.premiumModels]
-  );
-
-  const modelEntries = useMemo(
-    () => [...modelBreakdownData.standardModels, ...premiumModelEntries],
-    [modelBreakdownData.standardModels, premiumModelEntries]
-  );
-
   const autoTotal = useMemo(
     () => autoModelEntries.reduce((sum, entry) => sum + entry.total, 0),
     [autoModelEntries]
-  );
-
-  const modelTotal = useMemo(
-    () => modelEntries.reduce((sum, entry) => sum + entry.total, 0),
-    [modelEntries]
   );
 
   return (
@@ -57,8 +44,7 @@ export default function ModelDetailsView({ modelBreakdownData }: ModelDetailsVie
             className="font-medium underline decoration-blue-400 underline-offset-2 hover:text-blue-700"
           >
             Read the announcement.
-          </a>{' '}
-          Premium vs standard model separation is no longer applicable.
+          </a>
         </div>
         <ModelsUsageChart modelEntries={modelEntries} dates={modelBreakdownData.dates} totalInteractions={modelTotal} variant="all" />
         <ModelsUsageChart modelEntries={autoModelEntries} dates={modelBreakdownData.dates} totalInteractions={autoTotal} variant="auto" />

--- a/src/components/ModelDetailsView.tsx
+++ b/src/components/ModelDetailsView.tsx
@@ -16,14 +16,9 @@ export default function ModelDetailsView({ modelBreakdownData }: ModelDetailsVie
   const autoModels = modelBreakdownData.autoModels ?? [];
   const autoModeAdoptionTrend = modelBreakdownData.autoModeAdoptionTrend ?? [];
 
-  const autoModelEntries = useMemo(
-    () => autoModels,
-    [autoModels]
-  );
-
   const autoTotal = useMemo(
-    () => autoModelEntries.reduce((sum, entry) => sum + entry.total, 0),
-    [autoModelEntries]
+    () => autoModels.reduce((sum, entry) => sum + entry.total, 0),
+    [autoModels]
   );
 
   return (
@@ -47,7 +42,7 @@ export default function ModelDetailsView({ modelBreakdownData }: ModelDetailsVie
           </a>
         </div>
         <ModelsUsageChart modelEntries={modelEntries} dates={modelBreakdownData.dates} totalInteractions={modelTotal} variant="all" />
-        <ModelsUsageChart modelEntries={autoModelEntries} dates={modelBreakdownData.dates} totalInteractions={autoTotal} variant="auto" />
+        <ModelsUsageChart modelEntries={autoModels} dates={modelBreakdownData.dates} totalInteractions={autoTotal} variant="auto" />
         <AutoModeAdoptionTrendChart data={autoModeAdoptionTrend} />
       </div>
     </ViewPanel>


### PR DESCRIPTION
## Why

This change completes Stage 3 of the usage-based billing cleanup by moving the Model Usage UI onto the neutral model-breakdown contract. It keeps the legacy aggregation fields intact for later cleanup while removing split-specific UI framing from this page.

| Commit | Change |
|--------|--------|
| `refactor: use neutral model breakdown in UI` | Updates Model Usage to read `allModels` and `modelTotal` directly and removes split-specific banner text. |
| `refactor: simplify auto model entries` | Addresses review feedback by removing a no-op auto-model memo while preserving chart behavior. |