### PR TITLE
Improve completion visibility and user table performance

### DIFF
--- a/src/components/UniqueUsersView.tsx
+++ b/src/components/UniqueUsersView.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useEffect, useMemo, useState } from 'react';
 import type { UserSummary } from '../types/metrics';
 import { useUsernameTrieSearch } from '../hooks/useUsernameTrieSearch';
 import { useSortableTable } from '../hooks/useSortableTable';
@@ -15,6 +16,7 @@ interface UniqueUsersViewProps {
 }
 
 type SortField = 'user_login' | 'total_user_initiated_interactions' | 'total_code_generation_activities' | 'days_active' | 'net_loc_contribution' | 'cloud_agent_days' | 'code_review_days';
+const USERS_PER_PAGE = 500;
 
 export default function UniqueUsersView({ users, onUserClick }: UniqueUsersViewProps) {
   const { searchQuery, setSearchQuery, filteredUsers } = useUsernameTrieSearch(users);
@@ -23,10 +25,27 @@ export default function UniqueUsersView({ users, onUserClick }: UniqueUsersViewP
     'total_user_initiated_interactions',
     'desc'
   );
+  const [currentPage, setCurrentPage] = useState(1);
 
   const handleUserClick = (user: UserSummary) => {
     onUserClick(user.user_login, user.user_id);
   };
+
+  const totalPages = Math.max(1, Math.ceil(sortedUsers.length / USERS_PER_PAGE));
+  const pagedUsers = useMemo(() => {
+    const start = (currentPage - 1) * USERS_PER_PAGE;
+    return sortedUsers.slice(start, start + USERS_PER_PAGE);
+  }, [currentPage, sortedUsers]);
+  const pageStart = sortedUsers.length === 0 ? 0 : (currentPage - 1) * USERS_PER_PAGE + 1;
+  const pageEnd = Math.min(currentPage * USERS_PER_PAGE, sortedUsers.length);
+
+  useEffect(() => {
+    setCurrentPage(1);
+  }, [searchQuery, sortField, sortDirection]);
+
+  useEffect(() => {
+    setCurrentPage((page) => Math.min(page, totalPages));
+  }, [totalPages]);
 
   const tableSortState = { field: sortField as string, direction: sortDirection };
 
@@ -208,7 +227,7 @@ export default function UniqueUsersView({ users, onUserClick }: UniqueUsersViewP
         </div>
         <div className="overflow-x-auto border border-gray-200">
           <MetricsTable<UserSummary>
-            data={sortedUsers}
+            data={pagedUsers}
             columns={columns}
             sortState={tableSortState}
             onSortChange={({ field }) => handleSort(field as SortField)}
@@ -218,6 +237,34 @@ export default function UniqueUsersView({ users, onUserClick }: UniqueUsersViewP
             onRowClick={(user) => handleUserClick(user)}
           />
         </div>
+        {sortedUsers.length > USERS_PER_PAGE && (
+          <div className="mt-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <p className="text-sm text-gray-600">
+              Showing {pageStart.toLocaleString()}-{pageEnd.toLocaleString()} of {sortedUsers.length.toLocaleString()} users
+            </p>
+            <div className="flex items-center gap-2">
+              <button
+                type="button"
+                onClick={() => setCurrentPage((page) => Math.max(1, page - 1))}
+                disabled={currentPage === 1}
+                className="px-3 py-1.5 text-sm font-medium text-gray-700 border border-gray-300 rounded-md disabled:cursor-not-allowed disabled:opacity-50 hover:bg-gray-50 disabled:hover:bg-white"
+              >
+                Previous
+              </button>
+              <span className="text-sm text-gray-600">
+                Page {currentPage.toLocaleString()} of {totalPages.toLocaleString()}
+              </span>
+              <button
+                type="button"
+                onClick={() => setCurrentPage((page) => Math.min(totalPages, page + 1))}
+                disabled={currentPage === totalPages}
+                className="px-3 py-1.5 text-sm font-medium text-gray-700 border border-gray-300 rounded-md disabled:cursor-not-allowed disabled:opacity-50 hover:bg-gray-50 disabled:hover:bg-white"
+              >
+                Next
+              </button>
+            </div>
+          </div>
+        )}
 
       {users.length === 0 && (
         <div className="text-center py-8">

--- a/src/components/UniqueUsersView.tsx
+++ b/src/components/UniqueUsersView.tsx
@@ -41,7 +41,7 @@ export default function UniqueUsersView({ users, onUserClick }: UniqueUsersViewP
 
   useEffect(() => {
     setCurrentPage(1);
-  }, [searchQuery, sortField, sortDirection]);
+  }, [searchQuery, sortField, sortDirection, users]);
 
   useEffect(() => {
     setCurrentPage((page) => Math.min(page, totalPages));

--- a/src/components/UserDetailsView.tsx
+++ b/src/components/UserDetailsView.tsx
@@ -25,6 +25,7 @@ import type { ModeImpactData } from '../domain/calculators/metricCalculators';
 import type { TooltipItem } from 'chart.js';
 import { registerChartJS } from './charts/utils/chartSetup';
 import { isActiveAutoModeFeature } from '../domain/autoMode';
+import { getTotalUserInitiatedInteractionCount } from '../domain/assumedInteractions';
 
 registerChartJS();
 
@@ -157,12 +158,12 @@ export default function UserDetailsView({ userDetails, userSummary, userLogin, u
     .reduce((sum, f) => sum + f.user_initiated_interaction_count, 0);
   const completionInteractions = featureAggregates
     .filter(f => f.feature === 'code_completion')
-    .reduce((sum, f) => sum + f.code_acceptance_activity_count, 0);
+    .reduce((sum, f) => sum + getTotalUserInitiatedInteractionCount(f), 0);
   const cliInteractions = totalCliPrompts;
 
   const ideChartData = useMemo(() => {
     const labels = ideAggregates.map(ide => formatIDEName(ide.ide));
-    const data = ideAggregates.map(ide => ide.user_initiated_interaction_count);
+    const data = ideAggregates.map(getTotalUserInitiatedInteractionCount);
 
     if (totalCliPrompts > 0) {
       labels.push('Copilot CLI');
@@ -210,7 +211,7 @@ export default function UserDetailsView({ userDetails, userSummary, userLogin, u
   const { modelInteractions, modelChartData } = useMemo(() => {
     const interactions = modelFeatureAggregates.reduce((acc, item) => {
       if (item.model && item.model !== '') {
-        acc[item.model] = (acc[item.model] || 0) + item.user_initiated_interaction_count;
+        acc[item.model] = (acc[item.model] || 0) + getTotalUserInitiatedInteractionCount(item);
       }
       return acc;
     }, {} as Record<string, number>);
@@ -363,7 +364,7 @@ export default function UserDetailsView({ userDetails, userSummary, userLogin, u
         const dayData = dayMap.get(dayStr);
         const modelData = dayData?.totals_by_model_feature
           .filter(item => item.model === model)
-          .reduce((sum, item) => sum + item.user_initiated_interaction_count, 0) || 0;
+          .reduce((sum, item) => sum + getTotalUserInitiatedInteractionCount(item), 0) || 0;
         return modelData;
       });
 
@@ -685,7 +686,7 @@ export default function UserDetailsView({ userDetails, userSummary, userLogin, u
               {featureAggregates.map((feature) => (
                 <tr key={feature.feature}>
                   <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">{translateFeature(feature.feature)}</td>
-                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 text-right">{feature.user_initiated_interaction_count.toLocaleString()}</td>
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 text-right">{getTotalUserInitiatedInteractionCount(feature).toLocaleString()}</td>
                   <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 text-right">{feature.code_generation_activity_count.toLocaleString()}</td>
                   <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 text-right">{feature.code_acceptance_activity_count.toLocaleString()}</td>
                   <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 text-right">{feature.loc_added_sum.toLocaleString()}</td>

--- a/src/components/charts/ClientActivityChart.tsx
+++ b/src/components/charts/ClientActivityChart.tsx
@@ -12,12 +12,14 @@ import { formatShortDate, generateDateRange } from '../../utils/formatters';
 import ChartContainer from '../ui/ChartContainer';
 import MetricsTable, { type TableColumn } from '../ui/MetricsTable';
 import type { UserDayData } from '../../types/metrics';
+import { getTotalUserInitiatedInteractionCount } from '../../domain/assumedInteractions';
 
 registerChartJS();
 
 interface IDEAggregateItem {
   ide: string;
   user_initiated_interaction_count: number;
+  assumed_user_initiated_interaction_count?: number;
   code_generation_activity_count: number;
   code_acceptance_activity_count: number;
   loc_added_sum: number;
@@ -108,7 +110,7 @@ export default function ClientActivityChart({
       const data = allDays.map(dayStr => {
         const dayData = dayMap.get(dayStr);
         const ideData = dayData?.totals_by_ide.find(i => i.ide === ide);
-        return ideData?.user_initiated_interaction_count || 0;
+        return ideData ? getTotalUserInitiatedInteractionCount(ideData) : 0;
       });
 
       const color = getIdeColor(ide, fallbackIndex);
@@ -185,7 +187,7 @@ export default function ClientActivityChart({
                     <span>{formatIDEName(ide.ide)}</span>
                   </div>
                 </td>
-                <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 text-right">{ide.user_initiated_interaction_count.toLocaleString()}</td>
+                <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 text-right">{getTotalUserInitiatedInteractionCount(ide).toLocaleString()}</td>
                 <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 text-right">{ide.code_generation_activity_count.toLocaleString()}</td>
                 <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 text-right">{ide.code_acceptance_activity_count.toLocaleString()}</td>
                 <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 text-right">{ide.loc_added_sum.toLocaleString()}</td>

--- a/src/components/charts/DayClientDistributionChart.tsx
+++ b/src/components/charts/DayClientDistributionChart.tsx
@@ -11,6 +11,7 @@ import ChartContainer from '../ui/ChartContainer';
 import { formatIDEName } from '../icons/IDEIcons';
 import { sortBySelector } from '../../utils/sorting';
 import type { UserDayData } from '../../types/metrics';
+import { getTotalUserInitiatedInteractionCount } from '../../domain/assumedInteractions';
 
 registerChartJS();
 
@@ -21,8 +22,8 @@ interface DayClientDistributionChartProps {
 
 export default function DayClientDistributionChart({ dayMetrics, cliInteractionCount }: DayClientDistributionChartProps) {
   const sorted = sortBySelector(
-    dayMetrics.totals_by_ide.filter((ide) => ide.user_initiated_interaction_count > 0),
-    (ide) => ide.user_initiated_interaction_count,
+    dayMetrics.totals_by_ide.filter((ide) => getTotalUserInitiatedInteractionCount(ide) > 0),
+    getTotalUserInitiatedInteractionCount,
     'desc'
   );
   const hasCliActivity = cliInteractionCount > 0;
@@ -34,7 +35,7 @@ export default function DayClientDistributionChart({ dayMetrics, cliInteractionC
   ];
 
   const dataValues = [
-    ...sorted.map((ide) => ide.user_initiated_interaction_count),
+    ...sorted.map(getTotalUserInitiatedInteractionCount),
     ...(hasCliActivity ? [cliInteractionCount] : []),
   ];
 
@@ -72,7 +73,7 @@ export default function DayClientDistributionChart({ dayMetrics, cliInteractionC
   return (
     <ChartContainer
       title="Clients"
-      description="Share of interactions across clients on this day."
+      description="Share of recorded and assumed interactions across clients on this day."
       chartHeight="h-64"
       className="h-full"
       isEmpty={!hasData}

--- a/src/components/charts/UserActivityByModelAndFeatureChart.tsx
+++ b/src/components/charts/UserActivityByModelAndFeatureChart.tsx
@@ -1,10 +1,11 @@
 'use client';
 
 import { ChartData, ChartOptions } from 'chart.js';
-import { CopilotMetrics } from '../../types/metrics';
+import type { UserDetailedMetrics } from '../../types/aggregatedMetrics';
 import ActivityBreakdownChart from './ActivityBreakdownChart';
+import { getTotalUserInitiatedInteractionCount } from '../../domain/assumedInteractions';
 
-export type ModelFeatureAggregate = CopilotMetrics['totals_by_model_feature'][number];
+export type ModelFeatureAggregate = UserDetailedMetrics['modelFeatureAggregates'][number];
 
 interface UserActivityByModelAndFeatureChartProps {
   modelFeatureAggregates: ModelFeatureAggregate[];
@@ -19,9 +20,9 @@ const modelChartConfig = {
   unknownLabel: 'Unknown Model',
   totalLabel: 'total interactions',
   groupKey: 'model' as const,
-  countAccessor: (item: ModelFeatureAggregate) => item.user_initiated_interaction_count,
+  countAccessor: getTotalUserInitiatedInteractionCount,
   columns: [
-    { header: 'Interactions', accessor: (item: ModelFeatureAggregate) => item.user_initiated_interaction_count },
+    { header: 'Interactions', accessor: getTotalUserInitiatedInteractionCount },
     { header: 'Generation', accessor: (item: ModelFeatureAggregate) => item.code_generation_activity_count },
     { header: 'Acceptance', accessor: (item: ModelFeatureAggregate) => item.code_acceptance_activity_count },
     { header: 'LOC Added', accessor: (item: ModelFeatureAggregate) => item.loc_added_sum },

--- a/src/components/ui/DayDetailsModal.tsx
+++ b/src/components/ui/DayDetailsModal.tsx
@@ -9,6 +9,7 @@ import DayImpactCard from './DayImpactCard';
 import DayFeatureBreakdown from './DayFeatureBreakdown';
 import DayClientDistributionChart from '../charts/DayClientDistributionChart';
 import type { VoidCallback } from '../../types/events';
+import { getTotalUserInitiatedInteractionCount } from '../../domain/assumedInteractions';
 
 interface DayDetailsModalProps {
   isOpen: boolean;
@@ -74,7 +75,7 @@ export default function DayDetailsModal({ isOpen, onClose, date, dayMetrics, use
   const clientRows: ClientRow[] = hasData ? [
     ...dayMetrics!.totals_by_ide.map((ide) => ({
       name: formatIDEName(ide.ide),
-      user_initiated_interaction_count: ide.user_initiated_interaction_count,
+      user_initiated_interaction_count: getTotalUserInitiatedInteractionCount(ide),
       code_generation_activity_count: ide.code_generation_activity_count,
       code_acceptance_activity_count: ide.code_acceptance_activity_count,
       loc_added_sum: ide.loc_added_sum,

--- a/src/components/ui/DayFeatureBreakdown.tsx
+++ b/src/components/ui/DayFeatureBreakdown.tsx
@@ -3,6 +3,7 @@
 import React, { useId, useMemo, useState } from 'react';
 import type { UserDayData } from '../../types/metrics';
 import { translateFeature } from '../../domain/featureTranslations';
+import { getTotalUserInitiatedInteractionCount } from '../../domain/assumedInteractions';
 
 type FeatureRow = UserDayData['totals_by_feature'][number];
 type LanguageFeatureRow = UserDayData['totals_by_language_feature'][number];
@@ -98,7 +99,7 @@ function FeatureCard({
           <span className="text-sm font-semibold text-gray-900 truncate">{translateFeature(feature.feature)}</span>
         </span>
         <span className="flex items-center gap-4">
-          <MetricChip label="Interactions" value={fmt(feature.user_initiated_interaction_count)} />
+          <MetricChip label="Interactions" value={fmt(getTotalUserInitiatedInteractionCount(feature))} />
           <MetricChip label="Gen" value={fmt(feature.code_generation_activity_count)} />
           <MetricChip label="Acc" value={fmt(feature.code_acceptance_activity_count)} />
           <MetricChip label="LOC" value={`+${fmt(feature.loc_added_sum)} / -${fmt(feature.loc_deleted_sum)}`} />
@@ -124,6 +125,7 @@ export default function DayFeatureBreakdown({
     () =>
       [...totalsByFeature].sort(
         (a, b) =>
+          getTotalUserInitiatedInteractionCount(b) - getTotalUserInitiatedInteractionCount(a) ||
           b.user_initiated_interaction_count - a.user_initiated_interaction_count ||
           b.code_generation_activity_count - a.code_generation_activity_count
       ),

--- a/src/domain/assumedInteractions.ts
+++ b/src/domain/assumedInteractions.ts
@@ -18,7 +18,7 @@ export function getAssumedUserInitiatedInteractionCount(
   feature: string,
   codeGenerationActivityCount: number,
 ): number {
-  return feature === CODE_COMPLETION_FEATURE ? codeGenerationActivityCount : 0;
+  return feature === CODE_COMPLETION_FEATURE ? Math.max(0, codeGenerationActivityCount) : 0;
 }
 
 export function withAssumedUserInitiatedInteractionCount<T extends FeatureGenerationMetric>(

--- a/src/domain/assumedInteractions.ts
+++ b/src/domain/assumedInteractions.ts
@@ -1,0 +1,77 @@
+export const CODE_COMPLETION_FEATURE = 'code_completion';
+
+interface FeatureGenerationMetric {
+  feature: string;
+  code_generation_activity_count: number;
+}
+
+interface InteractionMetric {
+  user_initiated_interaction_count: number;
+  assumed_user_initiated_interaction_count?: number;
+}
+
+interface GenerationMetric {
+  code_generation_activity_count: number;
+}
+
+export function getAssumedUserInitiatedInteractionCount(
+  feature: string,
+  codeGenerationActivityCount: number,
+): number {
+  return feature === CODE_COMPLETION_FEATURE ? codeGenerationActivityCount : 0;
+}
+
+export function withAssumedUserInitiatedInteractionCount<T extends FeatureGenerationMetric>(
+  item: T,
+): T & { assumed_user_initiated_interaction_count: number } {
+  return {
+    ...item,
+    assumed_user_initiated_interaction_count: getAssumedUserInitiatedInteractionCount(
+      item.feature,
+      item.code_generation_activity_count,
+    ),
+  };
+}
+
+export function getTotalUserInitiatedInteractionCount(item: InteractionMetric): number {
+  return item.user_initiated_interaction_count + (item.assumed_user_initiated_interaction_count ?? 0);
+}
+
+export function sumAssumedUserInitiatedInteractions(items: FeatureGenerationMetric[]): number {
+  return items.reduce(
+    (sum, item) =>
+      sum + getAssumedUserInitiatedInteractionCount(item.feature, item.code_generation_activity_count),
+    0,
+  );
+}
+
+export function distributeAssumedInteractionsByGeneration<T extends GenerationMetric>(
+  items: T[],
+  assumedInteractionCount: number,
+): number[] {
+  if (items.length === 0 || assumedInteractionCount <= 0) {
+    return items.map(() => 0);
+  }
+
+  const generationCounts = items.map((item) => Math.max(0, item.code_generation_activity_count));
+  const totalGenerations = generationCounts.reduce((sum, value) => sum + value, 0);
+  if (totalGenerations === 0) {
+    return items.map(() => 0);
+  }
+
+  const allocations = generationCounts.map((value) => (assumedInteractionCount * value) / totalGenerations);
+  const roundedDown = allocations.map(Math.floor);
+  let remaining = assumedInteractionCount - roundedDown.reduce((sum, value) => sum + value, 0);
+
+  const indicesByRemainder = allocations
+    .map((value, index) => ({ index, remainder: value - Math.floor(value) }))
+    .sort((a, b) => b.remainder - a.remainder);
+
+  for (const { index } of indicesByRemainder) {
+    if (remaining <= 0) break;
+    roundedDown[index] += 1;
+    remaining -= 1;
+  }
+
+  return roundedDown;
+}

--- a/src/domain/calculators/__tests__/userDetailCalculator.test.ts
+++ b/src/domain/calculators/__tests__/userDetailCalculator.test.ts
@@ -427,6 +427,53 @@ describe('userDetailCalculator', () => {
   });
 
   describe('IDE aggregates alongside CLI data', () => {
+    it('should allocate assumed completion interactions to IDE client aggregates', () => {
+      const acc = createUserDetailAccumulator();
+      acc.reportStartDay = '2024-01-01';
+      acc.reportEndDay = '2024-01-31';
+
+      accumulateUserDetail(acc, createMetric({
+        totals_by_feature: [{
+          feature: 'code_completion',
+          user_initiated_interaction_count: 0,
+          code_generation_activity_count: 44,
+          code_acceptance_activity_count: 2,
+          loc_added_sum: 2,
+          loc_deleted_sum: 0,
+          loc_suggested_to_add_sum: 64,
+          loc_suggested_to_delete_sum: 0,
+        }],
+        totals_by_ide: [
+          {
+            ide: 'vscode',
+            user_initiated_interaction_count: 0,
+            code_generation_activity_count: 30,
+            code_acceptance_activity_count: 1,
+            loc_added_sum: 1,
+            loc_deleted_sum: 0,
+            loc_suggested_to_add_sum: 40,
+            loc_suggested_to_delete_sum: 0,
+          },
+          {
+            ide: 'jetbrains',
+            user_initiated_interaction_count: 0,
+            code_generation_activity_count: 14,
+            code_acceptance_activity_count: 1,
+            loc_added_sum: 1,
+            loc_deleted_sum: 0,
+            loc_suggested_to_add_sum: 24,
+            loc_suggested_to_delete_sum: 0,
+          },
+        ],
+      }));
+
+      const result = computeSingleUserDetailedMetrics(acc, 1);
+
+      expect(result!.ideAggregates.find(ide => ide.ide === 'vscode')!.assumed_user_initiated_interaction_count).toBe(30);
+      expect(result!.ideAggregates.find(ide => ide.ide === 'jetbrains')!.assumed_user_initiated_interaction_count).toBe(14);
+      expect(result!.days[0].totals_by_ide.reduce((sum, ide) => sum + (ide.assumed_user_initiated_interaction_count ?? 0), 0)).toBe(44);
+    });
+
     it('should produce correct ideAggregates AND cliVersions from a single metric', () => {
       const acc = createUserDetailAccumulator();
       acc.reportStartDay = '2024-01-01';
@@ -585,6 +632,46 @@ describe('userDetailCalculator', () => {
   });
 
   describe('Feature aggregate accumulation', () => {
+    it('should expose code completion generations as assumed user interactions', () => {
+      const acc = createUserDetailAccumulator();
+      acc.reportStartDay = '2024-01-01';
+      acc.reportEndDay = '2024-01-31';
+
+      accumulateUserDetail(acc, createMetric({
+        totals_by_feature: [
+          {
+            feature: 'code_completion',
+            user_initiated_interaction_count: 0,
+            code_generation_activity_count: 44,
+            code_acceptance_activity_count: 2,
+            loc_added_sum: 2,
+            loc_deleted_sum: 0,
+            loc_suggested_to_add_sum: 64,
+            loc_suggested_to_delete_sum: 0,
+          },
+          {
+            feature: 'chat_panel_agent_mode',
+            user_initiated_interaction_count: 3,
+            code_generation_activity_count: 11,
+            code_acceptance_activity_count: 1,
+            loc_added_sum: 5,
+            loc_deleted_sum: 1,
+            loc_suggested_to_add_sum: 8,
+            loc_suggested_to_delete_sum: 2,
+          },
+        ],
+      }));
+
+      const result = computeSingleUserDetailedMetrics(acc, 1);
+      const completionAgg = result!.featureAggregates.find(f => f.feature === 'code_completion')!;
+      const agentAgg = result!.featureAggregates.find(f => f.feature === 'chat_panel_agent_mode')!;
+
+      expect(completionAgg.user_initiated_interaction_count).toBe(0);
+      expect(completionAgg.assumed_user_initiated_interaction_count).toBe(44);
+      expect(agentAgg.assumed_user_initiated_interaction_count).toBe(0);
+      expect(result!.days[0].totals_by_feature.find(f => f.feature === 'code_completion')!.assumed_user_initiated_interaction_count).toBe(44);
+    });
+
     it('should accumulate all metric fields for the same feature across multiple days', () => {
       const acc = createUserDetailAccumulator();
       acc.reportStartDay = '2024-01-01';
@@ -757,6 +844,33 @@ describe('userDetailCalculator', () => {
   });
 
   describe('Model-feature aggregate accumulation', () => {
+    it('should include assumed code completion interactions in model request totals and daily model usage', () => {
+      const acc = createUserDetailAccumulator();
+      acc.reportStartDay = '2024-01-01';
+      acc.reportEndDay = '2024-01-31';
+
+      accumulateUserDetail(acc, createMetric({
+        totals_by_model_feature: [{
+          model: 'gpt-4o',
+          feature: 'code_completion',
+          user_initiated_interaction_count: 0,
+          code_generation_activity_count: 44,
+          code_acceptance_activity_count: 2,
+          loc_added_sum: 2,
+          loc_deleted_sum: 0,
+          loc_suggested_to_add_sum: 64,
+          loc_suggested_to_delete_sum: 0,
+        }],
+      }));
+
+      const result = computeSingleUserDetailedMetrics(acc, 1);
+      const completionAgg = result!.modelFeatureAggregates[0];
+
+      expect(result!.totalModelRequests).toBe(44);
+      expect(completionAgg.assumed_user_initiated_interaction_count).toBe(44);
+      expect(result!.dailyModelUsage[0].modelInteractions).toBe(44);
+    });
+
     it('should accumulate all metric fields for the same model-feature key across multiple days', () => {
       const acc = createUserDetailAccumulator();
       acc.reportStartDay = '2024-01-01';

--- a/src/domain/calculators/userDetailCalculator.ts
+++ b/src/domain/calculators/userDetailCalculator.ts
@@ -16,10 +16,17 @@ import {
   accumulateModelFeature,
   computeDailyModelUsageData,
 } from './modelUsageCalculator';
+import {
+  distributeAssumedInteractionsByGeneration,
+  getTotalUserInitiatedInteractionCount,
+  sumAssumedUserInitiatedInteractions,
+  withAssumedUserInitiatedInteractionCount,
+} from '../assumedInteractions';
 
 interface FeatureAgg {
   feature: string;
   user_initiated_interaction_count: number;
+  assumed_user_initiated_interaction_count: number;
   code_generation_activity_count: number;
   code_acceptance_activity_count: number;
   loc_added_sum: number;
@@ -31,6 +38,7 @@ interface FeatureAgg {
 interface IDEAgg {
   ide: string;
   user_initiated_interaction_count: number;
+  assumed_user_initiated_interaction_count: number;
   code_generation_activity_count: number;
   code_acceptance_activity_count: number;
   loc_added_sum: number;
@@ -54,6 +62,7 @@ interface ModelFeatureAgg {
   model: string;
   feature: string;
   user_initiated_interaction_count: number;
+  assumed_user_initiated_interaction_count: number;
   code_generation_activity_count: number;
   code_acceptance_activity_count: number;
   loc_added_sum: number;
@@ -131,6 +140,7 @@ interface AggMetricTotals {
 /** Extends AggMetricTotals with user-initiated interaction count (used by Feature, IDE, ModelFeature). */
 interface InteractionAggMetricTotals extends AggMetricTotals {
   user_initiated_interaction_count: number;
+  assumed_user_initiated_interaction_count: number;
 }
 
 /** Accumulates the 6 shared code-gen/acceptance/LOC fields in-place on `existing`. */
@@ -149,6 +159,7 @@ function accumulateInteractionAggMetricTotals(
   incoming: InteractionAggMetricTotals
 ): void {
   existing.user_initiated_interaction_count += incoming.user_initiated_interaction_count;
+  existing.assumed_user_initiated_interaction_count += incoming.assumed_user_initiated_interaction_count;
   accumulateAggMetricTotals(existing, incoming);
 }
 
@@ -177,19 +188,26 @@ export function accumulateUserDetail(
 ): void {
   const userId = metric.user_id;
   const state = getOrCreateUserState(accumulator, userId);
+  const featureTotals = metric.totals_by_feature.map(withAssumedUserInitiatedInteractionCount);
+  const modelFeatureTotals = metric.totals_by_model_feature.map(withAssumedUserInitiatedInteractionCount);
+  const ideAssumedInteractionCounts = distributeAssumedInteractionsByGeneration(
+    metric.totals_by_ide,
+    sumAssumedUserInitiatedInteractions(featureTotals),
+  );
 
-  for (const mf of metric.totals_by_model_feature) {
-    state.totalModelRequests += mf.user_initiated_interaction_count;
+  for (const mf of modelFeatureTotals) {
+    state.totalModelRequests += getTotalUserInitiatedInteractionCount(mf);
   }
 
-  for (const f of metric.totals_by_feature) {
+  for (const f of featureTotals) {
     upsertAggMapEntry(state.featureMap, f.feature, f, accumulateInteractionAggMetricTotals);
   }
 
-  for (const ide of metric.totals_by_ide) {
+  for (const [index, ide] of metric.totals_by_ide.entries()) {
     const ideEntry: IDEAgg = {
       ide: ide.ide,
       user_initiated_interaction_count: ide.user_initiated_interaction_count,
+      assumed_user_initiated_interaction_count: ideAssumedInteractionCounts[index] ?? 0,
       code_generation_activity_count: ide.code_generation_activity_count,
       code_acceptance_activity_count: ide.code_acceptance_activity_count,
       loc_added_sum: ide.loc_added_sum,
@@ -222,7 +240,7 @@ export function accumulateUserDetail(
     upsertAggMapEntry(state.langFeatureMap, `${lf.language}-${lf.feature}`, lf, accumulateAggMetricTotals);
   }
 
-  for (const mf of metric.totals_by_model_feature) {
+  for (const mf of modelFeatureTotals) {
     upsertAggMapEntry(state.modelFeatureMap, `${mf.model}-${mf.feature}`, mf, accumulateInteractionAggMetricTotals);
   }
 
@@ -238,10 +256,11 @@ export function accumulateUserDetail(
     used_copilot_coding_agent: metric.used_copilot_coding_agent ?? false,
     used_copilot_code_review_active: metric.used_copilot_code_review_active ?? false,
     used_copilot_code_review_passive: metric.used_copilot_code_review_passive ?? false,
-    totals_by_feature: metric.totals_by_feature.map((f) => ({ ...f })),
-    totals_by_ide: metric.totals_by_ide.map((ide) => ({
+    totals_by_feature: featureTotals.map((f) => ({ ...f })),
+    totals_by_ide: metric.totals_by_ide.map((ide, index) => ({
       ide: ide.ide,
       user_initiated_interaction_count: ide.user_initiated_interaction_count,
+      assumed_user_initiated_interaction_count: ideAssumedInteractionCounts[index] ?? 0,
       code_generation_activity_count: ide.code_generation_activity_count,
       code_acceptance_activity_count: ide.code_acceptance_activity_count,
       loc_added_sum: ide.loc_added_sum,
@@ -254,7 +273,7 @@ export function accumulateUserDetail(
     })),
     totals_by_language_feature: metric.totals_by_language_feature.map((lf) => ({ ...lf })),
     totals_by_language_model: metric.totals_by_language_model.map((lm) => ({ ...lm })),
-    totals_by_model_feature: metric.totals_by_model_feature.map((mf) => ({ ...mf })),
+    totals_by_model_feature: modelFeatureTotals.map((mf) => ({ ...mf })),
     totals_by_cli: metric.totals_by_cli ? {
       session_count: metric.totals_by_cli.session_count,
       request_count: metric.totals_by_cli.request_count,
@@ -315,7 +334,7 @@ export function computeSingleUserDetailedMetrics(
         modelUsageAccumulator,
         day.day,
         mf.model,
-        mf.user_initiated_interaction_count
+        getTotalUserInitiatedInteractionCount(mf)
       );
     }
   }

--- a/src/domain/featureCategories.ts
+++ b/src/domain/featureCategories.ts
@@ -110,7 +110,7 @@ export const FEATURE_ADOPTION_RADAR_METADATA = [
   { key: 'cliInteractions', label: 'CLI', summaryLabel: 'CLI', unit: 'interactions' },
   { key: 'askModeInteractions', label: 'Ask Mode', summaryLabel: 'Ask', unit: 'interactions' },
   { key: 'editModeInteractions', label: 'Edit Mode', summaryLabel: 'Edit', unit: 'interactions' },
-  { key: 'completionInteractions', label: 'Completions', summaryLabel: 'Completions', unit: 'acceptances' },
+  { key: 'completionInteractions', label: 'Completions', summaryLabel: 'Completions', unit: 'interactions' },
 ] as const;
 
 export function getFeatureTaxonomy(): readonly FeatureTaxonomyEntry[] {

--- a/src/types/aggregatedMetrics.ts
+++ b/src/types/aggregatedMetrics.ts
@@ -11,6 +11,7 @@ export interface UserDetailedMetrics {
   featureAggregates: Array<{
     feature: string;
     user_initiated_interaction_count: number;
+    assumed_user_initiated_interaction_count: number;
     code_generation_activity_count: number;
     code_acceptance_activity_count: number;
     loc_added_sum: number;
@@ -21,6 +22,7 @@ export interface UserDetailedMetrics {
   ideAggregates: Array<{
     ide: string;
     user_initiated_interaction_count: number;
+    assumed_user_initiated_interaction_count: number;
     code_generation_activity_count: number;
     code_acceptance_activity_count: number;
     loc_added_sum: number;
@@ -42,6 +44,7 @@ export interface UserDetailedMetrics {
     model: string;
     feature: string;
     user_initiated_interaction_count: number;
+    assumed_user_initiated_interaction_count: number;
     code_generation_activity_count: number;
     code_acceptance_activity_count: number;
     loc_added_sum: number;

--- a/src/types/metrics.ts
+++ b/src/types/metrics.ts
@@ -232,6 +232,7 @@ export interface UserDayData {
   totals_by_feature: Array<{
     feature: string;
     user_initiated_interaction_count: number;
+    assumed_user_initiated_interaction_count?: number;
     code_generation_activity_count: number;
     code_acceptance_activity_count: number;
     loc_added_sum: number;
@@ -242,6 +243,7 @@ export interface UserDayData {
   totals_by_ide: Array<{
     ide: string;
     user_initiated_interaction_count: number;
+    assumed_user_initiated_interaction_count?: number;
     code_generation_activity_count: number;
     code_acceptance_activity_count: number;
     loc_added_sum: number;
@@ -278,6 +280,7 @@ export interface UserDayData {
     model: string;
     feature: string;
     user_initiated_interaction_count: number;
+    assumed_user_initiated_interaction_count?: number;
     code_generation_activity_count: number;
     code_acceptance_activity_count: number;
     loc_added_sum: number;


### PR DESCRIPTION
## Why

Completion-heavy users were underrepresented in interaction-based charts because code completion records can have zero user-initiated interactions while still having substantial generation activity. The unique users table also became slow for large datasets because it rendered every user row at once.

| Commit | Change |
|--------|--------|
| `feat: account for completion activity in interactions` | Adds a virtual assumed interaction count for code completion based on generation activity, then uses recorded plus assumed interactions in user detail, client, feature, and model views. |
| `fix: paginate unique users table` | Restores the rich LOC impact display while limiting the unique users table to 500 rows per page for faster initial rendering. |