### PR TITLE
feat: add About page

### DIFF
--- a/src/components/AboutView.tsx
+++ b/src/components/AboutView.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import React from 'react';
+import { ViewPanel } from './ui';
+
+export default function AboutView() {
+  return (
+    <ViewPanel
+      headerProps={{
+        title: 'About',
+        description: 'Context for how this Copilot metrics reference application is maintained and intended to be used.',
+      }}
+      contentClassName="space-y-6"
+    >
+      <section className="rounded-lg border border-[#d1d9e0] bg-white p-6 shadow-sm">
+        <div className="space-y-4 text-sm leading-6 text-gray-700">
+          <p>
+            This application is maintained by a GitHub Solutions Engineer from EMEA as a reference
+            point for the data and insights that can be derived from GitHub Copilot Metrics.
+          </p>
+          <p>
+            It relies on static NDJSON file exports and is designed to serve as a foundation rather
+            than a day-to-day adoption monitoring platform.
+          </p>
+          <p>
+            Organizations are encouraged to fork and extend this repository in-house. It can be
+            adapted to include integration with the Copilot Metrics API, persistent data storage,
+            and enrichment using other GitHub APIs or identity providers.
+          </p>
+          <p>
+            Because GitHub Copilot Metrics are under active development, new features and data
+            points are introduced frequently. Keep an eye on{' '}
+            <a
+              href="https://github.blog/?s=metrics"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="font-medium text-blue-600 underline underline-offset-2 hover:text-blue-800"
+            >
+              GitHub Blog posts about metrics
+            </a>{' '}
+            to stay current. We strive to update this reference application as new data becomes
+            available, but following the blog ensures you receive the latest updates directly from
+            GitHub.
+          </p>
+        </div>
+      </section>
+    </ViewPanel>
+  );
+}

--- a/src/components/layout/ViewRouter.tsx
+++ b/src/components/layout/ViewRouter.tsx
@@ -20,6 +20,7 @@ import CLIAdoptionView from '../CLIAdoptionView';
 import ModelDetailsView from '../ModelDetailsView';
 import ExecutiveSummaryView from '../ExecutiveSummaryView';
 import ClientVersionsView from '../ClientVersionsView';
+import AboutView from '../AboutView';
 
 const ViewRouter: React.FC = () => {
   const { 
@@ -152,6 +153,9 @@ const ViewRouter: React.FC = () => {
           featureAdoptionData={featureAdoptionData}
         />
       );
+
+    case VIEW_MODES.ABOUT:
+      return <AboutView />;
 
     case VIEW_MODES.CLIENT_VERSIONS:
       return (

--- a/src/components/layout/navigationItems.tsx
+++ b/src/components/layout/navigationItems.tsx
@@ -103,6 +103,15 @@ export const NAV_ITEMS: NavItem[] = [
       </svg>
     ),
   },
+  {
+    label: 'About',
+    view: VIEW_MODES.ABOUT,
+    icon: (
+      <svg className="w-5 h-5" aria-hidden="true" focusable="false" fill="none" stroke="currentColor" strokeWidth={1.5} viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" d="M11.25 11.25l.041-.02a.75.75 0 011.063.852l-.708 2.836a.75.75 0 001.063.853l.041-.021M21 12a9 9 0 11-18 0 9 9 0 0118 0zm-9-3.75h.008v.008H12V8.25z" />
+      </svg>
+    ),
+  },
 ];
 
 export function getActiveNavItem(currentView: ViewMode): NavItem | undefined {

--- a/src/types/navigation.ts
+++ b/src/types/navigation.ts
@@ -1,6 +1,7 @@
 export const VIEW_MODES = {
   OVERVIEW: 'overview',
   EXECUTIVE_SUMMARY: 'executiveSummary',
+  ABOUT: 'about',
   CLIENT_VERSIONS: 'clientVersions',
   USERS: 'users',
   USER_DETAILS: 'userDetails',


### PR DESCRIPTION
## Why

This change adds an About page so users understand the purpose, ownership, and intended use of the Copilot metrics reference app. It helps clarify that the app is a forkable foundation based on NDJSON exports and points users to GitHub Blog updates for evolving metrics data.

| Commit | Change |
|--------|--------|
| `feat: add About page` | Adds an About view, wires it into navigation under Executive Summary, and documents ownership, intended usage, extensibility, and metrics update guidance. |