### PR TITLE
feat: surface AI adoption phase

### DIFF
--- a/src/components/UniqueUsersView.tsx
+++ b/src/components/UniqueUsersView.tsx
@@ -100,7 +100,7 @@ export default function UniqueUsersView({ users, onUserClick }: UniqueUsersViewP
     {
       id: 'ai_adoption_phase',
       header: 'AI ADOPTION',
-      headerClassName: `${headerRightClass} w-1/8`,
+      headerClassName: `${headerRightClass} w-[12.5%]`,
       className: 'px-6 py-4 whitespace-nowrap text-right',
       renderCell: (user) => (
         <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-purple-100 text-purple-800">

--- a/src/components/UniqueUsersView.tsx
+++ b/src/components/UniqueUsersView.tsx
@@ -3,6 +3,7 @@
 import type { UserSummary } from '../types/metrics';
 import { useUsernameTrieSearch } from '../hooks/useUsernameTrieSearch';
 import { useSortableTable } from '../hooks/useSortableTable';
+import { formatAiAdoptionPhase } from '../utils/formatters';
 import { ViewPanel } from './ui';
 import DashboardStatsCard from './ui/DashboardStatsCard';
 import StatsGrid from './ui/StatsGrid';
@@ -95,6 +96,17 @@ export default function UniqueUsersView({ users, onUserClick }: UniqueUsersViewP
       accessor: 'days_active',
       headerClassName: `${headerRightClass} w-1/8`,
       className: valueCellClass,
+    },
+    {
+      id: 'ai_adoption_phase',
+      header: 'AI ADOPTION',
+      headerClassName: `${headerRightClass} w-1/8`,
+      className: 'px-6 py-4 whitespace-nowrap text-right',
+      renderCell: (user) => (
+        <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-purple-100 text-purple-800">
+          {formatAiAdoptionPhase(user.ai_adoption_phase)}
+        </span>
+      ),
     },
     {
       id: 'features_used',

--- a/src/components/UserDetailsView.tsx
+++ b/src/components/UserDetailsView.tsx
@@ -5,7 +5,7 @@ import type { UserSummary, UserDayData } from '../types/metrics';
 import type { UserDetailedMetrics } from '../types/aggregatedMetrics';
 import { translateFeature } from '../domain/featureTranslations';
 import { formatIDEName } from './icons/IDEIcons';
-import { formatShortDate, generateDateRange } from '../utils/formatters';
+import { formatAiAdoptionPhase, formatShortDate, generateDateRange } from '../utils/formatters';
 import { padSeriesWithDefaults } from '../utils/timeSeries';
 import ClientActivityChart from './charts/ClientActivityChart';
 import CLISessionChart from './charts/CLISessionChart';
@@ -130,6 +130,7 @@ export default function UserDetailsView({ userDetails, userSummary, userLogin, u
 
   const totalCliPrompts = userDetails.days.reduce((sum, day) => sum + (day.totals_by_cli?.prompt_count ?? 0), 0);
   const daysActive = userSummary.days_active;
+  const aiAdoptionPhaseLabel = formatAiAdoptionPhase(userSummary.ai_adoption_phase);
   const usedAgent = userSummary.used_agent;
   const usedChat = userSummary.used_chat;
   const usedCli = userSummary.used_cli;
@@ -522,7 +523,11 @@ export default function UserDetailsView({ userDetails, userSummary, userLogin, u
               </li>
             </ol>
           </nav>
-          <p className="mt-1 text-sm text-gray-600">User ID: {userId}</p>
+          <p className="mt-1 flex flex-wrap items-center gap-2 text-sm text-gray-600">
+            <span>User ID: {userId}</span>
+            <span aria-hidden="true" className="text-gray-300">•</span>
+            <span>AI adoption phase: {aiAdoptionPhaseLabel}</span>
+          </p>
         </div>
       )}
       contentClassName="space-y-8"

--- a/src/domain/__tests__/metricsAggregator.test.ts
+++ b/src/domain/__tests__/metricsAggregator.test.ts
@@ -134,6 +134,35 @@ describe('metricsAggregator', () => {
       expect(summaries.find(u => u.user_id === 4)?.used_auto_mode).toBe(true);
     });
 
+    it('should keep the latest AI adoption phase per user', () => {
+      const earlierPhase = createBasicMetric({
+        user_id: 123,
+        day: '2024-01-15',
+        ai_adoption_phase: {
+          phase_number: 1,
+          phase: 'Phase 1',
+          version: 'v1',
+        },
+      });
+      const laterPhase = createBasicMetric({
+        user_id: 123,
+        day: '2024-01-16',
+        ai_adoption_phase: {
+          phase_number: 2,
+          phase: 'Phase 2',
+          version: 'v1',
+        },
+      });
+
+      const { aggregated } = aggregateMetrics([earlierPhase, laterPhase]);
+
+      expect(aggregated.userSummaries[0].ai_adoption_phase).toEqual({
+        phase_number: 2,
+        phase: 'Phase 2',
+        version: 'v1',
+      });
+    });
+
     it('should accumulate user flags across multiple days (OR logic)', () => {
       // User uses chat on day 1, agent on day 2
       const day1 = createBasicMetric({

--- a/src/domain/__tests__/metricsParser.test.ts
+++ b/src/domain/__tests__/metricsParser.test.ts
@@ -26,6 +26,11 @@ describe('metricsParser', () => {
         totals_by_model_feature: [],
         used_agent: false,
         used_chat: true,
+        ai_adoption_phase: {
+          phase_number: 2,
+          phase: 'Phase 2',
+          version: 'v1',
+        },
       });
 
       const result = parseMetricsLine(validLine);
@@ -37,6 +42,11 @@ describe('metricsParser', () => {
       expect(result?.loc_deleted_sum).toBe(20);
       expect(result?.loc_suggested_to_add_sum).toBe(150);
       expect(result?.loc_suggested_to_delete_sum).toBe(30);
+      expect(result?.ai_adoption_phase).toEqual({
+        phase_number: 2,
+        phase: 'Phase 2',
+        version: 'v1',
+      });
     });
 
     it('should reject deprecated schema with old LOC fields at root level', () => {

--- a/src/domain/metricsAggregator.ts
+++ b/src/domain/metricsAggregator.ts
@@ -134,12 +134,14 @@ export interface AggregatedMetrics {
 interface UserSummaryAccumulator {
   userMap: Map<number, UserSummary>;
   userActiveDays: Map<number, Set<string>>;
+  userAiAdoptionPhaseDays: Map<number, string>;
 }
 
 function createUserSummaryAccumulator(): UserSummaryAccumulator {
   return {
     userMap: new Map(),
     userActiveDays: new Map(),
+    userAiAdoptionPhaseDays: new Map(),
   };
 }
 
@@ -189,6 +191,13 @@ function accumulateUserSummary(
   userSummary.used_cli = userSummary.used_cli || metric.used_cli;
   userSummary.used_copilot_coding_agent = userSummary.used_copilot_coding_agent || usedCopilotCloudAgent;
   userSummary.used_auto_mode = userSummary.used_auto_mode || hasAutoModeActivity(metric);
+  if (metric.ai_adoption_phase) {
+    const latestPhaseDay = accumulator.userAiAdoptionPhaseDays.get(userId);
+    if (!latestPhaseDay || metric.day >= latestPhaseDay) {
+      userSummary.ai_adoption_phase = { ...metric.ai_adoption_phase };
+      accumulator.userAiAdoptionPhaseDays.set(userId, metric.day);
+    }
+  }
   accumulator.userActiveDays.get(userId)!.add(date);
 }
 

--- a/src/types/metrics.ts
+++ b/src/types/metrics.ts
@@ -1,3 +1,9 @@
+export interface AIAdoptionPhase {
+  phase_number: number;
+  phase: string;
+  version: string;
+}
+
 export interface CopilotMetrics {
   report_start_day: string;
   report_end_day: string;
@@ -76,6 +82,7 @@ export interface CopilotMetrics {
   used_cli: boolean;
   used_copilot_coding_agent: boolean;
   used_copilot_cloud_agent?: boolean;
+  ai_adoption_phase?: AIAdoptionPhase;
   totals_by_cli?: {
     session_count: number;
     request_count: number;
@@ -123,6 +130,7 @@ export interface UserSummary {
   used_cli: boolean;
   used_copilot_coding_agent: boolean;
   used_auto_mode?: boolean;
+  ai_adoption_phase?: AIAdoptionPhase;
 }
 
 // ==========================================

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -1,6 +1,7 @@
 /**
  * Centralized formatting utilities for consistent display across the application.
  */
+import type { AIAdoptionPhase } from '../types/metrics';
 
 /**
  * Format a date string for display.
@@ -150,6 +151,11 @@ export function truncateString(str: string, maxLength: number): string {
 export function formatModelDisplayName(modelName: string): string {
   if (!modelName || modelName === 'unknown') return 'Unknown Model';
   return modelName.charAt(0).toUpperCase() + modelName.slice(1).replace(/-/g, ' ');
+}
+
+export function formatAiAdoptionPhase(aiAdoptionPhase?: AIAdoptionPhase): string {
+  if (!aiAdoptionPhase) return 'N/A';
+  return aiAdoptionPhase.phase || `Phase ${aiAdoptionPhase.phase_number}`;
 }
 
 export function generateDateRange(startDay: string, endDay: string): string[] {


### PR DESCRIPTION
## Why

Copilot usage metrics now include AI adoption phase data, and the user-level views should expose that signal alongside each user. This helps reviewers and users see the current adoption phase in both the users table and the individual user detail header.

| Commit | Change |
|--------|--------|
| `feat: surface AI adoption phase` | Adds AI adoption phase typing, latest-per-user aggregation, display formatting, users table column, user detail header metadata, and coverage for parsing and aggregation. |