### PR TITLE
Improve activity calendar: month context and relative log-scaled shading

### DIFF
--- a/src/components/UserDetailsView.tsx
+++ b/src/components/UserDetailsView.tsx
@@ -538,7 +538,8 @@ export default function UserDetailsView({ userDetails, userSummary, userLogin, u
             days={userDetails.days}
             reportStartDay={userDetails.reportStartDay}
             reportEndDay={userDetails.reportEndDay}
-            title={`Activity Calendar (${daysActive} active ${daysActive === 1 ? 'day' : 'days'})`}
+            title="Activity Calendar"
+            activeDaysCount={daysActive}
             onDayClick={handleDayClick}
           />
         </div>

--- a/src/components/ui/ActivityCalendar.tsx
+++ b/src/components/ui/ActivityCalendar.tsx
@@ -8,12 +8,24 @@ interface ActivityCalendarProps {
   reportStartDay: string;
   reportEndDay: string;
   title?: string;
+  activeDaysCount?: number;
   onDayClick: (date: string, dayData?: UserDayData) => void;
 }
 
-export default function ActivityCalendar({ days, reportStartDay, reportEndDay, title = 'Activity Calendar', onDayClick }: ActivityCalendarProps) {
+export default function ActivityCalendar({ days, reportStartDay, reportEndDay, title = 'Activity Calendar', activeDaysCount, onDayClick }: ActivityCalendarProps) {
   const startDate = new Date(reportStartDay);
   const endDate = new Date(reportEndDay);
+
+  const spansMultipleYears = startDate.getFullYear() !== endDate.getFullYear();
+  const monthNameOptions: Intl.DateTimeFormatOptions = spansMultipleYears
+    ? { month: 'long', year: 'numeric' }
+    : { month: 'long' };
+  const sameMonth =
+    startDate.getFullYear() === endDate.getFullYear() &&
+    startDate.getMonth() === endDate.getMonth();
+  const monthLabel = sameMonth
+    ? startDate.toLocaleDateString('en-US', monthNameOptions)
+    : `${startDate.toLocaleDateString('en-US', monthNameOptions)} – ${endDate.toLocaleDateString('en-US', monthNameOptions)}`;
 
   const metricsMap = new Map<string, UserDayData>();
   days.forEach(day => {
@@ -63,36 +75,58 @@ export default function ActivityCalendar({ days, reportStartDay, reportEndDay, t
 
   const weeks = groupDatesByWeek(allDates);
   const dayNames = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+
+  const monthKey = (date: Date) => `${date.getFullYear()}-${date.getMonth()}`;
+  const orderedMonths = Array.from(new Set(allDates.map(monthKey)));
+  const hasMultipleMonths = orderedMonths.length > 1;
+  const monthTints = [
+    'bg-slate-50',
+    'bg-sky-50',
+    'bg-amber-50',
+    'bg-rose-50',
+    'bg-emerald-50',
+    'bg-violet-50',
+  ];
+  const getMonthTint = (date: Date) => {
+    if (!hasMultipleMonths || date.getTime() === 0) return 'bg-transparent';
+    const index = orderedMonths.indexOf(monthKey(date));
+    return monthTints[index % monthTints.length];
+  };
   
   const formatDateKey = (date: Date) => {
     if (date.getTime() === 0) return ''; // Placeholder date
     return date.toISOString().split('T')[0];
   };
 
+  const getDayTotal = (metrics: UserDayData) =>
+    metrics.user_initiated_interaction_count +
+    metrics.code_generation_activity_count +
+    metrics.code_acceptance_activity_count +
+    (metrics.totals_by_cli?.prompt_count ?? 0);
+
+  // Color intensity is relative to this user's busiest day, on a log scale so
+  // that large ranges (e.g. 900 vs 10000) still map to distinct shades.
+  const maxDailyTotal = days.reduce((max, day) => Math.max(max, getDayTotal(day)), 0);
+
   const getActivityLevel = (dateKey: string) => {
     const metrics = metricsMap.get(dateKey);
     if (!metrics) return 0;
-    
-    const totalActivity = metrics.user_initiated_interaction_count + 
-                         metrics.code_generation_activity_count + 
-                         metrics.code_acceptance_activity_count +
-                         (metrics.totals_by_cli?.prompt_count ?? 0);
-    
-    if (totalActivity === 0) return 0;
-    if (totalActivity <= 5) return 1;
-    if (totalActivity <= 20) return 2;
-    if (totalActivity <= 50) return 3;
-    return 4;
+
+    const totalActivity = getDayTotal(metrics);
+    if (totalActivity <= 0 || maxDailyTotal <= 0) return 0;
+
+    const ratio = Math.log(totalActivity + 1) / Math.log(maxDailyTotal + 1);
+    return Math.min(4, Math.max(1, Math.ceil(ratio * 4)));
   };
 
   const getActivityColor = (level: number) => {
     switch (level) {
-      case 0: return 'bg-gray-100 hover:bg-gray-200';
-      case 1: return 'bg-green-100 hover:bg-green-200';
-      case 2: return 'bg-green-300 hover:bg-green-400';
-      case 3: return 'bg-green-500 hover:bg-green-600';
-      case 4: return 'bg-green-700 hover:bg-green-800';
-      default: return 'bg-gray-100 hover:bg-gray-200';
+      case 0: return 'bg-green-100 hover:bg-green-200';
+      case 1: return 'bg-green-200 hover:bg-green-300';
+      case 2: return 'bg-green-400 hover:bg-green-500';
+      case 3: return 'bg-green-600 hover:bg-green-700';
+      case 4: return 'bg-green-800 hover:bg-green-900';
+      default: return 'bg-green-100 hover:bg-green-200';
     }
   };
 
@@ -106,11 +140,19 @@ export default function ActivityCalendar({ days, reportStartDay, reportEndDay, t
 
   return (
     <div className="bg-white rounded-md border border-[#d1d9e0] p-6">
-      <h3 className="text-lg font-semibold text-gray-900 mb-4">{title}</h3>
+      <h3 className="text-lg font-semibold text-gray-900 mb-4">
+        {title}
+        <span className="ml-2">{monthLabel}</span>
+        {activeDaysCount !== undefined && (
+          <span className="ml-2 text-sm font-normal text-gray-500">
+            · {activeDaysCount} active {activeDaysCount === 1 ? 'day' : 'days'}
+          </span>
+        )}
+      </h3>
       
       <div className="space-y-2">
         {/* Day headers */}
-        <div className="grid grid-cols-7 gap-1 mb-2">
+        <div className="grid grid-cols-7">
           {dayNames.map(day => (
             <div key={day} className="text-xs font-medium text-gray-500 text-center p-1">
               {day}
@@ -119,25 +161,27 @@ export default function ActivityCalendar({ days, reportStartDay, reportEndDay, t
         </div>
         
         {/* Calendar grid */}
-        <div className="border-t border-gray-300">
+        <div className="border-l border-t border-gray-300">
           {weeks.map((week, weekIndex) => (
-            <div key={weekIndex} className="grid grid-cols-7 gap-1 border-b border-gray-300 py-0.5">
+            <div key={weekIndex} className="grid grid-cols-7">
               {week.map((date, dayIndex) => {
                 const dateKey = formatDateKey(date);
                 const activityLevel = getActivityLevel(dateKey);
                 const isPlaceholder = date.getTime() === 0;
                 const hasData = metricsMap.has(dateKey);
+                const isMonthStart = !isPlaceholder && hasMultipleMonths && date.getDate() === 1;
                 
                 return (
                   <div
                     key={`${weekIndex}-${dayIndex}`}
                     className={`
-                      w-16 h-8 rounded text-xs flex items-center justify-center border
+                      h-8 text-xs flex items-center justify-center border-r border-b border-gray-300
+                      ${isMonthStart ? 'border-l-4 border-l-gray-800 font-semibold' : ''}
                       ${isPlaceholder 
-                        ? 'border-transparent' 
+                        ? 'bg-white' 
                         : hasData 
-                          ? `${getActivityColor(activityLevel)} border-gray-300 cursor-pointer transition-colors`
-                          : 'bg-gray-50 border-gray-200 cursor-default'
+                          ? `${getActivityColor(activityLevel)} cursor-pointer transition-colors`
+                          : `${getMonthTint(date)} cursor-default`
                       }
                     `}
                     onClick={() => !isPlaceholder && handleDayClick(date)}
@@ -149,7 +193,9 @@ export default function ActivityCalendar({ days, reportStartDay, reportEndDay, t
                         : undefined
                     }
                   >
-                    {!isPlaceholder && date.getDate()}
+                    {isMonthStart
+                      ? `${date.toLocaleDateString('en-US', { month: 'short' })} 1`
+                      : !isPlaceholder && date.getDate()}
                   </div>
                 );
               })}
@@ -161,10 +207,11 @@ export default function ActivityCalendar({ days, reportStartDay, reportEndDay, t
         <div className="flex items-center justify-end space-x-1 text-xs text-gray-500 mt-2">
           <span>Less activity</span>
           <div className="flex space-x-1 mx-2">
-            <div className="w-3 h-3 bg-gray-100 rounded-sm border"></div>
+            <div className="w-3 h-3 bg-green-100 rounded-sm border border-green-200"></div>
             <div className="w-3 h-3 bg-green-200 rounded-sm"></div>
             <div className="w-3 h-3 bg-green-400 rounded-sm"></div>
             <div className="w-3 h-3 bg-green-600 rounded-sm"></div>
+            <div className="w-3 h-3 bg-green-800 rounded-sm"></div>
           </div>
           <span>More activity</span>
         </div>

--- a/src/components/ui/ActivityCalendar.tsx
+++ b/src/components/ui/ActivityCalendar.tsx
@@ -16,13 +16,13 @@ export default function ActivityCalendar({ days, reportStartDay, reportEndDay, t
   const startDate = new Date(reportStartDay);
   const endDate = new Date(reportEndDay);
 
-  const spansMultipleYears = startDate.getFullYear() !== endDate.getFullYear();
+  const spansMultipleYears = startDate.getUTCFullYear() !== endDate.getUTCFullYear();
   const monthNameOptions: Intl.DateTimeFormatOptions = spansMultipleYears
-    ? { month: 'long', year: 'numeric' }
-    : { month: 'long' };
+    ? { month: 'long', year: 'numeric', timeZone: 'UTC' }
+    : { month: 'long', timeZone: 'UTC' };
   const sameMonth =
-    startDate.getFullYear() === endDate.getFullYear() &&
-    startDate.getMonth() === endDate.getMonth();
+    startDate.getUTCFullYear() === endDate.getUTCFullYear() &&
+    startDate.getUTCMonth() === endDate.getUTCMonth();
   const monthLabel = sameMonth
     ? startDate.toLocaleDateString('en-US', monthNameOptions)
     : `${startDate.toLocaleDateString('en-US', monthNameOptions)} – ${endDate.toLocaleDateString('en-US', monthNameOptions)}`;
@@ -38,7 +38,7 @@ export default function ActivityCalendar({ days, reportStartDay, reportEndDay, t
     
     while (current <= endDate) {
       dates.push(new Date(current));
-      current.setDate(current.getDate() + 1);
+      current.setUTCDate(current.getUTCDate() + 1);
     }
     
     return dates;
@@ -76,7 +76,7 @@ export default function ActivityCalendar({ days, reportStartDay, reportEndDay, t
   const weeks = groupDatesByWeek(allDates);
   const dayNames = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
 
-  const monthKey = (date: Date) => `${date.getFullYear()}-${date.getMonth()}`;
+  const monthKey = (date: Date) => `${date.getUTCFullYear()}-${date.getUTCMonth()}`;
   const orderedMonths = Array.from(new Set(allDates.map(monthKey)));
   const hasMultipleMonths = orderedMonths.length > 1;
   const monthTints = [
@@ -169,7 +169,7 @@ export default function ActivityCalendar({ days, reportStartDay, reportEndDay, t
                 const activityLevel = getActivityLevel(dateKey);
                 const isPlaceholder = date.getTime() === 0;
                 const hasData = metricsMap.has(dateKey);
-                const isMonthStart = !isPlaceholder && hasMultipleMonths && date.getDate() === 1;
+                const isMonthStart = !isPlaceholder && hasMultipleMonths && date.getUTCDate() === 1;
                 
                 return (
                   <div
@@ -194,8 +194,8 @@ export default function ActivityCalendar({ days, reportStartDay, reportEndDay, t
                     }
                   >
                     {isMonthStart
-                      ? `${date.toLocaleDateString('en-US', { month: 'short' })} 1`
-                      : !isPlaceholder && date.getDate()}
+                      ? `${date.toLocaleDateString('en-US', { month: 'short', timeZone: 'UTC' })} 1`
+                      : !isPlaceholder && date.getUTCDate()}
                   </div>
                 );
               })}


### PR DESCRIPTION
## Why

The user activity calendar was hard to read in two ways: when a date range spanned multiple months there was no indication of where one month ended and the next began, and the color scale used fixed absolute thresholds that capped at `> 50`, so every heavy day saturated to the darkest green (a day with 900 looked identical to a day with 10,000).

## What changed

**Month context**
- The heading now shows the month name(s) next to the active-days count: a single name within one month, or `May - June` when the range spans months (year is added when it crosses years).
- No-data cells are tinted per month, and each new month is marked with a bold `Mon 1` label plus a thick left divider so the switch stays visible even when a user is active on most days.

**Grid styling**
- Removed the gaps between cells and added full grid lines (vertical and horizontal) for a cleaner calendar look.

**Color scale**
- The whole activity scale is now shades of green (the gray bucket is gone), so any day that has data reads as active.
- Intensity is now computed relative to the user's busiest day in the range, on a log scale: `level = ceil( ln(total+1) / ln(max+1) * 4 )`, clamped to 1-4. This keeps large ranges distinct (e.g. 900 vs 10,000 now land on different shades) and is robust to a single outlier day. Divide-by-zero edge cases (all-zero or single active day) are guarded.

## Notes for reviewers
- The per-day "total activity" definition is unchanged (sum of `user_initiated_interaction_count`, `code_generation_activity_count`, `code_acceptance_activity_count`, and CLI `prompt_count`). Only the bucketing rule changed from absolute thresholds to relative log scaling.
- `UserDetailsView` now passes `activeDaysCount` as a prop instead of baking it into the title string.
- Shading is relative per user, so the legend's "less / more activity" is now relative to that user's peak day rather than a fixed scale.

Build, lint, and the full test suite (481 tests) pass.