### PR TITLE
Remodel day details modal: Clients/Impact cards and feature breakdown

### DIFF
--- a/src/components/charts/DayClientDistributionChart.tsx
+++ b/src/components/charts/DayClientDistributionChart.tsx
@@ -1,0 +1,84 @@
+'use client';
+
+import React from 'react';
+import { Doughnut } from 'react-chartjs-2';
+import type { TooltipItem } from 'chart.js';
+import { registerChartJS } from './utils/chartSetup';
+import { createDoughnutChartOptions } from './utils/chartOptions';
+import { createDoughnutDataset } from './utils/chartStyles';
+import { getIdeColor, hasIdeColor, ideColors } from './utils/chartColors';
+import ChartContainer from '../ui/ChartContainer';
+import { formatIDEName } from '../icons/IDEIcons';
+import { sortBySelector } from '../../utils/sorting';
+import type { UserDayData } from '../../types/metrics';
+
+registerChartJS();
+
+interface DayClientDistributionChartProps {
+  dayMetrics: UserDayData;
+  cliInteractionCount: number;
+}
+
+export default function DayClientDistributionChart({ dayMetrics, cliInteractionCount }: DayClientDistributionChartProps) {
+  const sorted = sortBySelector(
+    dayMetrics.totals_by_ide.filter((ide) => ide.user_initiated_interaction_count > 0),
+    (ide) => ide.user_initiated_interaction_count,
+    'desc'
+  );
+  const hasCliActivity = cliInteractionCount > 0;
+  const hasData = sorted.length > 0 || hasCliActivity;
+
+  const labels = [
+    ...sorted.map((ide) => formatIDEName(ide.ide)),
+    ...(hasCliActivity ? ['Copilot CLI'] : []),
+  ];
+
+  const dataValues = [
+    ...sorted.map((ide) => ide.user_initiated_interaction_count),
+    ...(hasCliActivity ? [cliInteractionCount] : []),
+  ];
+
+  let fallbackIndex = 0;
+  const backgroundColors = [
+    ...sorted.map((ide) => {
+      const color = getIdeColor(ide.ide, fallbackIndex);
+      if (!hasIdeColor(ide.ide)) {
+        fallbackIndex += 1;
+      }
+      return color;
+    }),
+    ...(hasCliActivity ? [ideColors['copilot_cli']] : []),
+  ];
+
+  const totalInteractions = dataValues.reduce((sum, v) => sum + v, 0);
+
+  const chartData = {
+    labels,
+    datasets: [
+      createDoughnutDataset(dataValues, backgroundColors),
+    ],
+  };
+
+  const options = createDoughnutChartOptions({
+    tooltipLabelCallback: (context: TooltipItem<'doughnut'>) => {
+      const value = context.parsed;
+      const percentage = totalInteractions > 0
+        ? ((value / totalInteractions) * 100).toFixed(1)
+        : '0.0';
+      return `${context.label}: ${value.toLocaleString()} interactions (${percentage}%)`;
+    },
+  });
+
+  return (
+    <ChartContainer
+      title="Clients"
+      description="Share of interactions across clients on this day."
+      chartHeight="h-64"
+      className="h-full"
+      isEmpty={!hasData}
+      emptyState="No client activity recorded"
+    >
+      <Doughnut data={chartData} options={options} />
+    </ChartContainer>
+  );
+}

--- a/src/components/ui/DayDetailsModal.tsx
+++ b/src/components/ui/DayDetailsModal.tsx
@@ -3,9 +3,11 @@
 import React from 'react';
 import type { UserDayData } from '../../types/metrics';
 import { computeCliDayTotals } from '../../domain/calculators/cliUsageCalculator';
-import { translateFeature } from '../../domain/featureTranslations';
 import { formatIDEName } from '../icons/IDEIcons';
 import MetricsTable, { type TableColumn } from './MetricsTable';
