### PR TITLE
refactor: remove legacy model bucket contract

### DIFF
--- a/docs/project-overview.md
+++ b/docs/project-overview.md
@@ -60,7 +60,7 @@ Next.js App Router SPA, TypeScript, Tailwind CSS. All rendering is client-side.
 
 ### 3.3. Model Configuration
 
-`src/domain/modelConfig.ts` contains a curated catalog of known LLM models with legacy PRU multipliers and premium flags retained for backward compatibility. Calculators use `classifyModelBucket()` to classify historical model requests as standard, premium, or unknown; multiplier helpers remain for legacy compatibility.
+`src/domain/modelConfig.ts` contains a curated catalog of known LLM models with legacy PRU multipliers and premium flags retained for backward compatibility. Calculators may still use model classification helpers for normalization and unknown-model detection; multiplier helpers remain for legacy compatibility.
 
 ---
 

--- a/src/domain/__tests__/metricsAggregator.test.ts
+++ b/src/domain/__tests__/metricsAggregator.test.ts
@@ -252,14 +252,11 @@ describe('metricsAggregator', () => {
 
       expect(aggregated.modelUsageData).toBeDefined();
       expect(aggregated.modelUsageData.length).toBeGreaterThan(0);
-      expect(aggregated.modelUsageData[0].modelInteractions).toBe(
-        aggregated.modelUsageData[0].pruModels
-        + aggregated.modelUsageData[0].standardModels
-        + aggregated.modelUsageData[0].unknownModels
-      );
+      expect(aggregated.modelUsageData[0].modelInteractions).toBe(10);
+      expect(aggregated.modelUsageData[0].unknownModels).toBe(0);
     });
 
