### PR TITLE
refactor: remove per-user model request buckets

### DIFF
--- a/src/domain/calculators/__tests__/userDetailCalculator.test.ts
+++ b/src/domain/calculators/__tests__/userDetailCalculator.test.ts
@@ -16,8 +16,8 @@ describe('userDetailCalculator', () => {
     });
   });
 
-  describe('accumulateUserDetail — model request classification', () => {
-    it('should count standard model requests (multiplier 0)', () => {
+  describe('accumulateUserDetail — model request totals', () => {
+    it('should count known model requests in the neutral total', () => {
       const acc = createUserDetailAccumulator();
       acc.reportStartDay = '2024-01-01';
       acc.reportEndDay = '2024-01-31';
@@ -33,12 +33,10 @@ describe('userDetailCalculator', () => {
       }));
 
       const state = acc.users.get(1)!;
-      expect(state.totalStandardModelRequests).toBe(20);
-      expect(state.totalPremiumModelRequests).toBe(0);
       expect(state.totalModelRequests).toBe(20);
     });
 
-    it('should count unknown models as premium', () => {
+    it('should count unknown model requests in the neutral total', () => {
       const acc = createUserDetailAccumulator();
       acc.reportStartDay = '2024-01-01';
       acc.reportEndDay = '2024-01-31';
@@ -54,12 +52,10 @@ describe('userDetailCalculator', () => {
       }));
 
       const state = acc.users.get(1)!;
-      expect(state.totalStandardModelRequests).toBe(0);
-      expect(state.totalPremiumModelRequests).toBe(10);
       expect(state.totalModelRequests).toBe(10);
     });
 
-    it('should count empty model names as premium', () => {
+    it('should count empty model names in the neutral total', () => {
       const acc = createUserDetailAccumulator();
       acc.reportStartDay = '2024-01-01';
       acc.reportEndDay = '2024-01-31';
@@ -75,12 +71,10 @@ describe('userDetailCalculator', () => {
       }));
 
       const state = acc.users.get(1)!;
-      expect(state.totalStandardModelRequests).toBe(0);
-      expect(state.totalPremiumModelRequests).toBe(5);
       expect(state.totalModelRequests).toBe(5);
     });
 
-    it('should classify normalized aliases as premium', () => {
+    it('should count decorated model names in the neutral total', () => {
       const acc = createUserDetailAccumulator();
       acc.reportStartDay = '2024-01-01';
       acc.reportEndDay = '2024-01-31';
@@ -96,12 +90,10 @@ describe('userDetailCalculator', () => {
       }));
 
       const state = acc.users.get(1)!;
-      expect(state.totalStandardModelRequests).toBe(0);
-      expect(state.totalPremiumModelRequests).toBe(7);
       expect(state.totalModelRequests).toBe(7);
     });
 
-    it('should expose neutral total model requests as the legacy bucket sum', () => {
+    it('should expose neutral total model requests in the user detail payload', () => {
       const acc = createUserDetailAccumulator();
       acc.reportStartDay = '2024-01-01';
       acc.reportEndDay = '2024-01-31';
@@ -135,9 +127,24 @@ describe('userDetailCalculator', () => {
 
       const result = computeSingleUserDetailedMetrics(acc, 1);
       expect(result!.totalModelRequests).toBe(25);
-      expect(result!.totalModelRequests).toBe(
-        result!.totalStandardModelRequests + result!.totalPremiumModelRequests
-      );
+      expect(Object.keys(result!).sort()).toEqual([
+        'cliVersions',
+        'dailyAgentImpact',
+        'dailyAskModeImpact',
+        'dailyCliImpact',
+        'dailyCombinedImpact',
+        'dailyCompletionImpact',
+        'dailyModelUsage',
+        'days',
+        'featureAggregates',
+        'ideAggregates',
+        'languageFeatureAggregates',
+        'modelFeatureAggregates',
+        'pluginVersions',
+        'reportEndDay',
+        'reportStartDay',
+        'totalModelRequests',
+      ].sort());
     });
   });
 

--- a/src/domain/calculators/__tests__/userDetailCalculator.test.ts
+++ b/src/domain/calculators/__tests__/userDetailCalculator.test.ts
@@ -126,25 +126,8 @@ describe('userDetailCalculator', () => {
       }));
 
       const result = computeSingleUserDetailedMetrics(acc, 1);
+      expect(result).not.toBeNull();
       expect(result!.totalModelRequests).toBe(25);
-      expect(Object.keys(result!).sort()).toEqual([
-        'cliVersions',
-        'dailyAgentImpact',
-        'dailyAskModeImpact',
-        'dailyCliImpact',
-        'dailyCombinedImpact',
-        'dailyCompletionImpact',
-        'dailyModelUsage',
-        'days',
-        'featureAggregates',
-        'ideAggregates',
-        'languageFeatureAggregates',
-        'modelFeatureAggregates',
-        'pluginVersions',
-        'reportEndDay',
-        'reportStartDay',
-        'totalModelRequests',
-      ].sort());
     });
   });
 

--- a/src/domain/calculators/userDetailCalculator.ts
+++ b/src/domain/calculators/userDetailCalculator.ts
@@ -8,7 +8,6 @@ import {
   calculateCodeCompletionImpactData,
   calculateCliImpactData,
 } from './metricCalculators';
-import { classifyModelRequest } from '../modelConfig';
 
 interface FeatureAgg {
   feature: string;
@@ -68,8 +67,6 @@ interface CliVersionEntry {
 
 interface UserAccState {
   totalModelRequests: number;
-  totalStandardModelRequests: number;
-  totalPremiumModelRequests: number;
   featureMap: Map<string, FeatureAgg>;
   ideMap: Map<string, IDEAgg>;
   langFeatureMap: Map<string, LangFeatureAgg>;
@@ -98,8 +95,6 @@ function getOrCreateUserState(accumulator: UserDetailAccumulator, userId: number
   if (!state) {
     state = {
       totalModelRequests: 0,
-      totalStandardModelRequests: 0,
-      totalPremiumModelRequests: 0,
       featureMap: new Map(),
       ideMap: new Map(),
       langFeatureMap: new Map(),
@@ -176,13 +171,7 @@ export function accumulateUserDetail(
   const state = getOrCreateUserState(accumulator, userId);
 
   for (const mf of metric.totals_by_model_feature) {
-    const { bucket } = classifyModelRequest(mf.model);
     state.totalModelRequests += mf.user_initiated_interaction_count;
-    if (bucket === 'standard') {
-      state.totalStandardModelRequests += mf.user_initiated_interaction_count;
-    } else {
-      state.totalPremiumModelRequests += mf.user_initiated_interaction_count;
-    }
   }
 
   for (const f of metric.totals_by_feature) {
@@ -331,8 +320,6 @@ export function computeSingleUserDetailedMetrics(
 
   return {
     totalModelRequests: state.totalModelRequests,
-    totalStandardModelRequests: state.totalStandardModelRequests,
-    totalPremiumModelRequests: state.totalPremiumModelRequests,
     featureAggregates: Array.from(state.featureMap.values()),
     ideAggregates: Array.from(state.ideMap.values()),
     languageFeatureAggregates: Array.from(state.langFeatureMap.values()),

--- a/src/types/aggregatedMetrics.ts
+++ b/src/types/aggregatedMetrics.ts
@@ -8,8 +8,6 @@ import type {
 
 export interface UserDetailedMetrics {
   totalModelRequests: number;
-  totalStandardModelRequests: number;
-  totalPremiumModelRequests: number;
   featureAggregates: Array<{
     feature: string;
     user_initiated_interaction_count: number;


### PR DESCRIPTION
## Why

This change removes the per-user legacy premium/standard request counters now that user detail metrics expose a neutral total model request count. It keeps the user-detail contract aligned with usage-based billing while preserving the global model breakdown legacy fields for later stages.

| Commit | Change |
|--------|--------|
| `refactor: remove per-user model request buckets` | Removes the per-user premium/standard counters from user-detail state and payloads, and updates user-detail tests to assert neutral total request behavior. |
| `test: focus user detail total assertion` | Addresses review feedback by removing a brittle full-payload key assertion while keeping the neutral total behavior covered. |