### PR TITLE
Add advanced adoption charts

### DIFF
--- a/src/components/CopilotAdoptionView.tsx
+++ b/src/components/CopilotAdoptionView.tsx
@@ -4,9 +4,16 @@ import React from 'react';
 import FeatureAdoptionChart from './charts/FeatureAdoptionChart';
 import AgentModeHeatmapChart from './charts/AgentModeHeatmapChart';
 import AdoptionTrendChart from './charts/AdoptionTrendChart';
+import CloudAgentAdoptionChart from './charts/CloudAgentAdoptionChart';
+import CodeReviewAdoptionChart from './charts/CodeReviewAdoptionChart';
 import { ViewPanel } from './ui';
-import type { FeatureAdoptionData, AgentModeHeatmapData } from '../domain/calculators/metricCalculators';
-import type { DailyAdoptionTrend } from '../domain/calculators/metricCalculators';
+import type {
+  FeatureAdoptionData,
+  AgentModeHeatmapData,
+  DailyAdoptionTrend,
+  DailyCloudAgentAdoptionData,
+  DailyCodeReviewAdoptionData,
+} from '../domain/calculators/metricCalculators';
 import type { MetricsStats } from '../types/metrics';
 
 interface CopilotAdoptionViewProps {
@@ -14,9 +21,37 @@ interface CopilotAdoptionViewProps {
   agentModeHeatmapData: AgentModeHeatmapData[];
   stats: MetricsStats;
   dailyAdoptionTrend: DailyAdoptionTrend[];
+  dailyCloudAgentAdoptionData?: DailyCloudAgentAdoptionData[];
+  dailyCodeReviewAdoptionData?: DailyCodeReviewAdoptionData[];
 }
 
-export default function CopilotAdoptionView({ featureAdoptionData, agentModeHeatmapData, stats, dailyAdoptionTrend }: CopilotAdoptionViewProps) {
+const EMPTY_FEATURE_ADOPTION_DATA: FeatureAdoptionData = {
+  totalUsers: 0,
+  completionUsers: 0,
+  completionOnlyUsers: 0,
+  chatUsers: 0,
+  agentModeUsers: 0,
+  askModeUsers: 0,
+  inlineModeUsers: 0,
+  planModeUsers: 0,
+  cliUsers: 0,
+  codingAgentUsers: 0,
+  codeReviewUsers: 0,
+  advancedUsers: 0,
+};
+
+export default function CopilotAdoptionView({
+  featureAdoptionData,
+  agentModeHeatmapData,
+  stats,
+  dailyAdoptionTrend,
+  dailyCloudAgentAdoptionData = [],
+  dailyCodeReviewAdoptionData = [],
+}: CopilotAdoptionViewProps) {
+  const adoptionData = featureAdoptionData ?? EMPTY_FEATURE_ADOPTION_DATA;
+  const hasCloudAgentAdoption = adoptionData.codingAgentUsers > 0;
+  const hasCodeReviewAdoption = adoptionData.codeReviewUsers > 0;
+
   return (
     <ViewPanel
       headerProps={{
@@ -26,24 +61,23 @@ export default function CopilotAdoptionView({ featureAdoptionData, agentModeHeat
       contentClassName="space-y-10"
     >
       <FeatureAdoptionChart
-        data={
-          featureAdoptionData || {
-            totalUsers: 0,
-            completionUsers: 0,
-            completionOnlyUsers: 0,
-            chatUsers: 0,
-            agentModeUsers: 0,
-            askModeUsers: 0,
-            inlineModeUsers: 0,
-            planModeUsers: 0,
-            cliUsers: 0,
-            codingAgentUsers: 0,
-            codeReviewUsers: 0,
-            advancedUsers: 0,
-          }
-        }
+        data={adoptionData}
       />
       <AgentModeHeatmapChart data={agentModeHeatmapData || []} />
+      {hasCloudAgentAdoption && (
+        <CloudAgentAdoptionChart
+          data={dailyCloudAgentAdoptionData}
+          reportStartDay={stats.reportStartDay}
+          reportEndDay={stats.reportEndDay}
+        />
+      )}
+      {hasCodeReviewAdoption && (
+        <CodeReviewAdoptionChart
+          data={dailyCodeReviewAdoptionData}
+          reportStartDay={stats.reportStartDay}
+          reportEndDay={stats.reportEndDay}
+        />
+      )}
       <AdoptionTrendChart
         data={dailyAdoptionTrend}
         reportStartDay={stats.reportStartDay}

--- a/src/components/charts/CloudAgentAdoptionChart.tsx
+++ b/src/components/charts/CloudAgentAdoptionChart.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+import { Bar } from 'react-chartjs-2';
+import type { ChartOptions } from 'chart.js';
+import { useMemo } from 'react';
+import { registerChartJS } from './utils/chartSetup';
+import { createBaseChartOptions } from './utils/chartOptions';
+import { createBarDataset } from './utils/chartStyles';
+import { chartColors } from './utils/chartColors';
+import { formatShortDate, generateDateRange } from '../../utils/formatters';
+import type { DailyCloudAgentAdoptionData } from '../../domain/calculators/metricCalculators';
+import ChartContainer from '../ui/ChartContainer';
+
+registerChartJS();
+
+interface CloudAgentAdoptionChartProps {
+  data: DailyCloudAgentAdoptionData[];
+  reportStartDay: string;
+  reportEndDay: string;
+}
+
+function padCloudAgentAdoptionData(
+  data: DailyCloudAgentAdoptionData[],
+  reportStartDay: string,
+  reportEndDay: string
+): DailyCloudAgentAdoptionData[] {
+  const dataByDate = new Map(data.map(day => [day.date, day]));
+
+  return generateDateRange(reportStartDay, reportEndDay).map(date => ({
+    date,
+    uniqueUsers: dataByDate.get(date)?.uniqueUsers ?? 0,
+  }));
+}
+
+export default function CloudAgentAdoptionChart({
+  data,
+  reportStartDay,
+  reportEndDay,
+}: CloudAgentAdoptionChartProps) {
+  const paddedData = useMemo(
+    () => padCloudAgentAdoptionData(data, reportStartDay, reportEndDay),
+    [data, reportStartDay, reportEndDay]
+  );
+  const peakDailyUsers = data.reduce((peak, day) => Math.max(peak, day.uniqueUsers), 0);
+  const userDays = data.reduce((sum, day) => sum + day.uniqueUsers, 0);
+
+  const chartData = {
+    labels: paddedData.map(day => formatShortDate(day.date)),
+    datasets: [
+      createBarDataset(
+        chartColors.teal.solid,
+        'Cloud Agent users',
+        paddedData.map(day => day.uniqueUsers)
+      ),
+    ],
+  };
+
+  const options = createBaseChartOptions({
+    xAxisLabel: 'Date',
+    yAxisLabel: 'Unique Users',
+    yStepSize: 1,
+    xMaxRotation: 45,
+    xAutoSkip: true,
+  }) as ChartOptions<'bar'>;
+
+  return (
+    <ChartContainer
+      title="Cloud Agent Adoption"
+      description="Daily number of unique users using Copilot Cloud Agent."
+      isEmpty={false}
+      summaryStats={[
+        { value: peakDailyUsers.toLocaleString(), label: 'Peak Daily Users' },
+        { value: data.length.toLocaleString(), label: 'Active Days' },
+        { value: userDays.toLocaleString(), label: 'User-days' },
+      ]}
+    >
+      <div className="h-full">
+        <Bar data={chartData} options={options} />
+      </div>
+    </ChartContainer>
+  );
+}

--- a/src/components/charts/CodeReviewAdoptionChart.tsx
+++ b/src/components/charts/CodeReviewAdoptionChart.tsx
@@ -1,0 +1,90 @@
+'use client';
+
+import { Bar } from 'react-chartjs-2';
+import type { ChartOptions } from 'chart.js';
+import { useMemo } from 'react';
+import { registerChartJS } from './utils/chartSetup';
+import { createBaseChartOptions } from './utils/chartOptions';
+import { createBarDataset } from './utils/chartStyles';
+import { chartColors } from './utils/chartColors';
+import { formatShortDate, generateDateRange } from '../../utils/formatters';
+import type { DailyCodeReviewAdoptionData } from '../../domain/calculators/metricCalculators';
+import ChartContainer from '../ui/ChartContainer';
+
+registerChartJS();
+
+interface CodeReviewAdoptionChartProps {
+  data: DailyCodeReviewAdoptionData[];
+  reportStartDay: string;
+  reportEndDay: string;
+}
+
+function padCodeReviewAdoptionData(
+  data: DailyCodeReviewAdoptionData[],
+  reportStartDay: string,
+  reportEndDay: string
+): DailyCodeReviewAdoptionData[] {
+  const dataByDate = new Map(data.map(day => [day.date, day]));
+
+  return generateDateRange(reportStartDay, reportEndDay).map(date => ({
+    date,
+    activeUsers: dataByDate.get(date)?.activeUsers ?? 0,
+    passiveUsers: dataByDate.get(date)?.passiveUsers ?? 0,
+  }));
+}
+
+export default function CodeReviewAdoptionChart({
+  data,
+  reportStartDay,
+  reportEndDay,
+}: CodeReviewAdoptionChartProps) {
+  const paddedData = useMemo(
+    () => padCodeReviewAdoptionData(data, reportStartDay, reportEndDay),
+    [data, reportStartDay, reportEndDay]
+  );
+  const peakActiveUsers = data.reduce((peak, day) => Math.max(peak, day.activeUsers), 0);
+  const peakPassiveUsers = data.reduce((peak, day) => Math.max(peak, day.passiveUsers), 0);
+  const activeUserDays = data.reduce((sum, day) => sum + day.activeUsers, 0);
+  const passiveUserDays = data.reduce((sum, day) => sum + day.passiveUsers, 0);
+
+  const chartData = {
+    labels: paddedData.map(day => formatShortDate(day.date)),
+    datasets: [
+      createBarDataset(
+        chartColors.cyan.solid,
+        'Active CCR users',
+        paddedData.map(day => day.activeUsers)
+      ),
+      createBarDataset(
+        chartColors.indigo.solid,
+        'Passive CCR users',
+        paddedData.map(day => day.passiveUsers)
+      ),
+    ],
+  };
+
+  const options = createBaseChartOptions({
+    xAxisLabel: 'Date',
+    yAxisLabel: 'Unique Users',
+    yStepSize: 1,
+    xMaxRotation: 45,
+    xAutoSkip: true,
+  }) as ChartOptions<'bar'>;
+
+  return (
+    <ChartContainer
+      title="Code Review Adoption"
+      description="Daily number of unique active and passive Copilot Code Review users."
+      isEmpty={false}
+      summaryStats={[
+        { value: peakActiveUsers.toLocaleString(), label: 'Peak Active Users' },
+        { value: peakPassiveUsers.toLocaleString(), label: 'Peak Passive Users' },
+        { value: (activeUserDays + passiveUserDays).toLocaleString(), label: 'CCR User-days' },
+      ]}
+    >
+      <div className="h-full">
+        <Bar data={chartData} options={options} />
+      </div>
+    </ChartContainer>
+  );
+}

--- a/src/components/charts/CodeReviewAdoptionChart.tsx
+++ b/src/components/charts/CodeReviewAdoptionChart.tsx
@@ -19,6 +19,10 @@ interface CodeReviewAdoptionChartProps {
   reportEndDay: string;
 }
 
+function getTotalUsers(day: DailyCodeReviewAdoptionData): number {
+  return day.totalUsers ?? Math.max(day.activeUsers, day.passiveUsers);
+}
+
 function padCodeReviewAdoptionData(
   data: DailyCodeReviewAdoptionData[],
   reportStartDay: string,
@@ -26,11 +30,16 @@ function padCodeReviewAdoptionData(
 ): DailyCodeReviewAdoptionData[] {
   const dataByDate = new Map(data.map(day => [day.date, day]));
 
-  return generateDateRange(reportStartDay, reportEndDay).map(date => ({
-    date,
-    activeUsers: dataByDate.get(date)?.activeUsers ?? 0,
-    passiveUsers: dataByDate.get(date)?.passiveUsers ?? 0,
-  }));
+  return generateDateRange(reportStartDay, reportEndDay).map(date => {
+    const day = dataByDate.get(date);
+
+    return {
+      date,
+      activeUsers: day?.activeUsers ?? 0,
+      passiveUsers: day?.passiveUsers ?? 0,
+      totalUsers: day ? getTotalUsers(day) : 0,
+    };
+  });
 }
 
 export default function CodeReviewAdoptionChart({
@@ -44,8 +53,7 @@ export default function CodeReviewAdoptionChart({
   );
   const peakActiveUsers = data.reduce((peak, day) => Math.max(peak, day.activeUsers), 0);
   const peakPassiveUsers = data.reduce((peak, day) => Math.max(peak, day.passiveUsers), 0);
-  const activeUserDays = data.reduce((sum, day) => sum + day.activeUsers, 0);
-  const passiveUserDays = data.reduce((sum, day) => sum + day.passiveUsers, 0);
+  const totalUserDays = data.reduce((sum, day) => sum + getTotalUsers(day), 0);
 
   const chartData = {
     labels: paddedData.map(day => formatShortDate(day.date)),
@@ -79,7 +87,7 @@ export default function CodeReviewAdoptionChart({
       summaryStats={[
         { value: peakActiveUsers.toLocaleString(), label: 'Peak Active Users' },
         { value: peakPassiveUsers.toLocaleString(), label: 'Peak Passive Users' },
-        { value: (activeUserDays + passiveUserDays).toLocaleString(), label: 'CCR User-days' },
+        { value: totalUserDays.toLocaleString(), label: 'CCR User-days' },
       ]}
     >
       <div className="h-full">

--- a/src/components/layout/ViewRouter.tsx
+++ b/src/components/layout/ViewRouter.tsx
@@ -136,6 +136,8 @@ const ViewRouter: React.FC = () => {
     dailyCliTokenData,
     dailyCliAdoptionTrend,
     dailyAdoptionTrend,
+    dailyCloudAgentAdoptionData = [],
+    dailyCodeReviewAdoptionData = [],
   } = aggregatedMetrics;
 
   switch (currentView) {
@@ -202,6 +204,8 @@ const ViewRouter: React.FC = () => {
           agentModeHeatmapData={agentModeHeatmapData}
           stats={stats}
           dailyAdoptionTrend={dailyAdoptionTrend}
+          dailyCloudAgentAdoptionData={dailyCloudAgentAdoptionData}
+          dailyCodeReviewAdoptionData={dailyCodeReviewAdoptionData}
         />
       );
 

--- a/src/domain/__tests__/metricsAggregator.test.ts
+++ b/src/domain/__tests__/metricsAggregator.test.ts
@@ -682,8 +682,8 @@ describe('metricsAggregator', () => {
         { date: '2024-01-15', uniqueUsers: 2 },
       ]);
       expect(aggregated.dailyCodeReviewAdoptionData).toEqual([
-        { date: '2024-01-15', activeUsers: 1, passiveUsers: 1 },
-        { date: '2024-01-16', activeUsers: 1, passiveUsers: 1 },
+        { date: '2024-01-15', activeUsers: 1, passiveUsers: 1, totalUsers: 2 },
+        { date: '2024-01-16', activeUsers: 1, passiveUsers: 1, totalUsers: 1 },
       ]);
     });
 

--- a/src/domain/__tests__/metricsAggregator.test.ts
+++ b/src/domain/__tests__/metricsAggregator.test.ts
@@ -645,6 +645,48 @@ describe('metricsAggregator', () => {
       expect(aggregated.userSummaries[0].used_copilot_coding_agent).toBe(true);
     });
 
+    it('should aggregate daily Cloud Agent and Code Review adoption users', () => {
+      const day1CloudUser = createBasicMetric({
+        user_id: 1,
+        day: '2024-01-15',
+        used_copilot_cloud_agent: true,
+        used_copilot_code_review_active: true,
+      });
+      const day1SecondCloudUser = createBasicMetric({
+        user_id: 2,
+        day: '2024-01-15',
+        used_copilot_cloud_agent: true,
+        used_copilot_code_review_passive: true,
+      });
+      const day1DuplicateCloudUser = createBasicMetric({
+        user_id: 1,
+        day: '2024-01-15',
+        used_copilot_cloud_agent: true,
+        used_copilot_code_review_active: true,
+      });
+      const day2CodeReviewUser = createBasicMetric({
+        user_id: 3,
+        day: '2024-01-16',
+        used_copilot_code_review_active: true,
+        used_copilot_code_review_passive: true,
+      });
+
+      const { aggregated } = aggregateMetrics([
+        day1CloudUser,
+        day1SecondCloudUser,
+        day1DuplicateCloudUser,
+        day2CodeReviewUser,
+      ]);
+
+      expect(aggregated.dailyCloudAgentAdoptionData).toEqual([
+        { date: '2024-01-15', uniqueUsers: 2 },
+      ]);
+      expect(aggregated.dailyCodeReviewAdoptionData).toEqual([
+        { date: '2024-01-15', activeUsers: 1, passiveUsers: 1 },
+        { date: '2024-01-16', activeUsers: 1, passiveUsers: 1 },
+      ]);
+    });
+
     it('should prefer the new cloud-agent flag over the legacy coding-agent flag', () => {
       const metric = createBasicMetric({
         used_chat: false,

--- a/src/domain/calculators/__tests__/advancedAdoptionCalculator.test.ts
+++ b/src/domain/calculators/__tests__/advancedAdoptionCalculator.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import {
+  accumulateCloudAgentAdoption,
+  accumulateCodeReviewAdoptionSignal,
+  computeDailyCloudAgentAdoptionData,
+  computeDailyCodeReviewAdoptionData,
+  createAdvancedAdoptionAccumulator,
+} from '../advancedAdoptionCalculator';
+
+describe('advancedAdoptionCalculator', () => {
+  it('counts daily unique Cloud Agent users', () => {
+    const accumulator = createAdvancedAdoptionAccumulator();
+
+    accumulateCloudAgentAdoption(accumulator, '2024-01-16', 1, true);
+    accumulateCloudAgentAdoption(accumulator, '2024-01-16', 1, true);
+    accumulateCloudAgentAdoption(accumulator, '2024-01-16', 2, true);
+    accumulateCloudAgentAdoption(accumulator, '2024-01-15', 3, true);
+    accumulateCloudAgentAdoption(accumulator, '2024-01-17', 4, false);
+
+    expect(computeDailyCloudAgentAdoptionData(accumulator)).toEqual([
+      { date: '2024-01-15', uniqueUsers: 1 },
+      { date: '2024-01-16', uniqueUsers: 2 },
+    ]);
+  });
+
+  it('counts daily unique active and passive Code Review users independently', () => {
+    const accumulator = createAdvancedAdoptionAccumulator();
+
+    accumulateCodeReviewAdoptionSignal(accumulator, '2024-01-16', 1, true, false);
+    accumulateCodeReviewAdoptionSignal(accumulator, '2024-01-16', 1, true, false);
+    accumulateCodeReviewAdoptionSignal(accumulator, '2024-01-16', 2, false, true);
+    accumulateCodeReviewAdoptionSignal(accumulator, '2024-01-16', 3, true, true);
+    accumulateCodeReviewAdoptionSignal(accumulator, '2024-01-15', 4, false, true);
+    accumulateCodeReviewAdoptionSignal(accumulator, '2024-01-17', 5, false, false);
+
+    expect(computeDailyCodeReviewAdoptionData(accumulator)).toEqual([
+      { date: '2024-01-15', activeUsers: 0, passiveUsers: 1 },
+      { date: '2024-01-16', activeUsers: 2, passiveUsers: 2 },
+    ]);
+  });
+});

--- a/src/domain/calculators/__tests__/advancedAdoptionCalculator.test.ts
+++ b/src/domain/calculators/__tests__/advancedAdoptionCalculator.test.ts
@@ -34,8 +34,8 @@ describe('advancedAdoptionCalculator', () => {
     accumulateCodeReviewAdoptionSignal(accumulator, '2024-01-17', 5, false, false);
 
     expect(computeDailyCodeReviewAdoptionData(accumulator)).toEqual([
-      { date: '2024-01-15', activeUsers: 0, passiveUsers: 1 },
-      { date: '2024-01-16', activeUsers: 2, passiveUsers: 2 },
+      { date: '2024-01-15', activeUsers: 0, passiveUsers: 1, totalUsers: 1 },
+      { date: '2024-01-16', activeUsers: 2, passiveUsers: 2, totalUsers: 3 },
     ]);
   });
 });

--- a/src/domain/calculators/advancedAdoptionCalculator.ts
+++ b/src/domain/calculators/advancedAdoptionCalculator.ts
@@ -1,0 +1,97 @@
+import { compareByDateAsc } from './statsCalculators';
+
+export interface DailyCloudAgentAdoptionData {
+  date: string;
+  uniqueUsers: number;
+}
+
+export interface DailyCodeReviewAdoptionData {
+  date: string;
+  activeUsers: number;
+  passiveUsers: number;
+}
+
+interface AdvancedAdoptionDay {
+  cloudAgentUsers: Set<number>;
+  codeReviewActiveUsers: Set<number>;
+  codeReviewPassiveUsers: Set<number>;
+}
+
+export interface AdvancedAdoptionAccumulator {
+  dailyAdoption: Map<string, AdvancedAdoptionDay>;
+}
+
+export function createAdvancedAdoptionAccumulator(): AdvancedAdoptionAccumulator {
+  return {
+    dailyAdoption: new Map(),
+  };
+}
+
+function ensureAdvancedAdoptionDate(
+  accumulator: AdvancedAdoptionAccumulator,
+  date: string
+): AdvancedAdoptionDay {
+  if (!accumulator.dailyAdoption.has(date)) {
+    accumulator.dailyAdoption.set(date, {
+      cloudAgentUsers: new Set(),
+      codeReviewActiveUsers: new Set(),
+      codeReviewPassiveUsers: new Set(),
+    });
+  }
+
+  return accumulator.dailyAdoption.get(date)!;
+}
+
+export function accumulateCloudAgentAdoption(
+  accumulator: AdvancedAdoptionAccumulator,
+  date: string,
+  userId: number,
+  usedCloudAgent: boolean
+): void {
+  if (!usedCloudAgent) return;
+
+  ensureAdvancedAdoptionDate(accumulator, date).cloudAgentUsers.add(userId);
+}
+
+export function accumulateCodeReviewAdoptionSignal(
+  accumulator: AdvancedAdoptionAccumulator,
+  date: string,
+  userId: number,
+  usedActiveCodeReview: boolean,
+  usedPassiveCodeReview: boolean
+): void {
+  if (!usedActiveCodeReview && !usedPassiveCodeReview) return;
+
+  const day = ensureAdvancedAdoptionDate(accumulator, date);
+  if (usedActiveCodeReview) {
+    day.codeReviewActiveUsers.add(userId);
+  }
+  if (usedPassiveCodeReview) {
+    day.codeReviewPassiveUsers.add(userId);
+  }
+}
+
+export function computeDailyCloudAgentAdoptionData(
+  accumulator: AdvancedAdoptionAccumulator
+): DailyCloudAgentAdoptionData[] {
+  return Array.from(accumulator.dailyAdoption.entries())
+    .map(([date, day]) => ({
+      date,
+      uniqueUsers: day.cloudAgentUsers.size,
+    }))
+    .filter(day => day.uniqueUsers > 0)
+    .sort(compareByDateAsc);
+}
+
+export function computeDailyCodeReviewAdoptionData(
+  accumulator: AdvancedAdoptionAccumulator
+): DailyCodeReviewAdoptionData[] {
+  return Array.from(accumulator.dailyAdoption.entries())
+    .map(([date, day]) => ({
+      date,
+      activeUsers: day.codeReviewActiveUsers.size,
+      passiveUsers: day.codeReviewPassiveUsers.size,
+    }))
+    .filter(day => day.activeUsers > 0 || day.passiveUsers > 0)
+    .sort(compareByDateAsc);
+}

--- a/src/domain/calculators/advancedAdoptionCalculator.ts
+++ b/src/domain/calculators/advancedAdoptionCalculator.ts
@@ -9,6 +9,7 @@ export interface DailyCodeReviewAdoptionData {
   date: string;
   activeUsers: number;
   passiveUsers: number;
+  totalUsers: number;
 }
 
 interface AdvancedAdoptionDay {
@@ -87,11 +88,19 @@ export function computeDailyCodeReviewAdoptionData(
   accumulator: AdvancedAdoptionAccumulator
 ): DailyCodeReviewAdoptionData[] {
   return Array.from(accumulator.dailyAdoption.entries())
-    .map(([date, day]) => ({
-      date,
-      activeUsers: day.codeReviewActiveUsers.size,
-      passiveUsers: day.codeReviewPassiveUsers.size,
-    }))
+    .map(([date, day]) => {
+      const totalUsers = new Set([
+        ...day.codeReviewActiveUsers,
+        ...day.codeReviewPassiveUsers,
+      ]).size;
+
+      return {
+        date,
+        activeUsers: day.codeReviewActiveUsers.size,
+        passiveUsers: day.codeReviewPassiveUsers.size,
+        totalUsers,
+      };
+    })
     .filter(day => day.activeUsers > 0 || day.passiveUsers > 0)
     .sort(compareByDateAsc);
 }

--- a/src/domain/calculators/index.ts
+++ b/src/domain/calculators/index.ts
@@ -143,4 +143,15 @@ export {
   computeCliAdoptionTrend,
 } from './cliUsageCalculator';
 
+export {
+  type DailyCloudAgentAdoptionData,
+  type DailyCodeReviewAdoptionData,
+  type AdvancedAdoptionAccumulator,
+  createAdvancedAdoptionAccumulator,
+  accumulateCloudAgentAdoption,
+  accumulateCodeReviewAdoptionSignal,
+  computeDailyCloudAgentAdoptionData,
+  computeDailyCodeReviewAdoptionData,
+} from './advancedAdoptionCalculator';
+
 export { compareDatesAsc, compareByDateAsc } from './statsCalculators';

--- a/src/domain/calculators/metricCalculators.ts
+++ b/src/domain/calculators/metricCalculators.ts
@@ -38,6 +38,11 @@ export type {
   DailyCliAdoptionTrend,
 } from './cliUsageCalculator';
 
+export type {
+  DailyCloudAgentAdoptionData,
+  DailyCodeReviewAdoptionData,
+} from './advancedAdoptionCalculator';
+
 export const calculateStats = calculateStatsFromMetrics;
 
 export const calculateDailyModelUsage = calculateDailyModelUsageFromMetrics;

--- a/src/domain/metricsAggregator.ts
+++ b/src/domain/metricsAggregator.ts
@@ -98,6 +98,14 @@ import {
   computeDailyCliSessionData,
   computeDailyCliTokenData,
   computeCliAdoptionTrend,
+
+  DailyCloudAgentAdoptionData,
+  DailyCodeReviewAdoptionData,
+  createAdvancedAdoptionAccumulator,
+  accumulateCloudAgentAdoption,
+  accumulateCodeReviewAdoptionSignal,
+  computeDailyCloudAgentAdoptionData,
+  computeDailyCodeReviewAdoptionData,
 } from './calculators';
 import { isActiveAutoModeFeature } from './autoMode';
 
@@ -130,6 +138,8 @@ export interface AggregatedMetrics {
   dailyCliTokenData: DailyCliTokenData[];
   dailyCliAdoptionTrend: DailyCliAdoptionTrend[];
   dailyAdoptionTrend: DailyAdoptionTrend[];
+  dailyCloudAgentAdoptionData: DailyCloudAgentAdoptionData[];
+  dailyCodeReviewAdoptionData: DailyCodeReviewAdoptionData[];
 }
 
 interface UserSummaryAccumulator {
@@ -251,6 +261,7 @@ export function aggregateMetrics(
   const languageFeatureImpactAccumulator = createLanguageFeatureImpactAccumulator();
   const modelBreakdownAccumulator = createModelBreakdownAccumulator();
   const cliUsageAccumulator = createCliUsageAccumulator();
+  const advancedAdoptionAccumulator = createAdvancedAdoptionAccumulator();
   const userDetailAccumulator = createUserDetailAccumulator();
 
   for (const metric of metrics) {
@@ -330,6 +341,14 @@ export function aggregateMetrics(
       userId,
       (metric.used_copilot_code_review_active ?? false) || (metric.used_copilot_code_review_passive ?? false)
     );
+    accumulateCloudAgentAdoption(advancedAdoptionAccumulator, date, userId, usedCopilotCloudAgent);
+    accumulateCodeReviewAdoptionSignal(
+      advancedAdoptionAccumulator,
+      date,
+      userId,
+      metric.used_copilot_code_review_active ?? false,
+      metric.used_copilot_code_review_passive ?? false
+    );
     accumulateCliUsage(cliUsageAccumulator, date, userId, metric);
 
     for (const feature of metric.totals_by_feature) {
@@ -396,6 +415,8 @@ export function aggregateMetrics(
     dailyCliTokenData: computeDailyCliTokenData(cliUsageAccumulator),
     dailyCliAdoptionTrend: computeCliAdoptionTrend(cliUsageAccumulator),
     dailyAdoptionTrend: computeAdoptionTrend(engagementAccumulator, cliUsageAccumulator),
+    dailyCloudAgentAdoptionData: computeDailyCloudAgentAdoptionData(advancedAdoptionAccumulator),
+    dailyCodeReviewAdoptionData: computeDailyCodeReviewAdoptionData(advancedAdoptionAccumulator),
     },
     userDetailAccumulator,
   };


### PR DESCRIPTION
## Why

The adoption view shows aggregate Cloud Agent and Code Review counts, but reviewers and users need daily visibility into when those advanced features are adopted. This adds daily CCA and CCR adoption charts below the Agent Mode heatmap while preserving empty report dates in the time series.

| Commit | Change |
|--------|--------|
| `feat: add advanced adoption charts` | Adds worker-side daily Cloud Agent and active/passive Code Review user aggregation, renders the charts only when CCA or CCR users exist, and covers the new aggregation with tests. |