-    it('should expose neutral model totals alongside legacy model buckets', () => {
+    it('should expose neutral model totals and entries', () => {
       const metric = createBasicMetric({
         totals_by_model_feature: [
           {
@@ -302,9 +299,7 @@ describe('metricsAggregator', () => {
       const { modelBreakdownData } = aggregated;
 
       expect(modelBreakdownData.modelTotal).toBe(20);
-      expect(modelBreakdownData.modelTotal).toBe(
-        modelBreakdownData.premiumTotal + modelBreakdownData.standardTotal + modelBreakdownData.unknownTotal
-      );
+      expect(modelBreakdownData.unknownTotal).toBe(3);
       expect(modelBreakdownData.allModels.map(entry => entry.model)).toEqual(['gpt-4o', 'gpt-5', 'unknown']);
     });
 
@@ -355,8 +350,8 @@ describe('metricsAggregator', () => {
           cumulativeUsers: 2,
         },
       ]);
-      expect(aggregated.modelBreakdownData.premiumModels.some(entry => entry.model === 'auto')).toBe(false);
-      expect(aggregated.modelBreakdownData.premiumTotal).toBe(0);
+      expect(aggregated.modelBreakdownData.allModels.some(entry => entry.model === 'auto')).toBe(false);
+      expect(aggregated.modelBreakdownData.modelTotal).toBe(0);
     });
 
     it('should count Auto model activity even when user initiated interactions are zero', () => {

--- a/src/domain/__tests__/modelConfig.test.ts
+++ b/src/domain/__tests__/modelConfig.test.ts
@@ -89,7 +89,7 @@ describe('modelConfig', () => {
 
   describe('isPremiumModel', () => {
     it('should correctly identify premium models', () => {
-      const premiumModels = [
+      const modelsExpectedPremium = [
         'gpt-5',
         'claude-3.5-sonnet',
         'claude-opus-4',
@@ -100,7 +100,7 @@ describe('modelConfig', () => {
         'auto',
       ];
 
-      premiumModels.forEach((model) => {
+      modelsExpectedPremium.forEach((model) => {
         expect(isPremiumModel(model)).toBe(true);
       });
     });

--- a/src/domain/calculators/__tests__/modelBreakdownCalculator.test.ts
+++ b/src/domain/calculators/__tests__/modelBreakdownCalculator.test.ts
@@ -17,56 +17,46 @@ describe('modelBreakdownCalculator', () => {
   describe('createModelBreakdownAccumulator', () => {
     it('should initialise all counters to zero and maps to empty', () => {
       const acc = createModelBreakdownAccumulator();
-      expect(acc.premiumTotal).toBe(0);
-      expect(acc.standardTotal).toBe(0);
       expect(acc.cliTotal).toBe(0);
       expect(acc.unknownTotal).toBe(0);
       expect(acc.modelTotal).toBe(0);
       expect(acc.allModels.size).toBe(0);
-      expect(acc.premiumModels.size).toBe(0);
-      expect(acc.standardModels.size).toBe(0);
     });
   });
 
-  describe('premium / standard classification', () => {
-    it('should classify a known premium model (gpt-5)', () => {
+  describe('model normalization and unknown handling', () => {
+    it('should aggregate known model interactions into neutral totals and entries', () => {
       const acc = createModelBreakdownAccumulator();
       accumulateModelBreakdown(acc, '2024-01-15', 1, makeModelFeature('gpt-5'));
-      expect(acc.premiumTotal).toBe(10);
-      expect(acc.standardTotal).toBe(0);
-    });
-
-    it('should classify a known standard model (gpt-4o)', () => {
-      const acc = createModelBreakdownAccumulator();
       accumulateModelBreakdown(acc, '2024-01-15', 1, makeModelFeature('gpt-4o'));
-      expect(acc.standardTotal).toBe(10);
-      expect(acc.premiumTotal).toBe(0);
+      expect(acc.modelTotal).toBe(20);
+      expect(acc.unknownTotal).toBe(0);
+      expect(acc.allModels.get('gpt-5')?.total).toBe(10);
+      expect(acc.allModels.get('gpt-4o')?.total).toBe(10);
     });
 
-    it('should classify a model name with spaces (e.g. "Claude Opus 4.7") as premium', () => {
+    it('should normalize a model name with spaces into allModels', () => {
       const acc = createModelBreakdownAccumulator();
       accumulateModelBreakdown(acc, '2024-01-15', 1, makeModelFeature('Claude Opus 4.7'));
-      expect(acc.premiumTotal).toBe(10);
-      expect(acc.standardTotal).toBe(0);
-      expect(Array.from(acc.premiumModels.keys())).toEqual(['claude-opus-4.7']);
+      expect(acc.modelTotal).toBe(10);
+      expect(Array.from(acc.allModels.keys())).toEqual(['claude-opus-4.7']);
     });
 
-    it('should classify a model name with parentheses (e.g. "Claude Opus 4.6 (fast mode)") as premium', () => {
+    it('should normalize a model name with parentheses into allModels', () => {
       const acc = createModelBreakdownAccumulator();
       accumulateModelBreakdown(acc, '2024-01-15', 1, makeModelFeature('Claude Opus 4.6 (fast mode)'));
-      expect(acc.premiumTotal).toBe(10);
-      expect(acc.standardTotal).toBe(0);
-      expect(Array.from(acc.premiumModels.keys())).toEqual(['claude-opus-4.6-fast-mode']);
+      expect(acc.modelTotal).toBe(10);
+      expect(Array.from(acc.allModels.keys())).toEqual(['claude-opus-4.6-fast-mode']);
     });
 
-    it('should aggregate premium variants with the same canonical model key', () => {
+    it('should aggregate variants with the same canonical model key', () => {
       const acc = createModelBreakdownAccumulator();
       accumulateModelBreakdown(acc, '2024-01-15', 1, makeModelFeature('Claude Opus 4.7'));
       accumulateModelBreakdown(acc, '2024-01-15', 2, makeModelFeature('claude-opus-4.7'));
 
-      expect(acc.premiumTotal).toBe(20);
-      expect(acc.premiumModels.size).toBe(1);
-      expect(acc.premiumModels.get('claude-opus-4.7')?.total).toBe(20);
+      expect(acc.modelTotal).toBe(20);
+      expect(acc.allModels.size).toBe(1);
+      expect(acc.allModels.get('claude-opus-4.7')?.total).toBe(20);
     });
 
     it('should classify the unknown sentinel to unknownTotal', () => {
@@ -75,8 +65,6 @@ describe('modelBreakdownCalculator', () => {
       expect(acc.unknownTotal).toBe(10);
       expect(acc.modelTotal).toBe(10);
       expect(acc.allModels.get('unknown')?.total).toBe(10);
-      expect(acc.premiumTotal).toBe(0);
-      expect(acc.standardTotal).toBe(0);
     });
 
     it('should classify empty model names to unknownTotal', () => {
@@ -85,17 +73,14 @@ describe('modelBreakdownCalculator', () => {
       expect(acc.unknownTotal).toBe(10);
       expect(acc.modelTotal).toBe(10);
       expect(acc.allModels.get('unknown')?.total).toBe(10);
-      expect(acc.premiumTotal).toBe(0);
-      expect(acc.standardTotal).toBe(0);
     });
   });
 
   describe('auto model handling', () => {
-    it('should route auto model to autoModels and not increment premium/standard', () => {
+    it('should route auto model to autoModels and not increment neutral model total', () => {
       const acc = createModelBreakdownAccumulator();
       accumulateModelBreakdown(acc, '2024-01-15', 1, makeModelFeature('auto'));
-      expect(acc.premiumTotal).toBe(0);
-      expect(acc.standardTotal).toBe(0);
+      expect(acc.modelTotal).toBe(0);
       expect(acc.autoModels.size).toBe(1);
     });
 
@@ -140,7 +125,7 @@ describe('modelBreakdownCalculator', () => {
       const acc = createModelBreakdownAccumulator();
       accumulateModelBreakdown(acc, '2024-01-15', 1, makeModelFeature('  Auto  ', 'chat_panel', 5));
       expect(acc.autoModels.size).toBe(1);
-      expect(acc.premiumTotal).toBe(0);
+      expect(acc.modelTotal).toBe(0);
     });
   });
 
@@ -160,9 +145,8 @@ describe('modelBreakdownCalculator', () => {
       accumulateModelBreakdown(acc, '2024-01-15', 2, makeModelFeature('gpt-4o'));
       const data = computeModelBreakdownData(acc);
       expect(data.dates).toEqual(['2024-01-15', '2024-01-16']);
-      expect(data.premiumTotal).toBe(10);
-      expect(data.standardTotal).toBe(10);
-      expect(data.modelTotal).toBe(data.premiumTotal + data.standardTotal + data.unknownTotal);
+      expect(data.modelTotal).toBe(20);
+      expect(data.unknownTotal).toBe(0);
       expect(data.allModels.map(entry => entry.model)).toEqual(['gpt-5', 'gpt-4o']);
     });
 
@@ -174,7 +158,7 @@ describe('modelBreakdownCalculator', () => {
       const data = computeModelBreakdownData(acc);
 
       expect(data.modelTotal).toBe(35);
-      expect(data.modelTotal).toBe(data.premiumTotal + data.standardTotal + data.unknownTotal);
+      expect(data.unknownTotal).toBe(5);
       expect(data.allModels).toEqual([
         { model: 'gpt-4o', total: 20, dailyData: { '2024-01-15': 20 } },
         { model: 'gpt-5', total: 10, dailyData: { '2024-01-15': 10 } },

--- a/src/domain/calculators/__tests__/modelUsageCalculator.test.ts
+++ b/src/domain/calculators/__tests__/modelUsageCalculator.test.ts
@@ -6,8 +6,8 @@ import {
 } from '../modelUsageCalculator';
 
 describe('modelUsageCalculator', () => {
-  describe('Model bucket accumulation', () => {
-    it('should classify interactions into standard, premium, and unknown buckets', () => {
+  describe('Model interaction accumulation', () => {
+    it('should aggregate interactions and track explicit unknown models', () => {
       const accumulator = createModelUsageAccumulator();
 
       accumulateModelFeature(accumulator, '2024-01-15', 'gpt-4o', 100);
@@ -18,33 +18,18 @@ describe('modelUsageCalculator', () => {
 
       expect(results).toHaveLength(1);
       expect(results[0].date).toBe('2024-01-15');
-      expect(results[0].standardModels).toBe(100);
-      expect(results[0].pruModels).toBe(50);
       expect(results[0].unknownModels).toBe(10);
       expect(results[0].modelInteractions).toBe(160);
     });
 
-    it('should classify normalized aliases in the premium bucket', () => {
+    it('should include normalized aliases in model interactions', () => {
       const accumulator = createModelUsageAccumulator();
 
       accumulateModelFeature(accumulator, '2024-01-15', 'Claude Opus 4.6 (fast mode)', 10);
 
       const results = computeDailyModelUsageData(accumulator);
-      expect(results[0].pruModels).toBe(10);
-      expect(results[0].standardModels).toBe(0);
+      expect(results[0].modelInteractions).toBe(10);
       expect(results[0].unknownModels).toBe(0);
-    });
-
-    it('should accumulate interactions for the same model bucket', () => {
-      const accumulator = createModelUsageAccumulator();
-
-      accumulateModelFeature(accumulator, '2024-01-15', 'gpt-5', 10);
-      accumulateModelFeature(accumulator, '2024-01-15', 'claude-sonnet-4.5', 20);
-      accumulateModelFeature(accumulator, '2024-01-15', 'o3-mini', 5);
-
-      const results = computeDailyModelUsageData(accumulator);
-
-      expect(results[0].pruModels).toBe(35);
     });
   });
 
@@ -63,10 +48,10 @@ describe('modelUsageCalculator', () => {
       const day1 = results.find(r => r.date === '2024-01-15');
       const day2 = results.find(r => r.date === '2024-01-16');
 
-      expect(day1?.pruModels).toBe(30);
-      expect(day1?.standardModels).toBe(0);
-      expect(day2?.pruModels).toBe(0);
-      expect(day2?.standardModels).toBe(5);
+      expect(day1?.modelInteractions).toBe(30);
+      expect(day1?.unknownModels).toBe(0);
+      expect(day2?.modelInteractions).toBe(5);
+      expect(day2?.unknownModels).toBe(0);
     });
 
     it('should maintain separate accumulation per date', () => {
@@ -81,7 +66,7 @@ describe('modelUsageCalculator', () => {
 
       expect(results).toHaveLength(3);
       results.forEach(result => {
-        expect(result.pruModels).toBe(10);
+        expect(result.modelInteractions).toBe(10);
       });
     });
   });
@@ -95,18 +80,19 @@ describe('modelUsageCalculator', () => {
 
       const results = computeDailyModelUsageData(accumulator);
 
-      expect(results[0].unknownModels).toBe(15); // 10 + 5
+      expect(results[0].unknownModels).toBe(15);
       expect(results[0].modelInteractions).toBe(15);
     });
 
-    it('should classify unrecognized model names as premium by default', () => {
+    it('should not count unrecognized model names as explicit unknown models', () => {
       const accumulator = createModelUsageAccumulator();
 
       accumulateModelFeature(accumulator, '2024-01-15', 'totally-unknown-xyz', 10);
 
       const results = computeDailyModelUsageData(accumulator);
 
-      expect(results[0].pruModels).toBe(10);
+      expect(results[0].modelInteractions).toBe(10);
+      expect(results[0].unknownModels).toBe(0);
     });
   });
 });

--- a/src/domain/calculators/modelBreakdownCalculator.ts
+++ b/src/domain/calculators/modelBreakdownCalculator.ts
@@ -12,14 +12,10 @@ interface ModelAccEntry {
 
 export interface ModelBreakdownAccumulator {
   allModels: Map<string, ModelAccEntry>;
-  premiumModels: Map<string, ModelAccEntry>;
-  standardModels: Map<string, ModelAccEntry>;
   autoModels: Map<string, ModelAccEntry>;
   cliModels: Map<string, ModelAccEntry>;
   autoModeUsersByDate: Map<string, Set<number>>;
   modelTotal: number;
-  premiumTotal: number;
-  standardTotal: number;
   cliTotal: number;
   unknownTotal: number;
   allDates: Set<string>;
@@ -28,14 +24,10 @@ export interface ModelBreakdownAccumulator {
 export function createModelBreakdownAccumulator(): ModelBreakdownAccumulator {
   return {
     allModels: new Map(),
-    premiumModels: new Map(),
-    standardModels: new Map(),
     autoModels: new Map(),
     cliModels: new Map(),
     autoModeUsersByDate: new Map(),
     modelTotal: 0,
-    premiumTotal: 0,
-    standardTotal: 0,
     cliTotal: 0,
     unknownTotal: 0,
     allDates: new Set(),
@@ -98,13 +90,7 @@ export function accumulateModelBreakdown(
   accumulator.modelTotal += interactionCount;
   accumulateModelEntry(accumulator.allModels, normalizedModel || 'unknown', date, interactionCount);
 
-  if (bucket === 'premium') {
-    accumulator.premiumTotal += interactionCount;
-    accumulateModelEntry(accumulator.premiumModels, normalizedModel, date, interactionCount);
-  } else if (bucket === 'standard') {
-    accumulator.standardTotal += interactionCount;
-    accumulateModelEntry(accumulator.standardModels, normalizedModel, date, interactionCount);
-  } else {
+  if (bucket === 'unknown') {
     accumulator.unknownTotal += interactionCount;
   }
 }
@@ -147,15 +133,11 @@ export function computeModelBreakdownData(
 
   return {
     allModels: buildModelEntries(accumulator.allModels),
-    premiumModels: buildModelEntries(accumulator.premiumModels),
-    standardModels: buildModelEntries(accumulator.standardModels),
     autoModels: buildModelEntries(accumulator.autoModels),
     cliModels: buildModelEntries(accumulator.cliModels),
     autoModeAdoptionTrend: computeAutoModeAdoptionTrend(dates, accumulator.autoModeUsersByDate),
     dates,
     modelTotal: accumulator.modelTotal,
-    premiumTotal: accumulator.premiumTotal,
-    standardTotal: accumulator.standardTotal,
     cliTotal: accumulator.cliTotal,
     unknownTotal: accumulator.unknownTotal,
   };

--- a/src/domain/calculators/modelUsageCalculator.ts
+++ b/src/domain/calculators/modelUsageCalculator.ts
@@ -5,8 +5,6 @@ import { compareByDateAsc } from './statsCalculators';
 export interface DailyModelUsageData {
   date: string;
   modelInteractions: number;
-  pruModels: number;
-  standardModels: number;
   unknownModels: number;
 }
 
@@ -19,8 +17,7 @@ export interface AgentModeHeatmapData {
 
 export interface ModelUsageAccumulator {
   dailyModelUsage: Map<string, {
-    pruModels: number;
-    standardModels: number;
+    modelInteractions: number;
     unknownModels: number;
   }>;
   dailyAgentHeatmap: Map<string, {
@@ -44,19 +41,15 @@ export function accumulateModelFeature(
 ): void {
   if (!accumulator.dailyModelUsage.has(date)) {
     accumulator.dailyModelUsage.set(date, {
-      pruModels: 0,
-      standardModels: 0,
+      modelInteractions: 0,
       unknownModels: 0,
     });
   }
   const dmu = accumulator.dailyModelUsage.get(date)!;
   const { bucket } = classifyModelRequest(model);
+  dmu.modelInteractions += interactions;
   if (bucket === 'unknown') {
     dmu.unknownModels += interactions;
-  } else if (bucket === 'standard') {
-    dmu.standardModels += interactions;
-  } else {
-    dmu.pruModels += interactions;
   }
 }
 
@@ -83,9 +76,7 @@ export function computeDailyModelUsageData(
   return Array.from(accumulator.dailyModelUsage.entries())
     .map(([date, data]) => ({
       date,
-      modelInteractions: data.pruModels + data.standardModels + data.unknownModels,
-      pruModels: data.pruModels,
-      standardModels: data.standardModels,
+      modelInteractions: data.modelInteractions,
       unknownModels: data.unknownModels,
     }))
     .sort(compareByDateAsc);

--- a/src/types/metrics.ts
+++ b/src/types/metrics.ts
@@ -189,15 +189,11 @@ export interface AutoModeAdoptionTrendEntry {
 
 export interface ModelBreakdownData {
   allModels: ModelDailyUsageEntry[];
-  premiumModels: ModelDailyUsageEntry[];
-  standardModels: ModelDailyUsageEntry[];
   autoModels?: ModelDailyUsageEntry[];
   cliModels?: ModelDailyUsageEntry[];
   autoModeAdoptionTrend?: AutoModeAdoptionTrendEntry[];
   dates: string[];
   modelTotal: number;
-  premiumTotal: number;
-  standardTotal: number;
   cliTotal?: number;
   unknownTotal: number;
 }


### PR DESCRIPTION
## Why

This change completes stage 7 of the usage-based billing cleanup by removing the legacy premium/standard model bucket aggregation contract. It keeps the neutral model totals and unknown-model tracking as the worker/UI-facing model usage contract.

| Commit | Change |
|--------|--------|
| `refactor: remove legacy model bucket contract` | Removes premium/standard and PRU bucket fields from model aggregation outputs, updates tests to assert neutral totals and known/unknown behavior, and refreshes docs wording. |