### PR TITLE
refactor: simplify model config classification

### DIFF
--- a/.github/workflows/code-duplication-scan.md
+++ b/.github/workflows/code-duplication-scan.md
@@ -86,7 +86,7 @@ Pay special attention to this app's architecture:
 - Parsing and aggregation run through the Web Worker `parseAndAggregate` flow.
 - Raw `CopilotMetrics[]` records should not be persisted on the main thread; UI code should consume the pre-aggregated `AggregatedMetrics` contract.
 - Only the new LOC schema (`loc_added_sum`, `loc_deleted_sum`, `loc_suggested_*`) is supported. Deprecated `generated_loc_sum` / `accepted_loc_sum` inputs are intentionally skipped.
-- Premium Request Unit (PRU) model multipliers belong in `src/domain/modelConfig.ts`.
+- Model normalization, known-model recognition, and unknown-model detection belong in `src/domain/modelConfig.ts`.
 - Chart components should use the shared Chart.js registration, chart option, dataset, color, and `ChartContainer` patterns documented in `.github/instructions/charts.instructions.md`.
 
 ## Scan protocol
@@ -110,8 +110,8 @@ Pay special attention to this app's architecture:
 4. Look for repeated:
    - NDJSON line parsing, validation, warning, and skipped-record handling
    - LOC field handling and deprecated-schema detection
-   - user, feature, IDE, language, model, CLI, and PRU aggregation loops
-   - model name normalization, premium-model checks, and multiplier lookups
+   - user, feature, IDE, language, model, and CLI aggregation loops
+   - model name normalization, known-model checks, and unknown-model detection
    - feature category or translation logic
    - language normalization and IDE/plugin version classification
    - date bucketing, report date range, and zero-fill logic
@@ -129,7 +129,7 @@ Good atomic groups:
 
 - "Centralize deprecated LOC schema detection"
 - "Extract shared report-date zero-fill helper for charts"
-- "Reuse model premium/multiplier helpers in calculators"
+- "Reuse model normalization helpers in calculators"
 - "Share top-N expandable table behavior across dashboard views"
 
 Bad groups:
@@ -174,7 +174,7 @@ For each issue, use the `create_issue` safe output with this body structure:
 - [ ] Parsing and aggregation still run through the Web Worker `parseAndAggregate` flow when applicable.
 - [ ] Raw metrics are not persisted on the main thread.
 - [ ] Deprecated LOC schema records remain skipped, and new LOC schema fields remain supported.