+import DayImpactCard from './DayImpactCard';
+import DayFeatureBreakdown from './DayFeatureBreakdown';
+import DayClientDistributionChart from '../charts/DayClientDistributionChart';
 import type { VoidCallback } from '../../types/events';
 
 interface DayDetailsModalProps {
@@ -16,10 +18,7 @@ interface DayDetailsModalProps {
   userLogin?: string;
 }
 
-type FeatureRow = UserDayData['totals_by_feature'][number];
-type LanguageFeatureRow = UserDayData['totals_by_language_feature'][number];
 type LanguageModelRow = UserDayData['totals_by_language_model'][number];
-type ModelFeatureRow = UserDayData['totals_by_model_feature'][number];
 
 interface ClientRow {
   name: string;
@@ -36,15 +35,6 @@ const cellRight = 'px-4 py-3 text-sm text-gray-900 text-right';
 const headerLeft = 'px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider';
 const headerRight = 'px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider';
 
-const featureColumns: TableColumn<FeatureRow>[] = [
-  { id: 'feature', header: 'Feature', headerClassName: headerLeft, className: cellLeft, renderCell: (r) => translateFeature(r.feature) },
-  { id: 'interactions', header: 'Interactions', headerClassName: headerRight, className: cellRight, renderCell: (r) => r.user_initiated_interaction_count.toLocaleString() },
-  { id: 'generation', header: 'Generation', headerClassName: headerRight, className: cellRight, renderCell: (r) => r.code_generation_activity_count.toLocaleString() },
-  { id: 'acceptance', header: 'Acceptance', headerClassName: headerRight, className: cellRight, renderCell: (r) => r.code_acceptance_activity_count.toLocaleString() },
-  { id: 'locAdded', header: 'LOC Added', headerClassName: headerRight, className: cellRight, renderCell: (r) => r.loc_added_sum.toLocaleString() },
-  { id: 'locDeleted', header: 'LOC Deleted', headerClassName: headerRight, className: cellRight, renderCell: (r) => r.loc_deleted_sum.toLocaleString() },
-];
-
 const clientColumns: TableColumn<ClientRow>[] = [
   { id: 'name', header: 'Client', headerClassName: headerLeft, className: cellLeft, renderCell: (r) => r.name },
   { id: 'interactions', header: 'Interactions', headerClassName: headerRight, className: cellRight, renderCell: (r) => r.user_initiated_interaction_count.toLocaleString() },
@@ -55,15 +45,6 @@ const clientColumns: TableColumn<ClientRow>[] = [
   { id: 'pluginVersion', header: 'Plugin Version', headerClassName: headerRight, className: cellRight, renderCell: (r) => r.plugin_version },
 ];
 
-const languageFeatureColumns: TableColumn<LanguageFeatureRow>[] = [
-  { id: 'language', header: 'Language', headerClassName: headerLeft, className: cellLeft, renderCell: (r) => r.language || 'Unknown' },
-  { id: 'feature', header: 'Feature', headerClassName: headerLeft, className: 'px-4 py-3 text-sm text-gray-900', renderCell: (r) => translateFeature(r.feature) },
-  { id: 'generation', header: 'Generation', headerClassName: headerRight, className: cellRight, renderCell: (r) => r.code_generation_activity_count.toLocaleString() },
-  { id: 'acceptance', header: 'Acceptance', headerClassName: headerRight, className: cellRight, renderCell: (r) => r.code_acceptance_activity_count.toLocaleString() },
-  { id: 'locAdded', header: 'LOC Added', headerClassName: headerRight, className: cellRight, renderCell: (r) => r.loc_added_sum.toLocaleString() },
-  { id: 'locDeleted', header: 'LOC Deleted', headerClassName: headerRight, className: cellRight, renderCell: (r) => r.loc_deleted_sum.toLocaleString() },
-];
-
 const languageModelColumns: TableColumn<LanguageModelRow>[] = [
   { id: 'language', header: 'Language', headerClassName: headerLeft, className: cellLeft, renderCell: (r) => r.language || 'Unknown' },
   { id: 'model', header: 'Model', headerClassName: headerLeft, className: 'px-4 py-3 text-sm text-gray-900', renderCell: (r) => r.model || 'Unknown' },
@@ -71,15 +52,6 @@ const languageModelColumns: TableColumn<LanguageModelRow>[] = [
   { id: 'acceptance', header: 'Acceptance', headerClassName: headerRight, className: cellRight, renderCell: (r) => r.code_acceptance_activity_count.toLocaleString() },
   { id: 'locAdded', header: 'LOC Added', headerClassName: headerRight, className: cellRight, renderCell: (r) => r.loc_added_sum.toLocaleString() },
   { id: 'locDeleted', header: 'LOC Deleted', headerClassName: headerRight, className: cellRight, renderCell: (r) => r.loc_deleted_sum.toLocaleString() },
-];
-
-const modelFeatureColumns: TableColumn<ModelFeatureRow>[] = [
-  { id: 'model', header: 'Model', headerClassName: headerLeft, className: cellLeft, renderCell: (r) => r.model || 'Unknown' },
-  { id: 'feature', header: 'Feature', headerClassName: headerLeft, className: 'px-4 py-3 text-sm text-gray-900', renderCell: (r) => translateFeature(r.feature) },
-  { id: 'interactions', header: 'Interactions', headerClassName: headerRight, className: cellRight, renderCell: (r) => r.user_initiated_interaction_count.toLocaleString() },
-  { id: 'generation', header: 'Generation', headerClassName: headerRight, className: cellRight, renderCell: (r) => r.code_generation_activity_count.toLocaleString() },
-  { id: 'acceptance', header: 'Acceptance', headerClassName: headerRight, className: cellRight, renderCell: (r) => r.code_acceptance_activity_count.toLocaleString() },
-  { id: 'locAdded', header: 'LOC Added', headerClassName: headerRight, className: cellRight, renderCell: (r) => r.loc_added_sum.toLocaleString() },
 ];
 
 export default function DayDetailsModal({ isOpen, onClose, date, dayMetrics, userLogin }: DayDetailsModalProps) {
@@ -133,7 +105,7 @@ export default function DayDetailsModal({ isOpen, onClose, date, dayMetrics, use
             <h2 className="text-xl font-bold text-gray-900">{formatDate(date)}</h2>
             {hasData && userLogin && (
               <p className="text-sm text-gray-600 mt-1">
-                Activity Details • User: {userLogin}
+                User: {userLogin}
               </p>
             )}
           </div>
@@ -161,47 +133,26 @@ export default function DayDetailsModal({ isOpen, onClose, date, dayMetrics, use
             </div>
           ) : (
             <div className="space-y-6">
-              {/* Summary Stats */}
-              <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-                <div className="bg-blue-50 rounded-lg p-4">
-                  <div className="text-2xl font-bold text-blue-600">
-                    {(dayMetrics.user_initiated_interaction_count + cliInteractionCount).toLocaleString()}
-                  </div>
-                  <div className="text-sm font-medium text-blue-800">Interactions</div>
-                </div>
-                <div className="bg-green-50 rounded-lg p-4">
-                  <div className="text-2xl font-bold text-green-600">
-                    {dayMetrics.code_generation_activity_count.toLocaleString()}
-                  </div>
-                  <div className="text-sm font-medium text-green-800">Code Generation</div>
-                </div>
-                <div className="bg-purple-50 rounded-lg p-4">
-                  <div className="text-2xl font-bold text-purple-600">
-                    {dayMetrics.code_acceptance_activity_count.toLocaleString()}
-                  </div>
-                  <div className="text-sm font-medium text-purple-800">Code Acceptance</div>
-                </div>
-                <div className="bg-orange-50 rounded-lg p-4">
-                  <div className="text-2xl font-bold text-orange-600">
-                    {(dayMetrics.loc_added_sum + dayMetrics.loc_deleted_sum).toLocaleString()}
-                  </div>
-                  <div className="text-sm font-medium text-orange-800">Total LOC Changed</div>
-                </div>
+              {/* Clients & Impact cards */}
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4 items-stretch">
+                <DayClientDistributionChart
+                  dayMetrics={dayMetrics}
+                  cliInteractionCount={cliInteractionCount}
+                />
+                <DayImpactCard
+                  locAdded={dayMetrics.loc_added_sum}
+                  locDeleted={dayMetrics.loc_deleted_sum}
+                />
               </div>
 
               {/* Features Section */}
               <div className="bg-white rounded-md border border-[#d1d9e0] p-6">
-                <h4 className="text-lg font-semibold text-gray-900 mb-4">Activity by Feature</h4>
-                <MetricsTable
-                  data={dayMetrics.totals_by_feature}
-                  columns={featureColumns}
-                  tableClassName="w-full divide-y divide-gray-200"
-                  tableContainerClassName="overflow-x-auto"
-                  theadClassName="bg-gray-50"
-                  tbodyClassName="bg-white divide-y divide-gray-200"
-                  rowClassName={() => 'hover:bg-gray-50'}
-                  getRowKey={(_, idx) => idx}
-                  initialCount={5}
+                <h4 className="text-lg font-semibold text-gray-900 mb-1">Activity by Feature</h4>
+                <p className="text-sm text-gray-600 mb-4">Expand a feature to see the languages and models used.</p>
+                <DayFeatureBreakdown
+                  totalsByFeature={dayMetrics.totals_by_feature}
+                  totalsByLanguageFeature={dayMetrics.totals_by_language_feature}
+                  totalsByModelFeature={dayMetrics.totals_by_model_feature}
                 />
               </div>
 
@@ -221,44 +172,12 @@ export default function DayDetailsModal({ isOpen, onClose, date, dayMetrics, use
                 />
               </div>
 
-              {/* Language + Feature Section */}
-              <div className="bg-white rounded-md border border-[#d1d9e0] p-6">
-                <h4 className="text-lg font-semibold text-gray-900 mb-4">Activity by Language &amp; Feature</h4>
-                <MetricsTable
-                  data={dayMetrics.totals_by_language_feature}
-                  columns={languageFeatureColumns}
-                  tableClassName="w-full divide-y divide-gray-200"
-                  tableContainerClassName="overflow-x-auto"
-                  theadClassName="bg-gray-50"
-                  tbodyClassName="bg-white divide-y divide-gray-200"
-                  rowClassName={() => 'hover:bg-gray-50'}
-                  getRowKey={(_, idx) => idx}
-                  initialCount={10}
-                />
-              </div>
-
               {/* Language + Model Section */}
               <div className="bg-white rounded-md border border-[#d1d9e0] p-6">
                 <h4 className="text-lg font-semibold text-gray-900 mb-4">Activity by Language &amp; Model</h4>
                 <MetricsTable
                   data={dayMetrics.totals_by_language_model}
                   columns={languageModelColumns}
-                  tableClassName="w-full divide-y divide-gray-200"
-                  tableContainerClassName="overflow-x-auto"
-                  theadClassName="bg-gray-50"
-                  tbodyClassName="bg-white divide-y divide-gray-200"
-                  rowClassName={() => 'hover:bg-gray-50'}
-                  getRowKey={(_, idx) => idx}
-                  initialCount={10}
-                />
-              </div>
-
-              {/* Model + Feature Section */}
-              <div className="bg-white rounded-md border border-[#d1d9e0] p-6">
-                <h4 className="text-lg font-semibold text-gray-900 mb-4">Activity by Model &amp; Feature</h4>
-                <MetricsTable
-                  data={dayMetrics.totals_by_model_feature}
-                  columns={modelFeatureColumns}
                   tableClassName="w-full divide-y divide-gray-200"
                   tableContainerClassName="overflow-x-auto"
                   theadClassName="bg-gray-50"

--- a/src/components/ui/DayFeatureBreakdown.tsx
+++ b/src/components/ui/DayFeatureBreakdown.tsx
@@ -1,0 +1,167 @@
+'use client';
+
+import React, { useId, useState } from 'react';
+import type { UserDayData } from '../../types/metrics';
+import { translateFeature } from '../../domain/featureTranslations';
+
+type FeatureRow = UserDayData['totals_by_feature'][number];
+type LanguageFeatureRow = UserDayData['totals_by_language_feature'][number];
+type ModelFeatureRow = UserDayData['totals_by_model_feature'][number];
+
+interface DayFeatureBreakdownProps {
+  totalsByFeature: FeatureRow[];
+  totalsByLanguageFeature: LanguageFeatureRow[];
+  totalsByModelFeature: ModelFeatureRow[];
+}
+
+interface BreakdownItem {
+  name: string;
+  generation: number;
+  acceptance: number;
+  locAdded: number;
+  locDeleted: number;
+}
+
+function fmt(value: number): string {
+  return value.toLocaleString();
+}
+
+function MetricChip({ label, value, valueClassName }: { label: string; value: string; valueClassName?: string }) {
+  return (
+    <span className="inline-flex items-baseline gap-1 whitespace-nowrap text-xs">
+      <span className="text-gray-500">{label}</span>
+      <span className={`font-semibold ${valueClassName ?? 'text-gray-900'}`}>{value}</span>
+    </span>
+  );
+}
+
+function BreakdownList({ title, items }: { title: string; items: BreakdownItem[] }) {
+  return (
+    <div>
+      <h5 className="text-xs font-semibold uppercase tracking-wider text-gray-500 mb-2">{title}</h5>
+      {items.length === 0 ? (
+        <p className="text-sm text-gray-400">No data</p>
+      ) : (
+        <ul className="space-y-2">
+          {items.map((item) => (
+            <li key={item.name} className="flex items-center justify-between gap-3">
+              <span className="text-sm font-medium text-gray-900 truncate">{item.name}</span>
+              <span className="flex items-center gap-3 whitespace-nowrap text-xs text-gray-600">
+                <span>Gen {fmt(item.generation)}</span>
+                <span>Acc {fmt(item.acceptance)}</span>
+                <span>
+                  <span className="text-green-600">+{fmt(item.locAdded)}</span>
+                  {' / '}
+                  <span className="text-red-600">-{fmt(item.locDeleted)}</span>
+                </span>
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+function FeatureCard({
+  feature,
+  languages,
+  models,
+}: {
+  feature: FeatureRow;
+  languages: BreakdownItem[];
+  models: BreakdownItem[];
+}) {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const contentId = useId();
+
+  return (
+    <div className="border border-[#d1d9e0] rounded-md overflow-hidden">
+      <button
+        type="button"
+        onClick={() => setIsExpanded((prev) => !prev)}
+        className="flex items-center justify-between w-full gap-4 px-4 py-3 bg-gray-50 hover:bg-gray-100 transition-colors"
+        aria-expanded={isExpanded}
+        aria-controls={contentId}
+      >
+        <span className="flex items-center gap-2 min-w-0">
+          <svg
+            className={`w-4 h-4 flex-shrink-0 text-gray-500 transition-transform duration-200 ${isExpanded ? 'rotate-90' : ''}`}
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+          </svg>
+          <span className="text-sm font-semibold text-gray-900 truncate">{translateFeature(feature.feature)}</span>
+        </span>
+        <span className="flex items-center gap-4">
+          <MetricChip label="Interactions" value={fmt(feature.user_initiated_interaction_count)} />
+          <MetricChip label="Gen" value={fmt(feature.code_generation_activity_count)} />
+          <MetricChip label="Acc" value={fmt(feature.code_acceptance_activity_count)} />
+          <MetricChip label="LOC" value={`+${fmt(feature.loc_added_sum)} / -${fmt(feature.loc_deleted_sum)}`} />
+        </span>
+      </button>
+
+      {isExpanded && (
+        <div id={contentId} className="grid grid-cols-1 md:grid-cols-2 gap-6 px-4 py-4 bg-white">
+          <BreakdownList title="Languages" items={languages} />
+          <BreakdownList title="Models" items={models} />
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function DayFeatureBreakdown({
+  totalsByFeature,
+  totalsByLanguageFeature,
+  totalsByModelFeature,
+}: DayFeatureBreakdownProps) {
+  const features = [...totalsByFeature].sort(
+    (a, b) =>
+      b.user_initiated_interaction_count - a.user_initiated_interaction_count ||
+      b.code_generation_activity_count - a.code_generation_activity_count
+  );
+
+  const languagesFor = (feature: string): BreakdownItem[] =>
+    totalsByLanguageFeature
+      .filter((row) => row.feature === feature)
+      .map((row) => ({
+        name: row.language || 'Unknown',
+        generation: row.code_generation_activity_count,
+        acceptance: row.code_acceptance_activity_count,
+        locAdded: row.loc_added_sum,
+        locDeleted: row.loc_deleted_sum,
+      }))
+      .sort((a, b) => b.generation - a.generation || b.acceptance - a.acceptance);
+
+  const modelsFor = (feature: string): BreakdownItem[] =>
+    totalsByModelFeature
+      .filter((row) => row.feature === feature)
+      .map((row) => ({
+        name: row.model || 'Unknown',
+        generation: row.code_generation_activity_count,
+        acceptance: row.code_acceptance_activity_count,
+        locAdded: row.loc_added_sum,
+        locDeleted: row.loc_deleted_sum,
+      }))
+      .sort((a, b) => b.generation - a.generation || b.acceptance - a.acceptance);
+
+  if (features.length === 0) {
+    return <p className="text-sm text-gray-400">No feature activity recorded</p>;
+  }
+
+  return (
+    <div className="space-y-3">
+      {features.map((feature) => (
+        <FeatureCard
+          key={feature.feature}
+          feature={feature}
+          languages={languagesFor(feature.feature)}
+          models={modelsFor(feature.feature)}
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/components/ui/DayFeatureBreakdown.tsx
+++ b/src/components/ui/DayFeatureBreakdown.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useId, useState } from 'react';
+import React, { useId, useMemo, useState } from 'react';
 import type { UserDayData } from '../../types/metrics';
 import { translateFeature } from '../../domain/featureTranslations';
 
@@ -90,6 +90,8 @@ function FeatureCard({
             fill="none"
             stroke="currentColor"
             viewBox="0 0 24 24"
+            aria-hidden="true"
+            focusable="false"
           >
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
           </svg>
@@ -118,35 +120,53 @@ export default function DayFeatureBreakdown({
   totalsByLanguageFeature,
   totalsByModelFeature,
 }: DayFeatureBreakdownProps) {
-  const features = [...totalsByFeature].sort(
-    (a, b) =>
-      b.user_initiated_interaction_count - a.user_initiated_interaction_count ||
-      b.code_generation_activity_count - a.code_generation_activity_count
+  const features = useMemo(
+    () =>
+      [...totalsByFeature].sort(
+        (a, b) =>
+          b.user_initiated_interaction_count - a.user_initiated_interaction_count ||
+          b.code_generation_activity_count - a.code_generation_activity_count
+      ),
+    [totalsByFeature]
   );
 
-  const languagesFor = (feature: string): BreakdownItem[] =>
-    totalsByLanguageFeature
-      .filter((row) => row.feature === feature)
-      .map((row) => ({
+  const languagesByFeature = useMemo(() => {
+    const map = new Map<string, BreakdownItem[]>();
+    for (const row of totalsByLanguageFeature) {
+      const list = map.get(row.feature) ?? [];
+      list.push({
         name: row.language || 'Unknown',
         generation: row.code_generation_activity_count,
         acceptance: row.code_acceptance_activity_count,
         locAdded: row.loc_added_sum,
         locDeleted: row.loc_deleted_sum,
-      }))
-      .sort((a, b) => b.generation - a.generation || b.acceptance - a.acceptance);
+      });
+      map.set(row.feature, list);
+    }
+    for (const list of map.values()) {
+      list.sort((a, b) => b.generation - a.generation || b.acceptance - a.acceptance);
+    }
+    return map;
+  }, [totalsByLanguageFeature]);
 
-  const modelsFor = (feature: string): BreakdownItem[] =>
-    totalsByModelFeature
-      .filter((row) => row.feature === feature)
-      .map((row) => ({
+  const modelsByFeature = useMemo(() => {
+    const map = new Map<string, BreakdownItem[]>();
+    for (const row of totalsByModelFeature) {
+      const list = map.get(row.feature) ?? [];
+      list.push({
         name: row.model || 'Unknown',
         generation: row.code_generation_activity_count,
         acceptance: row.code_acceptance_activity_count,
         locAdded: row.loc_added_sum,
         locDeleted: row.loc_deleted_sum,
-      }))
-      .sort((a, b) => b.generation - a.generation || b.acceptance - a.acceptance);
+      });
+      map.set(row.feature, list);
+    }
+    for (const list of map.values()) {
+      list.sort((a, b) => b.generation - a.generation || b.acceptance - a.acceptance);
+    }
+    return map;
+  }, [totalsByModelFeature]);
 
   if (features.length === 0) {
     return <p className="text-sm text-gray-400">No feature activity recorded</p>;
@@ -158,8 +178,8 @@ export default function DayFeatureBreakdown({
         <FeatureCard
           key={feature.feature}
           feature={feature}
-          languages={languagesFor(feature.feature)}
-          models={modelsFor(feature.feature)}
+          languages={languagesByFeature.get(feature.feature) ?? []}
+          models={modelsByFeature.get(feature.feature) ?? []}
         />
       ))}
     </div>

--- a/src/components/ui/DayImpactCard.tsx
+++ b/src/components/ui/DayImpactCard.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import React from 'react';
+
+interface DayImpactCardProps {
+  locAdded: number;
+  locDeleted: number;
+}
+
+interface ImpactRow {
+  label: string;
+  value: number;
+  valueClassName: string;
+  barClassName: string;
+}
+
+export default function DayImpactCard({ locAdded, locDeleted }: DayImpactCardProps) {
+  const net = locAdded - locDeleted;
+  const max = Math.max(locAdded, locDeleted, Math.abs(net), 1);
+
+  const rows: ImpactRow[] = [
+    { label: 'LOC Added', value: locAdded, valueClassName: 'text-green-600', barClassName: 'bg-green-500' },
+    { label: 'LOC Deleted', value: locDeleted, valueClassName: 'text-red-600', barClassName: 'bg-red-500' },
+    {
+      label: 'Net LOC',
+      value: net,
+      valueClassName: net >= 0 ? 'text-blue-600' : 'text-orange-600',
+      barClassName: net >= 0 ? 'bg-blue-500' : 'bg-orange-500',
+    },
+  ];
+
+  return (
+    <div className="h-full bg-white rounded-md border border-[#d1d9e0] p-6 flex flex-col">
+      <h3 className="text-lg font-semibold text-gray-900 mb-2">Impact</h3>
+      <p className="text-sm text-gray-600 mb-6">Lines of code kept from accepted suggestions.</p>
+      <div className="flex flex-1 flex-col justify-center gap-6">
+        {rows.map((row) => (
+          <div key={row.label}>
+            <div className="flex items-baseline justify-between mb-2">
+              <span className="text-sm font-medium text-gray-700">{row.label}</span>
+              <span className={`text-2xl font-bold ${row.valueClassName}`}>
+                {row.value.toLocaleString()}
+              </span>
+            </div>
+            <div className="h-2 w-full rounded-full bg-gray-100 overflow-hidden">
+              <div
+                className={`h-full rounded-full ${row.barClassName}`}
+                style={{ width: `${(Math.abs(row.value) / max) * 100}%` }}
+              />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/DayImpactCard.tsx
+++ b/src/components/ui/DayImpactCard.tsx
@@ -32,7 +32,7 @@ export default function DayImpactCard({ locAdded, locDeleted }: DayImpactCardPro
   return (
     <div className="h-full bg-white rounded-md border border-[#d1d9e0] p-6 flex flex-col">
       <h3 className="text-lg font-semibold text-gray-900 mb-2">Impact</h3>
-      <p className="text-sm text-gray-600 mb-6">Lines of code kept from accepted suggestions.</p>
+      <p className="text-sm text-gray-600 mb-6">Lines of code added and deleted from accepted suggestions.</p>
       <div className="flex flex-1 flex-col justify-center gap-6">
         {rows.map((row) => (
           <div key={row.label}>


### PR DESCRIPTION
## Why

The day details modal had grown into a stack of five flat tables plus a row of colored "info tile" stat cards, a UI pattern we are moving away from. The language/model/feature data was spread across three separate tables, making it hard to answer a simple question like "for this feature, which languages and models were used?"

## What changed

**New cards under the header**
- **Clients** card: a doughnut chart showing the share of interactions across clients (IDEs + Copilot CLI) for the day, reusing the shared chart utilities and IDE brand colors.
- **Impact** card: LOC added, deleted, and net, each with a proportional bar.

These sit as two equal-height, side-by-side cards.

**Feature-centric breakdown**
The separate Activity by Feature, Language & Feature, and Model & Feature tables are merged into one expandable list. Each feature is a collapsible row showing its aggregate metrics; expanding it reveals the Languages and Models used for that feature side by side.

**Trimmed chrome**
- Removed the four colored summary info tiles.
- Header subtext reduced to just `User: {login}` (dropped "Activity Details").

## Notes for reviewers

- Activity by Language & Model is kept as a standalone table because it has no feature dimension to merge on.
- In this single-user, single-day context the Clients pie distributes by interactions, since the org-wide "unique users" metric used elsewhere does not apply here.
- Verified with `npm run lint` and `npm run test:run` (481 tests passing). The full `npm run build` was skipped locally because the dev server task holds the worker build; CI will cover it.