### PR TITLE
Add AI adoption phase view

### DIFF
--- a/docs/project-overview.md
+++ b/docs/project-overview.md
@@ -88,7 +88,7 @@ flowchart LR
 
 ### 4.3. Views
 
-`ViewRouter` (`src/components/layout/ViewRouter.tsx`) maps the current `ViewMode` to the appropriate component. Views include: overview dashboard, users list, user details, languages, IDEs, Copilot impact, model usage analysis, adoption, and model details.
+`ViewRouter` (`src/components/layout/ViewRouter.tsx`) maps the current `ViewMode` to the appropriate component. Views include: overview dashboard, users list, user details, languages, IDEs, Copilot impact, model usage analysis, adoption, AI adoption phases, and model details.
 
 Charts use **Chart.js** via **react-chartjs-2**, wrapped in a `ChartContainer` component for consistent styling.
 

--- a/src/components/AiAdoptionPhaseView.tsx
+++ b/src/components/AiAdoptionPhaseView.tsx
@@ -1,0 +1,186 @@
+'use client';
+
+import React from 'react';
+import MetricsTable, { TableColumn } from './ui/MetricsTable';
+import { ViewPanel } from './ui';
+import type { AiAdoptionPhaseData, AiAdoptionPhaseTopEntry } from '../domain/calculators/metricCalculators';
+import { formatAiAdoptionPhase, formatModelDisplayName, formatNumber } from '../utils/formatters';
+import { formatIDEName, getIDEIcon } from './icons/IDEIcons';
+
+interface AiAdoptionPhaseViewProps {
+  phaseData: AiAdoptionPhaseData[];
+}
+
+function formatAverage(value: number): string {
+  return formatNumber(value, 1);
+}
+
+function renderTopEntries(
+  entries: AiAdoptionPhaseTopEntry[],
+  formatName: (name: string) => string = (name) => name
+) {
+  if (entries.length === 0) {
+    return <span className="text-sm text-gray-400">No data</span>;
+  }
+
+  return (
+    <div className="space-y-1">
+      {entries.map((entry) => (
+        <div key={entry.name} className="flex items-center justify-between gap-3 text-sm">
+          <span className="truncate text-gray-900" title={entry.name}>
+            {formatName(entry.name)}
+          </span>
+          <span className="whitespace-nowrap text-xs text-gray-500" title={`${entry.uniqueUsers.toLocaleString()} users`}>
+            {entry.total.toLocaleString()}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function renderTopClientEntries(entries: AiAdoptionPhaseTopEntry[]) {
+  if (entries.length === 0) {
+    return <span className="text-sm text-gray-400">No data</span>;
+  }
+
+  return (
+    <div className="space-y-1">
+      {entries.map((entry) => {
+        const ClientIcon = getIDEIcon(entry.name);
+        return (
+          <div key={entry.name} className="flex items-center justify-between gap-3 text-sm">
+            <div className="flex min-w-0 items-center gap-2">
+              <div className="flex-shrink-0">
+                <ClientIcon />
+              </div>
+              <span className="truncate text-gray-900" title={entry.name}>
+                {formatIDEName(entry.name)}
+              </span>
+            </div>
+            <span className="whitespace-nowrap text-xs text-gray-500" title={`${entry.uniqueUsers.toLocaleString()} users`}>
+              {entry.total.toLocaleString()}
+            </span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+export default function AiAdoptionPhaseView({ phaseData }: AiAdoptionPhaseViewProps) {
+  const rightHeaderClass = 'px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider';
+  const rightCellClass = 'px-6 py-4 whitespace-nowrap text-sm text-gray-900 text-right';
+  const columns: TableColumn<AiAdoptionPhaseData>[] = [
+    {
+      id: 'phase',
+      header: 'Phase',
+      headerClassName: 'px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider min-w-[180px]',
+      className: 'px-6 py-4 whitespace-nowrap',
+      renderCell: (phase) => (
+        <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-purple-100 text-purple-800">
+          {formatAiAdoptionPhase(phase.phase)}
+        </span>
+      ),
+    },
+    {
+      id: 'userCount',
+      header: 'Users',
+      headerClassName: rightHeaderClass,
+      className: `${rightCellClass} font-medium`,
+      renderCell: (phase) => phase.userCount.toLocaleString(),
+    },
+    {
+      id: 'avgUserInitiatedInteractions',
+      header: 'Avg Interactions',
+      headerClassName: rightHeaderClass,
+      className: rightCellClass,
+      renderCell: (phase) => formatAverage(phase.avgUserInitiatedInteractions),
+    },
+    {
+      id: 'avgLocImpact',
+      header: 'Avg LOC Impact',
+      headerClassName: rightHeaderClass,
+      className: rightCellClass,
+      renderCell: (phase) => (
+        <span className="whitespace-nowrap tabular-nums">
+          <span className="text-green-600">+{formatAverage(phase.avgLocAdded)}</span>
+          <span className="text-gray-400">/</span>
+          <span className="text-red-600">-{formatAverage(phase.avgLocDeleted)}</span>
+        </span>
+      ),
+    },
+    {
+      id: 'totalLocImpact',
+      header: 'Total LOC Impact',
+      headerClassName: rightHeaderClass,
+      className: rightCellClass,
+      renderCell: (phase) => (
+        <span className="whitespace-nowrap tabular-nums">
+          <span className="text-green-600">+{phase.totalLocAdded.toLocaleString()}</span>
+          <span className="text-gray-400">/</span>
+          <span className="text-red-600">-{phase.totalLocDeleted.toLocaleString()}</span>
+        </span>
+      ),
+    },
+    {
+      id: 'avgDaysActive',
+      header: 'Avg Active Days',
+      headerClassName: rightHeaderClass,
+      className: rightCellClass,
+      renderCell: (phase) => formatAverage(phase.avgDaysActive),
+    },
+    {
+      id: 'topModels',
+      header: 'Top Models - interactions',
+      headerClassName: 'px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider min-w-[180px]',
+      className: 'px-6 py-4 align-top',
+      renderCell: (phase) => renderTopEntries(phase.topModels, formatModelDisplayName),
+    },
+    {
+      id: 'topClients',
+      header: 'Top Clients - activity',
+      headerClassName: 'px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider min-w-[180px]',
+      className: 'px-6 py-4 align-top',
+      renderCell: (phase) => renderTopClientEntries(phase.topClients),
+    },
+    {
+      id: 'topLanguages',
+      header: 'Top Languages - generations + acceptances',
+      headerClassName: 'px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider min-w-[180px]',
+      className: 'px-6 py-4 align-top',
+      renderCell: (phase) => renderTopEntries(phase.topLanguages),
+    },
+  ];
+
+  return (
+    <ViewPanel
+      headerProps={{
+        title: 'AI Adoption Phases',
+        description: 'Compare Copilot adoption cohorts by user count, per-user averages, and their most-used models, clients, and languages.',
+      }}
+      contentClassName="space-y-8"
+    >
+      <div className="bg-white rounded-md border border-[#d1d9e0]">
+        <div className="px-6 py-4 border-b border-gray-200">
+          <h3 className="text-lg font-semibold text-gray-900">Phase comparison</h3>
+          <p className="mt-1 text-sm text-gray-600">Averages are calculated per user in each phase.</p>
+        </div>
+        <MetricsTable<AiAdoptionPhaseData>
+          data={phaseData}
+          columns={columns}
+          tableClassName="w-full divide-y divide-gray-200"
+          tableContainerClassName="overflow-x-auto"
+          theadClassName="bg-gray-50"
+          rowClassName={(_, index) => `${index % 2 === 0 ? 'bg-white' : 'bg-gray-50'} hover:bg-gray-50`}
+          getRowKey={(phase) => phase.phase.phase_number}
+          emptyState={(
+            <div className="px-6 py-8 text-center text-sm text-gray-500">
+              No AI adoption phase data is available in this metrics upload.
+            </div>
+          )}
+        />
+      </div>
+    </ViewPanel>
+  );
+}

--- a/src/components/layout/ViewRouter.tsx
+++ b/src/components/layout/ViewRouter.tsx
@@ -16,6 +16,7 @@ import LanguagesView from '../LanguagesView';
 import ClientsView from '../ClientsView';
 import CopilotImpactView from '../CopilotImpactView';
 import CopilotAdoptionView from '../CopilotAdoptionView';
+import AiAdoptionPhaseView from '../AiAdoptionPhaseView';
 import CLIAdoptionView from '../CLIAdoptionView';
 import ModelDetailsView from '../ModelDetailsView';
 import ExecutiveSummaryView from '../ExecutiveSummaryView';
@@ -139,6 +140,7 @@ const ViewRouter: React.FC = () => {
     dailyAdoptionTrend,
     dailyCloudAgentAdoptionData = [],
     dailyCodeReviewAdoptionData = [],
+    aiAdoptionPhaseData,
   } = aggregatedMetrics;
 
   switch (currentView) {
@@ -210,6 +212,13 @@ const ViewRouter: React.FC = () => {
           dailyAdoptionTrend={dailyAdoptionTrend}
           dailyCloudAgentAdoptionData={dailyCloudAgentAdoptionData}
           dailyCodeReviewAdoptionData={dailyCodeReviewAdoptionData}
+        />
+      );
+
+    case VIEW_MODES.AI_ADOPTION_PHASES:
+      return (
+        <AiAdoptionPhaseView
+          phaseData={aiAdoptionPhaseData}
         />
       );
 

--- a/src/components/layout/ViewRouter.tsx
+++ b/src/components/layout/ViewRouter.tsx
@@ -140,7 +140,7 @@ const ViewRouter: React.FC = () => {
     dailyAdoptionTrend,
     dailyCloudAgentAdoptionData = [],
     dailyCodeReviewAdoptionData = [],
-    aiAdoptionPhaseData,
+    aiAdoptionPhaseData = [],
   } = aggregatedMetrics;
 
   switch (currentView) {

--- a/src/components/layout/navigationItems.tsx
+++ b/src/components/layout/navigationItems.tsx
@@ -68,6 +68,15 @@ export const NAV_ITEMS: NavItem[] = [
     ),
   },
   {
+    label: 'AI Adoption Phases',
+    view: VIEW_MODES.AI_ADOPTION_PHASES,
+    icon: (
+      <svg className="w-5 h-5" aria-hidden="true" focusable="false" fill="none" stroke="currentColor" strokeWidth={1.5} viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5M3.75 17.25h16.5M6.75 6.75v10.5M12 6.75v10.5M17.25 6.75v10.5" />
+      </svg>
+    ),
+  },
+  {
     label: 'Model Usage',
     view: VIEW_MODES.MODEL_DETAILS,
     icon: (

--- a/src/domain/__tests__/metricsAggregator.test.ts
+++ b/src/domain/__tests__/metricsAggregator.test.ts
@@ -196,6 +196,116 @@ describe('metricsAggregator', () => {
       });
     });
 
+    it('should aggregate AI adoption phase metrics and top dimensions per user phase', () => {
+      const ideTotal = (ide: string, activity: number) => ({
+        ide,
+        user_initiated_interaction_count: activity,
+        code_generation_activity_count: 0,
+        code_acceptance_activity_count: 0,
+        loc_added_sum: 0,
+        loc_deleted_sum: 0,
+        loc_suggested_to_add_sum: 0,
+        loc_suggested_to_delete_sum: 0,
+      });
+      const modelFeature = (model: string, interactions: number) => ({
+        model,
+        feature: 'chat_panel_ask_mode',
+        user_initiated_interaction_count: interactions,
+        code_generation_activity_count: 0,
+        code_acceptance_activity_count: 0,
+        loc_added_sum: 0,
+        loc_deleted_sum: 0,
+        loc_suggested_to_add_sum: 0,
+        loc_suggested_to_delete_sum: 0,
+      });
+      const languageFeature = (language: string, generations: number, acceptances: number) => ({
+        language,
+        feature: 'code_completion',
+        code_generation_activity_count: generations,
+        code_acceptance_activity_count: acceptances,
+        loc_added_sum: 0,
+        loc_deleted_sum: 0,
+        loc_suggested_to_add_sum: 0,
+        loc_suggested_to_delete_sum: 0,
+      });
+
+      const user1Day1 = createBasicMetric({
+        user_id: 1,
+        day: '2024-01-15',
+        user_initiated_interaction_count: 10,
+        loc_added_sum: 100,
+        loc_deleted_sum: 10,
+        ai_adoption_phase: { phase_number: 1, phase: 'Phase 1', version: 'v1' },
+        totals_by_ide: [ideTotal('vscode', 10)],
+        totals_by_model_feature: [modelFeature('gpt-4o', 8)],
+        totals_by_language_feature: [languageFeature('typescript', 5, 1)],
+      });
+      const user1Day2 = createBasicMetric({
+        user_id: 1,
+        day: '2024-01-16',
+        user_initiated_interaction_count: 20,
+        loc_added_sum: 50,
+        loc_deleted_sum: 5,
+        ai_adoption_phase: { phase_number: 1, phase: 'Phase 1', version: 'v1' },
+        totals_by_ide: [ideTotal('vscode', 4)],
+        totals_by_model_feature: [modelFeature('claude-sonnet-4.6', 15)],
+        totals_by_language_feature: [languageFeature('python', 7, 3)],
+      });
+      const user2 = createBasicMetric({
+        user_id: 2,
+        day: '2024-01-15',
+        user_initiated_interaction_count: 10,
+        loc_added_sum: 50,
+        loc_deleted_sum: 5,
+        ai_adoption_phase: { phase_number: 1, phase: 'Phase 1', version: 'v1' },
+        totals_by_ide: [ideTotal('vscode', 3)],
+        totals_by_model_feature: [modelFeature('gpt-4o', 20)],
+        totals_by_language_feature: [languageFeature('typescript', 10, 2)],
+      });
+      const user3 = createBasicMetric({
+        user_id: 3,
+        day: '2024-01-15',
+        user_initiated_interaction_count: 5,
+        loc_added_sum: 30,
+        loc_deleted_sum: 3,
+        ai_adoption_phase: { phase_number: 2, phase: 'Phase 2', version: 'v1' },
+        totals_by_ide: [ideTotal('intellij', 7)],
+        totals_by_model_feature: [modelFeature('gpt-4o', 10)],
+        totals_by_language_feature: [languageFeature('go', 6, 2)],
+      });
+
+      const { aggregated } = aggregateMetrics([user1Day1, user1Day2, user2, user3]);
+
+      expect(aggregated.aiAdoptionPhaseData).toHaveLength(2);
+
+      const phase1 = aggregated.aiAdoptionPhaseData.find(phase => phase.phase.phase_number === 1)!;
+      expect(phase1.userCount).toBe(2);
+      expect(phase1.avgUserInitiatedInteractions).toBe(20);
+      expect(phase1.totalLocAdded).toBe(200);
+      expect(phase1.totalLocDeleted).toBe(20);
+      expect(phase1.avgLocAdded).toBe(100);
+      expect(phase1.avgLocDeleted).toBe(10);
+      expect(phase1.avgDaysActive).toBe(1.5);
+      expect(phase1.topModels).toEqual([
+        { name: 'gpt-4o', total: 28, uniqueUsers: 2 },
+        { name: 'claude-sonnet-4.6', total: 15, uniqueUsers: 1 },
+      ]);
+      expect(phase1.topClients).toEqual([
+        { name: 'vscode', total: 17, uniqueUsers: 2 },
+      ]);
+      expect(phase1.topLanguages).toEqual([
+        { name: 'typescript', total: 18, uniqueUsers: 2 },
+        { name: 'python', total: 10, uniqueUsers: 1 },
+      ]);
+
+      const phase2 = aggregated.aiAdoptionPhaseData.find(phase => phase.phase.phase_number === 2)!;
+      expect(phase2.userCount).toBe(1);
+      expect(phase2.avgUserInitiatedInteractions).toBe(5);
+      expect(phase2.topClients).toEqual([
+        { name: 'intellij', total: 7, uniqueUsers: 1 },
+      ]);
+    });
+
     it('should accumulate user flags across multiple days (OR logic)', () => {
       // User uses chat on day 1, agent on day 2
       const day1 = createBasicMetric({

--- a/src/domain/__tests__/metricsAggregator.test.ts
+++ b/src/domain/__tests__/metricsAggregator.test.ts
@@ -306,6 +306,28 @@ describe('metricsAggregator', () => {
       ]);
     });
 
+    it('should not fall back to CLI request counts when prompt count is zero for AI adoption clients', () => {
+      const metric = createBasicMetric({
+        user_id: 1,
+        day: '2024-01-15',
+        ai_adoption_phase: { phase_number: 1, phase: 'Phase 1', version: 'v1' },
+        totals_by_cli: {
+          session_count: 2,
+          request_count: 4,
+          prompt_count: 0,
+          token_usage: {
+            output_tokens_sum: 0,
+            prompt_tokens_sum: 0,
+            avg_tokens_per_request: 0,
+          },
+        },
+      });
+
+      const { aggregated } = aggregateMetrics([metric]);
+
+      expect(aggregated.aiAdoptionPhaseData[0].topClients).toEqual([]);
+    });
+
     it('should accumulate user flags across multiple days (OR logic)', () => {
       // User uses chat on day 1, agent on day 2
       const day1 = createBasicMetric({

--- a/src/domain/calculators/aiAdoptionPhaseCalculator.ts
+++ b/src/domain/calculators/aiAdoptionPhaseCalculator.ts
@@ -1,0 +1,229 @@
+import type { AIAdoptionPhase, CopilotMetrics } from '../../types/metrics';
+import { classifyModelRequest } from '../modelConfig';
+
+export interface AiAdoptionPhaseTopEntry {
+  name: string;
+  total: number;
+  uniqueUsers: number;
+}
+
+export interface AiAdoptionPhaseData {
+  phase: AIAdoptionPhase;
+  userCount: number;
+  avgUserInitiatedInteractions: number;
+  totalLocAdded: number;
+  totalLocDeleted: number;
+  avgLocAdded: number;
+  avgLocDeleted: number;
+  avgDaysActive: number;
+  topModels: AiAdoptionPhaseTopEntry[];
+  topClients: AiAdoptionPhaseTopEntry[];
+  topLanguages: AiAdoptionPhaseTopEntry[];
+}
+
+interface UserPhaseAccumulatorEntry {
+  phase?: AIAdoptionPhase;
+  latestPhaseDay?: string;
+  totalUserInitiatedInteractions: number;
+  totalLocAdded: number;
+  totalLocDeleted: number;
+  activeDays: Set<string>;
+  models: Map<string, number>;
+  clients: Map<string, number>;
+  languages: Map<string, number>;
+}
+
+interface PhaseAccumulatorEntry {
+  phase: AIAdoptionPhase;
+  userCount: number;
+  totalUserInitiatedInteractions: number;
+  totalLocAdded: number;
+  totalLocDeleted: number;
+  totalDaysActive: number;
+  models: Map<string, { total: number; uniqueUsers: number }>;
+  clients: Map<string, { total: number; uniqueUsers: number }>;
+  languages: Map<string, { total: number; uniqueUsers: number }>;
+}
+
+export interface AiAdoptionPhaseAccumulator {
+  users: Map<number, UserPhaseAccumulatorEntry>;
+}
+
+const MISSING_PHASE: AIAdoptionPhase = {
+  phase_number: -1,
+  phase: 'N/A',
+  version: 'unknown',
+};
+
+export function createAiAdoptionPhaseAccumulator(): AiAdoptionPhaseAccumulator {
+  return {
+    users: new Map(),
+  };
+}
+
+function getOrCreateUserEntry(
+  accumulator: AiAdoptionPhaseAccumulator,
+  userId: number
+): UserPhaseAccumulatorEntry {
+  if (!accumulator.users.has(userId)) {
+    accumulator.users.set(userId, {
+      totalUserInitiatedInteractions: 0,
+      totalLocAdded: 0,
+      totalLocDeleted: 0,
+      activeDays: new Set(),
+      models: new Map(),
+      clients: new Map(),
+      languages: new Map(),
+    });
+  }
+
+  return accumulator.users.get(userId)!;
+}
+
+function addDimensionUsage(map: Map<string, number>, name: string | undefined, count: number): void {
+  const normalizedName = name?.trim();
+  if (!normalizedName || count <= 0) return;
+  map.set(normalizedName, (map.get(normalizedName) ?? 0) + count);
+}
+
+function getActivityCount(item: {
+  user_initiated_interaction_count?: number;
+  code_generation_activity_count?: number;
+  code_acceptance_activity_count?: number;
+}): number {
+  return (item.user_initiated_interaction_count ?? 0)
+    + (item.code_generation_activity_count ?? 0)
+    + (item.code_acceptance_activity_count ?? 0);
+}
+
+function getCliActivityCount(metric: CopilotMetrics): number {
+  const cli = metric.totals_by_cli;
+  if (!cli) return metric.used_cli ? 1 : 0;
+  return cli.prompt_count || cli.request_count || cli.session_count || 0;
+}
+
+export function accumulateAiAdoptionPhase(
+  accumulator: AiAdoptionPhaseAccumulator,
+  metric: CopilotMetrics
+): void {
+  const entry = getOrCreateUserEntry(accumulator, metric.user_id);
+
+  entry.totalUserInitiatedInteractions += metric.user_initiated_interaction_count;
+  entry.totalLocAdded += metric.loc_added_sum;
+  entry.totalLocDeleted += metric.loc_deleted_sum;
+  entry.activeDays.add(metric.day);
+
+  if (metric.ai_adoption_phase) {
+    if (!entry.latestPhaseDay || metric.day >= entry.latestPhaseDay) {
+      entry.phase = { ...metric.ai_adoption_phase };
+      entry.latestPhaseDay = metric.day;
+    }
+  }
+
+  for (const modelFeature of metric.totals_by_model_feature) {
+    const interactionCount = modelFeature.user_initiated_interaction_count || 0;
+    const activityCount = (modelFeature.code_generation_activity_count || 0) + (modelFeature.code_acceptance_activity_count || 0);
+    const usageCount = interactionCount > 0 ? interactionCount : activityCount;
+    const { normalizedModel } = classifyModelRequest(modelFeature.model);
+    addDimensionUsage(entry.models, normalizedModel || 'unknown', usageCount);
+  }
+
+  for (const ideTotal of metric.totals_by_ide) {
+    addDimensionUsage(entry.clients, ideTotal.ide, getActivityCount(ideTotal));
+  }
+
+  addDimensionUsage(entry.clients, 'copilot_cli', getCliActivityCount(metric));
+
+  for (const languageFeature of metric.totals_by_language_feature) {
+    const language = languageFeature.language?.trim();
+    if (!language || language === 'unknown') continue;
+    const usageCount = languageFeature.code_generation_activity_count + languageFeature.code_acceptance_activity_count;
+    addDimensionUsage(entry.languages, language, usageCount);
+  }
+}
+
+function addUserDimensionsToPhase(
+  phaseDimensions: PhaseAccumulatorEntry['models'],
+  userDimensions: Map<string, number>
+): void {
+  for (const [name, total] of userDimensions) {
+    if (!phaseDimensions.has(name)) {
+      phaseDimensions.set(name, { total: 0, uniqueUsers: 0 });
+    }
+
+    const phaseDimension = phaseDimensions.get(name)!;
+    phaseDimension.total += total;
+    phaseDimension.uniqueUsers += 1;
+  }
+}
+
+function getOrCreatePhaseEntry(
+  phases: Map<number, PhaseAccumulatorEntry>,
+  phase: AIAdoptionPhase
+): PhaseAccumulatorEntry {
+  if (!phases.has(phase.phase_number)) {
+    phases.set(phase.phase_number, {
+      phase,
+      userCount: 0,
+      totalUserInitiatedInteractions: 0,
+      totalLocAdded: 0,
+      totalLocDeleted: 0,
+      totalDaysActive: 0,
+      models: new Map(),
+      clients: new Map(),
+      languages: new Map(),
+    });
+  }
+
+  return phases.get(phase.phase_number)!;
+}
+
+function computeTopEntries(dimensions: Map<string, { total: number; uniqueUsers: number }>): AiAdoptionPhaseTopEntry[] {
+  return Array.from(dimensions.entries())
+    .map(([name, entry]) => ({
+      name,
+      total: entry.total,
+      uniqueUsers: entry.uniqueUsers,
+    }))
+    .sort((a, b) => b.total - a.total || b.uniqueUsers - a.uniqueUsers || a.name.localeCompare(b.name))
+    .slice(0, 3);
+}
+
+function getPhaseSortValue(phaseNumber: number): number {
+  return phaseNumber < 0 ? Number.MAX_SAFE_INTEGER : phaseNumber;
+}
+
+export function computeAiAdoptionPhaseData(
+  accumulator: AiAdoptionPhaseAccumulator
+): AiAdoptionPhaseData[] {
+  const phases = new Map<number, PhaseAccumulatorEntry>();
+
+  for (const userEntry of accumulator.users.values()) {
+    const phase = userEntry.phase ?? MISSING_PHASE;
+    const phaseEntry = getOrCreatePhaseEntry(phases, phase);
+    phaseEntry.userCount += 1;
+    phaseEntry.totalUserInitiatedInteractions += userEntry.totalUserInitiatedInteractions;
+    phaseEntry.totalLocAdded += userEntry.totalLocAdded;
+    phaseEntry.totalLocDeleted += userEntry.totalLocDeleted;
+    phaseEntry.totalDaysActive += userEntry.activeDays.size;
+    addUserDimensionsToPhase(phaseEntry.models, userEntry.models);
+    addUserDimensionsToPhase(phaseEntry.clients, userEntry.clients);
+    addUserDimensionsToPhase(phaseEntry.languages, userEntry.languages);
+  }
+
+  return Array.from(phases.values())
+    .map((phaseEntry) => ({
+      phase: phaseEntry.phase,
+      userCount: phaseEntry.userCount,
+      avgUserInitiatedInteractions: phaseEntry.totalUserInitiatedInteractions / phaseEntry.userCount,
+      totalLocAdded: phaseEntry.totalLocAdded,
+      totalLocDeleted: phaseEntry.totalLocDeleted,
+      avgLocAdded: phaseEntry.totalLocAdded / phaseEntry.userCount,
+      avgLocDeleted: phaseEntry.totalLocDeleted / phaseEntry.userCount,
+      avgDaysActive: phaseEntry.totalDaysActive / phaseEntry.userCount,
+      topModels: computeTopEntries(phaseEntry.models),
+      topClients: computeTopEntries(phaseEntry.clients),
+      topLanguages: computeTopEntries(phaseEntry.languages),
+    }))
+    .sort((a, b) => getPhaseSortValue(a.phase.phase_number) - getPhaseSortValue(b.phase.phase_number));
+}

--- a/src/domain/calculators/aiAdoptionPhaseCalculator.ts
+++ b/src/domain/calculators/aiAdoptionPhaseCalculator.ts
@@ -99,7 +99,7 @@ function getActivityCount(item: {
 function getCliActivityCount(metric: CopilotMetrics): number {
   const cli = metric.totals_by_cli;
   if (!cli) return metric.used_cli ? 1 : 0;
-  return cli.prompt_count || cli.request_count || cli.session_count || 0;
+  return cli.prompt_count ?? cli.request_count ?? cli.session_count ?? 0;
 }
 
 export function accumulateAiAdoptionPhase(

--- a/src/domain/calculators/index.ts
+++ b/src/domain/calculators/index.ts
@@ -154,4 +154,13 @@ export {
   computeDailyCodeReviewAdoptionData,
 } from './advancedAdoptionCalculator';
 
+export {
+  type AiAdoptionPhaseAccumulator,
+  type AiAdoptionPhaseData,
+  type AiAdoptionPhaseTopEntry,
+  createAiAdoptionPhaseAccumulator,
+  accumulateAiAdoptionPhase,
+  computeAiAdoptionPhaseData,
+} from './aiAdoptionPhaseCalculator';
+
 export { compareDatesAsc, compareByDateAsc } from './statsCalculators';

--- a/src/domain/calculators/metricCalculators.ts
+++ b/src/domain/calculators/metricCalculators.ts
@@ -43,6 +43,11 @@ export type {
   DailyCodeReviewAdoptionData,
 } from './advancedAdoptionCalculator';
 
+export type {
+  AiAdoptionPhaseData,
+  AiAdoptionPhaseTopEntry,
+} from './aiAdoptionPhaseCalculator';
+
 export const calculateStats = calculateStatsFromMetrics;
 
 export const calculateDailyModelUsage = calculateDailyModelUsageFromMetrics;

--- a/src/domain/metricsAggregator.ts
+++ b/src/domain/metricsAggregator.ts
@@ -106,6 +106,11 @@ import {
   accumulateCodeReviewAdoptionSignal,
   computeDailyCloudAgentAdoptionData,
   computeDailyCodeReviewAdoptionData,
+
+  AiAdoptionPhaseData,
+  createAiAdoptionPhaseAccumulator,
+  accumulateAiAdoptionPhase,
+  computeAiAdoptionPhaseData,
 } from './calculators';
 import { isActiveAutoModeFeature } from './autoMode';
 
@@ -140,6 +145,7 @@ export interface AggregatedMetrics {
   dailyAdoptionTrend: DailyAdoptionTrend[];
   dailyCloudAgentAdoptionData: DailyCloudAgentAdoptionData[];
   dailyCodeReviewAdoptionData: DailyCodeReviewAdoptionData[];
+  aiAdoptionPhaseData: AiAdoptionPhaseData[];
 }
 
 interface UserSummaryAccumulator {
@@ -262,6 +268,7 @@ export function aggregateMetrics(
   const modelBreakdownAccumulator = createModelBreakdownAccumulator();
   const cliUsageAccumulator = createCliUsageAccumulator();
   const advancedAdoptionAccumulator = createAdvancedAdoptionAccumulator();
+  const aiAdoptionPhaseAccumulator = createAiAdoptionPhaseAccumulator();
   const userDetailAccumulator = createUserDetailAccumulator();
 
   for (const metric of metrics) {
@@ -279,6 +286,7 @@ export function aggregateMetrics(
     const usedCopilotCloudAgent = resolveCopilotCloudAgentUsage(metric);
 
     accumulateUserSummary(userSummaryAccumulator, metric, usedCopilotCloudAgent);
+    accumulateAiAdoptionPhase(aiAdoptionPhaseAccumulator, metric);
     accumulateUserDetail(userDetailAccumulator, metric);
 
     accumulateUserUsage(statsAccumulator, userId, metric.used_chat, metric.used_agent, metric.used_cli, usedCopilotCloudAgent);
@@ -417,6 +425,7 @@ export function aggregateMetrics(
     dailyAdoptionTrend: computeAdoptionTrend(engagementAccumulator, cliUsageAccumulator),
     dailyCloudAgentAdoptionData: computeDailyCloudAgentAdoptionData(advancedAdoptionAccumulator),
     dailyCodeReviewAdoptionData: computeDailyCodeReviewAdoptionData(advancedAdoptionAccumulator),
+    aiAdoptionPhaseData: computeAiAdoptionPhaseData(aiAdoptionPhaseAccumulator),
     },
     userDetailAccumulator,
   };

--- a/src/types/navigation.ts
+++ b/src/types/navigation.ts
@@ -9,6 +9,7 @@ export const VIEW_MODES = {
   CLIENT_ANALYSIS: 'ides',
   COPILOT_IMPACT: 'copilotImpact',
   COPILOT_ADOPTION: 'copilotAdoption',
+  AI_ADOPTION_PHASES: 'aiAdoptionPhases',
   MODEL_DETAILS: 'modelDetails',
   CLI_ADOPTION: 'cliAdoption',
 } as const;

--- a/src/utils/formatters.test.ts
+++ b/src/utils/formatters.test.ts
@@ -1,9 +1,33 @@
 import { describe, it, expect } from 'vitest';
 import { formatAiAdoptionPhase, formatAiAdoptionPhaseName, generateDateRange } from './formatters';
 
-describe('generateDateRange', () => {
-  it('returns a single date when start equals end', () => {
-    expect(generateDateRange('2024-01-15', '2024-01-15')).toEqual(['2024-01-15']);
+describe('formatters', () => {
+  describe('generateDateRange', () => {
+    it('returns a single date when start equals end', () => {
+      expect(generateDateRange('2024-01-15', '2024-01-15')).toEqual(['2024-01-15']);
+    });
+
+    it('returns all dates inclusive for a multi-day range', () => {
+      expect(generateDateRange('2024-01-13', '2024-01-15')).toEqual([
+        '2024-01-13',
+        '2024-01-14',
+        '2024-01-15',
+      ]);
+    });
+
+    it('returns an empty array when start is after end', () => {
+      expect(generateDateRange('2024-01-15', '2024-01-13')).toEqual([]);
+    });
+
+    it('correctly crosses a month boundary', () => {
+      const result = generateDateRange('2024-01-30', '2024-02-02');
+      expect(result).toEqual(['2024-01-30', '2024-01-31', '2024-02-01', '2024-02-02']);
+    });
+
+    it('correctly crosses a year boundary', () => {
+      const result = generateDateRange('2024-12-30', '2025-01-02');
+      expect(result).toEqual(['2024-12-30', '2024-12-31', '2025-01-01', '2025-01-02']);
+    });
   });
 
   describe('AI adoption phase formatters', () => {
@@ -27,27 +51,5 @@ describe('generateDateRange', () => {
       expect(formatAiAdoptionPhase()).toBe('N/A');
       expect(formatAiAdoptionPhaseName()).toBe('N/A');
     });
-  });
-
-  it('returns all dates inclusive for a multi-day range', () => {
-    expect(generateDateRange('2024-01-13', '2024-01-15')).toEqual([
-      '2024-01-13',
-      '2024-01-14',
-      '2024-01-15',
-    ]);
-  });
-
-  it('returns an empty array when start is after end', () => {
-    expect(generateDateRange('2024-01-15', '2024-01-13')).toEqual([]);
-  });
-
-  it('correctly crosses a month boundary', () => {
-    const result = generateDateRange('2024-01-30', '2024-02-02');
-    expect(result).toEqual(['2024-01-30', '2024-01-31', '2024-02-01', '2024-02-02']);
-  });
-
-  it('correctly crosses a year boundary', () => {
-    const result = generateDateRange('2024-12-30', '2025-01-02');
-    expect(result).toEqual(['2024-12-30', '2024-12-31', '2025-01-01', '2025-01-02']);
   });
 });

--- a/src/utils/formatters.test.ts
+++ b/src/utils/formatters.test.ts
@@ -1,9 +1,32 @@
 import { describe, it, expect } from 'vitest';
-import { generateDateRange } from './formatters';
+import { formatAiAdoptionPhase, formatAiAdoptionPhaseName, generateDateRange } from './formatters';
 
 describe('generateDateRange', () => {
   it('returns a single date when start equals end', () => {
     expect(generateDateRange('2024-01-15', '2024-01-15')).toEqual(['2024-01-15']);
+  });
+
+  describe('AI adoption phase formatters', () => {
+    it('formats known phase numbers using GitHub adoption labels', () => {
+      expect(formatAiAdoptionPhase({ phase_number: 0, phase: 'No Cohort', version: 'v1' })).toBe('Phase 0 — No cohort');
+      expect(formatAiAdoptionPhase({ phase_number: 1, phase: 'Phase 1', version: 'v1' })).toBe('Phase 1 — Code first');
+      expect(formatAiAdoptionPhase({ phase_number: 2, phase: 'Phase 2', version: 'v1' })).toBe('Phase 2 — Agent first');
+      expect(formatAiAdoptionPhase({ phase_number: 3, phase: 'Phase 3', version: 'v1' })).toBe('Phase 3 — Multi-agent');
+    });
+
+    it('formats phase names without phase numbers for compact header display', () => {
+      expect(formatAiAdoptionPhaseName({ phase_number: 2, phase: 'Phase 2', version: 'v1' })).toBe('Agent first');
+    });
+
+    it('falls back to API-provided values for unknown phases', () => {
+      expect(formatAiAdoptionPhase({ phase_number: 4, phase: 'Experimental', version: 'v2' })).toBe('Experimental');
+      expect(formatAiAdoptionPhaseName({ phase_number: 4, phase: 'Experimental', version: 'v2' })).toBe('Experimental');
+    });
+
+    it('formats missing phase data as not available', () => {
+      expect(formatAiAdoptionPhase()).toBe('N/A');
+      expect(formatAiAdoptionPhaseName()).toBe('N/A');
+    });
   });
 
   it('returns all dates inclusive for a multi-day range', () => {

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -153,9 +153,26 @@ export function formatModelDisplayName(modelName: string): string {
   return modelName.charAt(0).toUpperCase() + modelName.slice(1).replace(/-/g, ' ');
 }
 
+const AI_ADOPTION_PHASE_NAMES_BY_NUMBER: Partial<Record<number, string>> = {
+  0: 'No cohort',
+  1: 'Code first',
+  2: 'Agent first',
+  3: 'Multi-agent',
+};
+
+export function formatAiAdoptionPhaseName(aiAdoptionPhase?: AIAdoptionPhase): string {
+  if (!aiAdoptionPhase) return 'N/A';
+  return AI_ADOPTION_PHASE_NAMES_BY_NUMBER[aiAdoptionPhase.phase_number]
+    ?? aiAdoptionPhase.phase
+    ?? `Phase ${aiAdoptionPhase.phase_number}`;
+}
+
 export function formatAiAdoptionPhase(aiAdoptionPhase?: AIAdoptionPhase): string {
   if (!aiAdoptionPhase) return 'N/A';
-  return aiAdoptionPhase.phase || `Phase ${aiAdoptionPhase.phase_number}`;
+  const phaseName = AI_ADOPTION_PHASE_NAMES_BY_NUMBER[aiAdoptionPhase.phase_number];
+  return phaseName
+    ? `Phase ${aiAdoptionPhase.phase_number} — ${phaseName}`
+    : aiAdoptionPhase.phase || `Phase ${aiAdoptionPhase.phase_number}`;
 }
 
 export function generateDateRange(startDay: string, endDay: string): string[] {


### PR DESCRIPTION
## Why

GitHub now classifies Copilot users into AI adoption phases, and admins need a dedicated view to compare cohort maturity and activity patterns. This adds phase-aware aggregation in the worker flow so the UI can show phase distribution and usage characteristics without raw metric processing on the main thread.

| Commit | Change |
|--------|--------|
| `feat: add AI adoption phase view` | Adds phase label formatting, worker-side phase aggregation, navigation under Copilot Adoption, and a phase comparison table with averages, total LOC impact, and top models, clients, and languages. |