-- [ ] PRU calculations continue to use `src/domain/modelConfig.ts` when model multipliers are involved.
+- [ ] Model normalization and unknown-model detection continue to use `src/domain/modelConfig.ts`.
 - [ ] Chart changes follow `.github/instructions/charts.instructions.md` when chart components are involved.
 - [ ] Relevant tests are updated or added.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@ All parsing and metrics aggregation should run in a **Web Worker** via the `pars
 
 ## Key Domain File
 
-`src/domain/modelConfig.ts` contains legacy Copilot model multipliers retained for backward compatibility.
+`src/domain/modelConfig.ts` contains Copilot model normalization and known-model catalog helpers.
 
 ## UX Patterns
 

--- a/docs/project-overview.md
+++ b/docs/project-overview.md
@@ -60,7 +60,7 @@ Next.js App Router SPA, TypeScript, Tailwind CSS. All rendering is client-side.
 
 ### 3.3. Model Configuration
 
-`src/domain/modelConfig.ts` contains a curated catalog of known LLM models with legacy PRU multipliers and premium flags retained for backward compatibility. Calculators may still use model classification helpers for normalization and unknown-model detection; multiplier helpers remain for legacy compatibility.
+`src/domain/modelConfig.ts` contains a curated catalog of known LLM models. Calculators use model helpers for normalization, known-model alias recognition, and explicit unknown/empty model detection.
 
 ---
 

--- a/src/domain/__tests__/modelConfig.test.ts
+++ b/src/domain/__tests__/modelConfig.test.ts
@@ -40,6 +40,7 @@ describe('modelConfig', () => {
 
     it('should not treat arbitrary non-empty model names as known models', () => {
       expect(isKnownModelName('totally-made-up')).toBe(false);
+      expect(isKnownModelName('unknown')).toBe(false);
       expect(isKnownModelName('')).toBe(false);
     });
   });
@@ -67,7 +68,7 @@ describe('modelConfig', () => {
       expect(classifyModelRequest('unknown')).toEqual({
         normalizedModel: 'unknown',
         isUnknown: true,
-        isKnownModel: true,
+        isKnownModel: false,
       });
       expect(classifyModelRequest('')).toEqual({
         normalizedModel: '',

--- a/src/domain/__tests__/modelConfig.test.ts
+++ b/src/domain/__tests__/modelConfig.test.ts
@@ -1,180 +1,87 @@
 import { describe, it, expect } from 'vitest';
-import { getModelMultiplier, isPremiumModel, classifyModelBucket, classifyModelRequest, MODEL_MULTIPLIERS, KNOWN_MODELS, isActiveAutoModeFeature } from '../modelConfig';
+import {
+  classifyModelRequest,
+  isActiveAutoModeFeature,
+  isKnownModelName,
+  isUnknownModelName,
+  KNOWN_MODELS,
+  normalizeModelName,
+} from '../modelConfig';
 
 describe('modelConfig', () => {
-  describe('getModelMultiplier', () => {
-    it('should return correct multiplier for exact model name match', () => {
-      const testCases = [
-        { model: 'gpt-4o', expected: 0 },
-        { model: 'gpt-5', expected: 1 },
-        { model: 'claude-3.5-sonnet', expected: 1 },
-        { model: 'claude-opus-4.7', expected: 15 },
-        { model: 'claude-opus-4.6-fast-mode', expected: 30 },
-        { model: 'claude-opus-4.6-fast-mode-preview', expected: 30 },
-        { model: 'o3-mini', expected: 0.33 },
-        { model: 'gemini-2.0-flash', expected: 0.25 },
-        { model: 'gemini-3.5-flash', expected: 14 },
-        { model: 'gpt-5.4-nano', expected: 0.25 },
-      ];
-
-      testCases.forEach(({ model, expected }) => {
-        expect(getModelMultiplier(model)).toBe(expected);
-      });
+  describe('normalizeModelName', () => {
+    it('should normalize casing, whitespace, underscores, and parentheses', () => {
+      expect(normalizeModelName('  Claude Opus 4.6 (fast mode)  ')).toBe('claude-opus-4.6-fast-mode');
+      expect(normalizeModelName('GPT_4O')).toBe('gpt-4o');
+      expect(normalizeModelName('Gemini   3.5   Flash')).toBe('gemini-3.5-flash');
     });
 
-    it('should handle display names with parentheses (fast mode / preview)', () => {
-      const testCases = [
-        { model: 'Claude Opus 4.6 (fast mode) (preview)', expected: 30 },
-        { model: 'Claude Opus 4.6 (fast mode)', expected: 30 },
-      ];
-
-      testCases.forEach(({ model, expected }) => {
-        expect(getModelMultiplier(model)).toBe(expected);
-      });
-    });
-
-    it('should handle case-insensitive matching', () => {
-      const testCases = [
-        { model: 'GPT-4O', expected: 0 },
-        { model: 'Claude-3.5-Sonnet', expected: 1 },
-        { model: 'Claude Opus 4.7', expected: 15 },
-        { model: 'GEMINI-2.0-FLASH', expected: 0.25 },
-        { model: 'Gemini 3.5 Flash', expected: 14 },
-      ];
-
-      testCases.forEach(({ model, expected }) => {
-        expect(getModelMultiplier(model)).toBe(expected);
-      });
-    });
-
-    it('should handle trailing/leading spaces', () => {
-      expect(getModelMultiplier('  gpt-4o  ')).toBe(0);
-      expect(getModelMultiplier(' claude-3.5-sonnet ')).toBe(1);
-    });
-
-    it('should use partial matching for model name variations', () => {
-      // Fuzzy matching should find models by substring
-      // For example, a model name containing "claude-opus-4" should match "claude-opus-4"
-      const testCases = [
-        { model: 'claude-opus-4-special', expected: 10 }, // Should match claude-opus-4
-        { model: 'claude-opus-4.6-custom', expected: 3 }, // Should prefer claude-opus-4.6 over claude-opus-4
-        { model: 'claude-opus-4.7-custom', expected: 15 }, // Should prefer claude-opus-4.7 over claude-opus-4
-        { model: 'gpt-4o-special-edition', expected: 0 }, // Should match gpt-4o
-      ];
-
-      testCases.forEach(({ model, expected }) => {
-        expect(getModelMultiplier(model)).toBe(expected);
-      });
-    });
-
-    it('should return unknown multiplier for completely unknown models', () => {
-      const unknownMultiplier = MODEL_MULTIPLIERS['unknown'];
-
-      expect(getModelMultiplier('some-random-model-xyz')).toBe(unknownMultiplier);
-      expect(getModelMultiplier('totally-made-up-123')).toBe(unknownMultiplier);
-    });
-
-    it('should not match unknown during fuzzy search', () => {
-      // A model containing "unknown" shouldn't get special treatment
-      const result = getModelMultiplier('my-unknown-model');
-      // It should get the unknown multiplier through fallback, not fuzzy match
-      expect(result).toBe(MODEL_MULTIPLIERS['unknown']);
-    });
-
-    it('should handle empty string gracefully', () => {
-      const unknownMultiplier = MODEL_MULTIPLIERS['unknown'];
-      expect(getModelMultiplier('')).toBe(unknownMultiplier);
+    it('should collapse repeated separators', () => {
+      expect(normalizeModelName('claude---opus___4.7')).toBe('claude-opus-4.7');
     });
   });
 
-  describe('isPremiumModel', () => {
-    it('should correctly identify premium models', () => {
-      const modelsExpectedPremium = [
-        'gpt-5',
-        'claude-3.5-sonnet',
-        'claude-opus-4',
-        'o3',
-        'gemini-2.5-pro',
-        'gemini-3.5-flash',
-        'gpt-5.4-nano',
-        'auto',
-      ];
+  describe('known model catalog', () => {
+    it('should keep model entries name-only', () => {
+      const model = KNOWN_MODELS.find(entry => entry.name === 'gpt-5');
 
-      modelsExpectedPremium.forEach((model) => {
-        expect(isPremiumModel(model)).toBe(true);
-      });
+      expect(model).toEqual({ name: 'gpt-5' });
     });
 
-    it('should correctly identify non-premium (included) models', () => {
-      const includedModels = [
-        'gpt-4.0',
-        'gpt-4o',
-        'gpt-4o-mini',
-        'gpt-3.5',
-        'grok-code-fast',
-      ];
-
-      includedModels.forEach((model) => {
-        expect(isPremiumModel(model)).toBe(false);
-      });
+    it('should include the unknown sentinel', () => {
+      expect(KNOWN_MODELS.some(model => model.name === 'unknown')).toBe(true);
     });
 
-    it('should treat zero-multiplier models as non-premium', () => {
-      // Zero multiplier means included in base tier
-      expect(isPremiumModel('gpt-4o')).toBe(false);
-      expect(getModelMultiplier('gpt-4o')).toBe(0);
+    it('should recognize known models after normalization', () => {
+      expect(isKnownModelName('GPT-5')).toBe(true);
+      expect(isKnownModelName('Claude Opus 4.6 (fast mode)')).toBe(true);
+      expect(isKnownModelName('Gemini 3.5 Flash')).toBe(true);
     });
 
-    it('should treat unknown models as premium (conservative default)', () => {
-      expect(isPremiumModel('totally-unknown-model')).toBe(true);
-      expect(isPremiumModel('xyz-123')).toBe(true);
-    });
-
-    it('should handle case-insensitive matching for premium detection', () => {
-      expect(isPremiumModel('GPT-5')).toBe(true);
-      expect(isPremiumModel('Claude Opus 4.7')).toBe(true);
-      expect(isPremiumModel('GPT-4O')).toBe(false);
-    });
-
-    it('should use partial matching for premium detection', () => {
-      // Should match by partial name
-      expect(isPremiumModel('claude-opus-4-custom')).toBe(true);
+    it('should not treat arbitrary non-empty model names as known models', () => {
+      expect(isKnownModelName('totally-made-up')).toBe(false);
+      expect(isKnownModelName('')).toBe(false);
     });
   });
 
-  describe('MODEL_MULTIPLIERS and KNOWN_MODELS consistency', () => {
-    it('should have consistent multiplier values between Model class and multiplier map', () => {
-      KNOWN_MODELS.forEach((model) => {
-        const mapValue = MODEL_MULTIPLIERS[model.name.toLowerCase().trim()];
-        expect(mapValue).toBe(model.multiplier);
-      });
-    });
-
-    it('should have unknown model defined', () => {
-      const unknownModel = KNOWN_MODELS.find(m => m.name === 'unknown');
-      expect(unknownModel).toBeDefined();
-      expect(unknownModel?.multiplier).toBeDefined();
+  describe('unknown model detection', () => {
+    it('should identify only empty model names and the unknown sentinel as unknown', () => {
+      expect(isUnknownModelName('unknown')).toBe(true);
+      expect(isUnknownModelName(' UNKNOWN ')).toBe(true);
+      expect(isUnknownModelName('')).toBe(true);
+      expect(isUnknownModelName('totally-unknown-model')).toBe(false);
+      expect(isUnknownModelName('gpt-5')).toBe(false);
     });
   });
 
-  describe('classifyModelBucket', () => {
-    it('should classify standard models', () => {
-      expect(classifyModelBucket('gpt-4o')).toBe('standard');
+  describe('classifyModelRequest', () => {
+    it('should return normalized model metadata for known aliases', () => {
+      expect(classifyModelRequest('Claude Opus 4.6 (fast mode)')).toEqual({
+        normalizedModel: 'claude-opus-4.6-fast-mode',
+        isUnknown: false,
+        isKnownModel: true,
+      });
     });
 
-    it('should classify premium models', () => {
-      expect(classifyModelBucket('claude-3.5-sonnet')).toBe('premium');
-      expect(classifyModelBucket('Gemini 3.5 Flash')).toBe('premium');
-      expect(classifyModelBucket('gpt-5')).toBe('premium');
+    it('should preserve unknown and empty detection for aggregation', () => {
+      expect(classifyModelRequest('unknown')).toEqual({
+        normalizedModel: 'unknown',
+        isUnknown: true,
+        isKnownModel: true,
+      });
+      expect(classifyModelRequest('')).toEqual({
+        normalizedModel: '',
+        isUnknown: true,
+        isKnownModel: false,
+      });
     });
 
-    it('should classify unknown models', () => {
-      expect(classifyModelBucket('unknown')).toBe('unknown');
-      expect(classifyModelBucket('')).toBe('unknown');
-    });
-
-    it('should treat unrecognized models as premium', () => {
-      expect(classifyModelBucket('totally-made-up')).toBe('premium');
+    it('should leave unrecognized non-empty models out of unknown totals', () => {
+      expect(classifyModelRequest('some-random-model')).toEqual({
+        normalizedModel: 'some-random-model',
+        isUnknown: false,
+        isKnownModel: false,
+      });
     });
   });
 
@@ -216,20 +123,6 @@ describe('modelConfig', () => {
 
     it('should return false when auto activity counts are negative', () => {
       expect(isActiveAutoModeFeature(makeFeature('auto', -1, -2, -3))).toBe(false);
-    });
-  });
-
-  describe('classifyModelRequest', () => {
-    it('should return normalized model and bucket for aliases', () => {
-      expect(classifyModelRequest('Claude Opus 4.6 (fast mode)')).toEqual({
-        normalizedModel: 'claude-opus-4.6-fast-mode',
-        bucket: 'premium',
-      });
-    });
-
-    it('should preserve unknown and empty buckets', () => {
-      expect(classifyModelRequest('unknown')).toEqual({ normalizedModel: 'unknown', bucket: 'unknown' });
-      expect(classifyModelRequest('')).toEqual({ normalizedModel: '', bucket: 'unknown' });
     });
   });
 });

--- a/src/domain/calculators/__tests__/modelBreakdownCalculator.test.ts
+++ b/src/domain/calculators/__tests__/modelBreakdownCalculator.test.ts
@@ -136,6 +136,12 @@ describe('modelBreakdownCalculator', () => {
       expect(acc.cliTotal).toBe(10);
       expect(acc.cliModels.size).toBe(1);
     });
+
+    it('should coerce empty CLI model names to unknown', () => {
+      const acc = createModelBreakdownAccumulator();
+      accumulateModelBreakdown(acc, '2024-01-15', 1, makeModelFeature('', 'copilot_cli'));
+      expect(Array.from(acc.cliModels.keys())).toEqual(['unknown']);
+    });
   });
 
   describe('computeModelBreakdownData', () => {

--- a/src/domain/calculators/modelBreakdownCalculator.ts
+++ b/src/domain/calculators/modelBreakdownCalculator.ts
@@ -62,7 +62,7 @@ export function accumulateModelBreakdown(
 ): void {
   const interactionCount = modelFeature.user_initiated_interaction_count || 0;
   const activityCount = (modelFeature.code_generation_activity_count || 0) + (modelFeature.code_acceptance_activity_count || 0);
-  const { normalizedModel, bucket } = classifyModelRequest(modelFeature.model);
+  const { normalizedModel, isUnknown } = classifyModelRequest(modelFeature.model);
 
   if (isCliFeature(modelFeature.feature) && interactionCount > 0) {
     accumulator.allDates.add(date);
@@ -90,7 +90,7 @@ export function accumulateModelBreakdown(
   accumulator.modelTotal += interactionCount;
   accumulateModelEntry(accumulator.allModels, normalizedModel || 'unknown', date, interactionCount);
 
-  if (bucket === 'unknown') {
+  if (isUnknown) {
     accumulator.unknownTotal += interactionCount;
   }
 }

--- a/src/domain/calculators/modelBreakdownCalculator.ts
+++ b/src/domain/calculators/modelBreakdownCalculator.ts
@@ -67,7 +67,7 @@ export function accumulateModelBreakdown(
   if (isCliFeature(modelFeature.feature) && interactionCount > 0) {
     accumulator.allDates.add(date);
     accumulator.cliTotal += interactionCount;
-    accumulateModelEntry(accumulator.cliModels, normalizedModel, date, interactionCount);
+    accumulateModelEntry(accumulator.cliModels, normalizedModel || 'unknown', date, interactionCount);
   }
 
   if (isActiveAutoModeFeature(modelFeature)) {

--- a/src/domain/calculators/modelUsageCalculator.ts
+++ b/src/domain/calculators/modelUsageCalculator.ts
@@ -46,9 +46,9 @@ export function accumulateModelFeature(
     });
   }
   const dmu = accumulator.dailyModelUsage.get(date)!;
-  const { bucket } = classifyModelRequest(model);
+  const { isUnknown } = classifyModelRequest(model);
   dmu.modelInteractions += interactions;
-  if (bucket === 'unknown') {
+  if (isUnknown) {
     dmu.unknownModels += interactions;
   }
 }

--- a/src/domain/modelConfig.ts
+++ b/src/domain/modelConfig.ts
@@ -95,9 +95,10 @@ export function isKnownModelName(modelName: string): boolean {
 
 export function classifyModelRequest(modelName: string): ModelRequestClassification {
   const normalizedModel = normalizeModelName(modelName);
+  const isUnknown = normalizedModel === '' || normalizedModel === UNKNOWN_MODEL_NAME;
   return {
     normalizedModel,
-    isUnknown: isUnknownModelName(normalizedModel),
-    isKnownModel: isKnownModelName(normalizedModel),
+    isUnknown,
+    isKnownModel: normalizedModel !== '' && KNOWN_MODEL_NAMES.has(normalizedModel),
   };
 }

--- a/src/domain/modelConfig.ts
+++ b/src/domain/modelConfig.ts
@@ -90,7 +90,7 @@ export function isUnknownModelName(modelName: string): boolean {
 
 export function isKnownModelName(modelName: string): boolean {
   const normalized = normalizeModelName(modelName);
-  return normalized !== '' && KNOWN_MODEL_NAMES.has(normalized);
+  return normalized !== '' && normalized !== UNKNOWN_MODEL_NAME && KNOWN_MODEL_NAMES.has(normalized);
 }
 
 export function classifyModelRequest(modelName: string): ModelRequestClassification {
@@ -99,6 +99,6 @@ export function classifyModelRequest(modelName: string): ModelRequestClassificat
   return {
     normalizedModel,
     isUnknown,
-    isKnownModel: normalizedModel !== '' && KNOWN_MODEL_NAMES.has(normalizedModel),
+    isKnownModel: normalizedModel !== '' && normalizedModel !== UNKNOWN_MODEL_NAME && KNOWN_MODEL_NAMES.has(normalizedModel),
   };
 }

--- a/src/domain/modelConfig.ts
+++ b/src/domain/modelConfig.ts
@@ -1,168 +1,103 @@
 /**
- * Shared configuration for model classification and cost calculations.
- * Keep this list in sync with GitHub Copilot pricing and entitlement docs.
+ * Shared configuration for model normalization and known-model recognition.
  */
 import { normalizeModelName } from './autoMode';
 
 export { isActiveAutoModeFeature, normalizeModelName } from './autoMode';
 
 export class Model {
-  constructor(
-    public readonly name: string,
-    public readonly multiplier: number,
-    public readonly isPremium: boolean
-  ) {}
+  constructor(public readonly name: string) {}
 }
 
 /**
- * Canonical list of known models with associated PRU multipliers and premium flags.
+ * Canonical list of known models.
  */
 export const KNOWN_MODELS: Model[] = [
-  // Included models (0 PRUs for paid plans)
-  new Model('goldeneye', 0, false),
-  new Model('gpt-4.0', 0, false),
-  new Model('gpt-4.1', 0, false),
-  new Model('gpt-3.5', 0, false),
-  new Model('gpt-4o', 0, false),
-  new Model('gpt-4o-mini', 0, false),
-  new Model('gpt-4o-latest', 0, false),
-  new Model('gpt-5-mini', 0, false),
-  new Model('grok-code-fast', 0, false),
-  new Model('raptor-mini', 0, false),
-
-  // Premium models with multipliers
-  new Model('gpt-5', 1, true),
-  new Model('gpt-5.0', 1, true),
-  new Model('gpt-5.1', 1, true),
-  new Model('gpt-5.2', 1, true),
-  new Model('gpt-5.4', 1, true),
-  new Model('gpt-5.5', 7.5, true),
-  new Model('gpt-5.3-codex', 1, true),
-  new Model('gpt-5-codex', 1, true),
-  new Model('gpt-5.2-codex', 1, true),
-  new Model('gpt-5.1-codex', 1, true),
-  new Model('gpt-5.1-codex-max', 1, true),
-  new Model('gpt-5.1-codex-mini', 0.33, true),
-  new Model('gpt-5.4-mini', 0.33, true),
-  new Model('gpt-5.4-nano', 0.25, true),
-  new Model('grok-code-fast-1', 0.25, true),
-  new Model('o3', 1, true),
-  new Model('o3-mini', 0.33, true),
-  new Model('o4-mini', 0.33, true),
-  new Model('claude-3.5-sonnet', 1, true),
-  new Model('claude-3.7-sonnet', 1, true),
-  new Model('claude-3.7-sonnet-thought', 1.25, true),
-  new Model('claude-4.0-sonnet', 1, true),
-  new Model('claude-4.5-sonnet', 1, true),
-  new Model('claude-4.6-sonnet', 1, true),
-  new Model('claude-opus-4', 10, true),
-  new Model('claude-opus-4.1', 10, true),
-  new Model('claude-opus-4.5', 3, true),
-  new Model('claude-opus-4.6', 3, true),
-  new Model('claude-opus-4.7', 15, true),
-  new Model('claude-opus-4.8', 15, true),
-  new Model('claude-opus-4.6-fast-mode', 30, true),
-  new Model('claude-opus-4.6-fast-mode-preview', 30, true),
-  new Model('claude-4.5-haiku', 0.33, true),
-  new Model('claude-haiku-4.5', 0.33, true),
-  new Model('claude-sonnet-4', 1, true),
-  new Model('claude-sonnet-4.5', 1, true),
-  new Model('claude-sonnet-4.6', 1, true),
-  new Model('gemini-2.0-flash', 0.25, true),
-  new Model('gemini-2.5-pro', 1, true),
-  new Model('gemini-3.0-pro', 1, true),
-  new Model('gemini-3.1-pro', 1, true),
-  new Model('gemini-3.0-flash', 0.33, true),
-  new Model('gemini-3-flash', 0.33, true),
-  new Model('gemini-3.5-flash', 14, true),
-
-  new Model('auto', 0.7, true), // a temp hack for auto premium models, we don't know the actual model behind it yet.
-
-  // Default multiplier for unknown models
-  new Model('unknown', 1, true),
+  new Model('goldeneye'),
+  new Model('gpt-4.0'),
+  new Model('gpt-4.1'),
+  new Model('gpt-3.5'),
+  new Model('gpt-4o'),
+  new Model('gpt-4o-mini'),
+  new Model('gpt-4o-latest'),
+  new Model('gpt-5-mini'),
+  new Model('grok-code-fast'),
+  new Model('raptor-mini'),
+  new Model('gpt-5'),
+  new Model('gpt-5.0'),
+  new Model('gpt-5.1'),
+  new Model('gpt-5.2'),
+  new Model('gpt-5.4'),
+  new Model('gpt-5.5'),
+  new Model('gpt-5.3-codex'),
+  new Model('gpt-5-codex'),
+  new Model('gpt-5.2-codex'),
+  new Model('gpt-5.1-codex'),
+  new Model('gpt-5.1-codex-max'),
+  new Model('gpt-5.1-codex-mini'),
+  new Model('gpt-5.4-mini'),
+  new Model('gpt-5.4-nano'),
+  new Model('grok-code-fast-1'),
+  new Model('o3'),
+  new Model('o3-mini'),
+  new Model('o4-mini'),
+  new Model('claude-3.5-sonnet'),
+  new Model('claude-3.7-sonnet'),
+  new Model('claude-3.7-sonnet-thought'),
+  new Model('claude-4.0-sonnet'),
+  new Model('claude-4.5-sonnet'),
+  new Model('claude-4.6-sonnet'),
+  new Model('claude-opus-4'),
+  new Model('claude-opus-4.1'),
+  new Model('claude-opus-4.5'),
+  new Model('claude-opus-4.6'),
+  new Model('claude-opus-4.7'),
+  new Model('claude-opus-4.8'),
+  new Model('claude-opus-4.6-fast-mode'),
+  new Model('claude-opus-4.6-fast-mode-preview'),
+  new Model('claude-4.5-haiku'),
+  new Model('claude-haiku-4.5'),
+  new Model('claude-sonnet-4'),
+  new Model('claude-sonnet-4.5'),
+  new Model('claude-sonnet-4.6'),
+  new Model('gemini-2.0-flash'),
+  new Model('gemini-2.5-pro'),
+  new Model('gemini-3.0-pro'),
+  new Model('gemini-3.1-pro'),
+  new Model('gemini-3.0-flash'),
+  new Model('gemini-3-flash'),
+  new Model('gemini-3.5-flash'),
+  new Model('auto'),
+  new Model('unknown'),
 ];
 
-/**
- * Multiplier map keyed by model name for quick lookups.
- */
-export const MODEL_MULTIPLIERS: Record<string, number> = KNOWN_MODELS.reduce(
-  (acc, model) => {
-    acc[normalizeModelName(model.name)] = model.multiplier;
-    return acc;
-  },
-  {} as Record<string, number>
+const UNKNOWN_MODEL_NAME = 'unknown';
+
+const KNOWN_MODEL_NAMES = new Set(
+  KNOWN_MODELS.map(model => normalizeModelName(model.name))
 );
-
-const UNKNOWN_MULTIPLIER = MODEL_MULTIPLIERS['unknown'] ?? 1;
-
-/**
- * Resolve the PRU multiplier for a model name using exact or partial matching.
- */
-export function getModelMultiplier(modelName: string): number {
-  const normalized = normalizeModelName(modelName);
-
-  if (!normalized) {
-    return UNKNOWN_MULTIPLIER;
-  }
-
-  if (normalized in MODEL_MULTIPLIERS) {
-    return MODEL_MULTIPLIERS[normalized];
-  }
-
-  const bestPartialMatch = Object.entries(MODEL_MULTIPLIERS).reduce<[string, number] | undefined>(
-    (best, [key, multiplier]) => {
-      if (key === 'unknown' || !normalized.includes(key)) return best;
-      if (!best || key.length > best[0].length) return [key, multiplier];
-      return best;
-    },
-    undefined
-  );
-
-  if (bestPartialMatch) {
-    return bestPartialMatch[1];
-  }
-
-  return UNKNOWN_MULTIPLIER;
-}
-
-/**
- * Determine if a model should be treated as premium (incurs PRU consumption beyond included tier).
- * Uses the canonical KNOWN_MODELS list. Unknown models inherit the flag from the 'unknown' entry.
- */
-export type ModelBucket = 'premium' | 'standard' | 'unknown';
-
-export function classifyModelBucket(modelName: string): ModelBucket {
-  const normalized = normalizeModelName(modelName);
-  if (normalized === 'unknown' || normalized === '') return 'unknown';
-  return getModelMultiplier(normalized) === 0 ? 'standard' : 'premium';
-}
 
 export interface ModelRequestClassification {
   normalizedModel: string;
-  bucket: ModelBucket;
+  isUnknown: boolean;
+  isKnownModel: boolean;
+}
+
+export function isUnknownModelName(modelName: string): boolean {
+  const normalized = normalizeModelName(modelName);
+  return normalized === '' || normalized === UNKNOWN_MODEL_NAME;
+}
+
+export function isKnownModelName(modelName: string): boolean {
+  const normalized = normalizeModelName(modelName);
+  return normalized !== '' && KNOWN_MODEL_NAMES.has(normalized);
 }
 
 export function classifyModelRequest(modelName: string): ModelRequestClassification {
   const normalizedModel = normalizeModelName(modelName);
   return {
     normalizedModel,
-    bucket: classifyModelBucket(normalizedModel),
+    isUnknown: isUnknownModelName(normalizedModel),
+    isKnownModel: isKnownModelName(normalizedModel),
   };
-}
-
-export function isPremiumModel(modelName: string): boolean {
-  const normalized = normalizeModelName(modelName);
-  // Exact match first
-  const direct = KNOWN_MODELS.find(m => normalizeModelName(m.name) === normalized);
-  if (direct) return direct.isPremium;
-  // Partial match fallback (mirrors multiplier resolution logic, excluding 'unknown')
-  for (const model of KNOWN_MODELS) {
-    if (normalizeModelName(model.name) === 'unknown') continue;
-    if (normalized.includes(normalizeModelName(model.name))) {
-      return model.isPremium;
-    }
-  }
-  // Fallback to 'unknown' model's premium flag
-  const unknown = KNOWN_MODELS.find(m => normalizeModelName(m.name) === 'unknown');
-  return unknown ? unknown.isPremium : true;
 }


### PR DESCRIPTION
## Why

This change completes Stage 8 of the usage-based billing cleanup by removing legacy PRU multiplier and premium/base model semantics after Stage 7 eliminated bucketed aggregation consumers. It keeps the model catalog focused on normalization, known-model recognition, and explicit unknown/empty model detection for neutral aggregation.

| Commit | Change |
|--------|--------|
| `refactor: simplify model config classification` | Removes multiplier and premium bucket APIs, updates aggregation callers to use neutral unknown detection, and rewrites related tests/docs around the remaining model normalization contract. |
| `fix: avoid repeated model normalization` | Addresses review feedback by computing model request metadata from the already-normalized model key inside aggregation hot paths. |
| `fix: keep unknown model flags exclusive` | Addresses review feedback by keeping `unknown` out of known-model matches and coercing empty CLI model labels to `unknown`. |
