### PR TITLE
Add AI cost metrics

### DIFF
--- a/src/__tests__/factories/metrics.ts
+++ b/src/__tests__/factories/metrics.ts
@@ -26,6 +26,7 @@ export function makeMetric(overrides: Partial<CopilotMetrics> = {}): CopilotMetr
     loc_deleted_sum: 0,
     loc_suggested_to_add_sum: 0,
     loc_suggested_to_delete_sum: 0,
+    ai_credits_used: 0,
     totals_by_ide: [],
     totals_by_feature: [],
     totals_by_language_feature: [],

--- a/src/components/AiAdoptionPhaseView.tsx
+++ b/src/components/AiAdoptionPhaseView.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import MetricsTable, { TableColumn } from './ui/MetricsTable';
 import { ViewPanel } from './ui';
 import type { AiAdoptionPhaseData, AiAdoptionPhaseTopEntry } from '../domain/calculators/metricCalculators';
-import { formatAiAdoptionPhase, formatModelDisplayName, formatNumber } from '../utils/formatters';
+import { formatAiAdoptionPhase, formatAiCreditCost, formatModelDisplayName, formatNumber } from '../utils/formatters';
 import { formatIDEName, getIDEIcon } from './icons/IDEIcons';
 
 interface AiAdoptionPhaseViewProps {
@@ -109,6 +109,13 @@ export default function AiAdoptionPhaseView({ phaseData }: AiAdoptionPhaseViewPr
           <span className="text-red-600">-{formatAverage(phase.avgLocDeleted)}</span>
         </span>
       ),
+    },
+    {
+      id: 'avgAiCreditsUsed',
+      header: 'Avg AI Cost',
+      headerClassName: rightHeaderClass,
+      className: rightCellClass,
+      renderCell: (phase) => formatAiCreditCost(phase.avgAiCreditsUsed),
     },
     {
       id: 'totalLocImpact',

--- a/src/components/UniqueUsersView.tsx
+++ b/src/components/UniqueUsersView.tsx
@@ -4,7 +4,7 @@ import { useEffect, useMemo, useState } from 'react';
 import type { UserSummary } from '../types/metrics';
 import { useUsernameTrieSearch } from '../hooks/useUsernameTrieSearch';
 import { useSortableTable } from '../hooks/useSortableTable';
-import { formatAiAdoptionPhase } from '../utils/formatters';
+import { formatAiAdoptionPhase, formatAiCreditCost } from '../utils/formatters';
 import { ViewPanel } from './ui';
 import DashboardStatsCard from './ui/DashboardStatsCard';
 import StatsGrid from './ui/StatsGrid';
@@ -15,7 +15,7 @@ interface UniqueUsersViewProps {
   onUserClick: (userLogin: string, userId: number) => void;
 }
 
-type SortField = 'user_login' | 'total_user_initiated_interactions' | 'total_code_generation_activities' | 'days_active' | 'net_loc_contribution' | 'cloud_agent_days' | 'code_review_days';
+type SortField = 'user_login' | 'total_user_initiated_interactions' | 'total_code_generation_activities' | 'total_ai_credits_used' | 'days_active' | 'net_loc_contribution' | 'cloud_agent_days' | 'code_review_days';
 const USERS_PER_PAGE = 500;
 
 export default function UniqueUsersView({ users, onUserClick }: UniqueUsersViewProps) {
@@ -99,6 +99,14 @@ export default function UniqueUsersView({ users, onUserClick }: UniqueUsersViewP
       accessor: 'total_code_generation_activities',
       headerClassName: `${headerRightClass} w-1/8`,
       className: valueCellClass,
+    },
+    {
+      id: 'total_ai_credits_used',
+      header: 'AI COST',
+      sortable: true,
+      headerClassName: `${headerRightClass} w-1/8`,
+      className: valueCellClass,
+      renderCell: (user) => formatAiCreditCost(user.total_ai_credits_used),
     },
     {
       id: 'net_loc_contribution',

--- a/src/components/UserDetailsView.tsx
+++ b/src/components/UserDetailsView.tsx
@@ -132,7 +132,7 @@ export default function UserDetailsView({ userDetails, userSummary, userLogin, u
 
   const totalCliPrompts = userDetails.days.reduce((sum, day) => sum + (day.totals_by_cli?.prompt_count ?? 0), 0);
   const daysActive = userSummary.days_active;
-  const aiCreditsUsed = userDetails.total_ai_credits_used;
+  const aiCreditsUsed = userDetails.totalAiCreditsUsed;
   const aiAdoptionPhaseLabel = formatAiAdoptionPhase(userSummary.ai_adoption_phase);
   const usedAgent = userSummary.used_agent;
   const usedChat = userSummary.used_chat;

--- a/src/components/UserDetailsView.tsx
+++ b/src/components/UserDetailsView.tsx
@@ -5,7 +5,7 @@ import type { UserSummary, UserDayData } from '../types/metrics';
 import type { UserDetailedMetrics } from '../types/aggregatedMetrics';
 import { translateFeature } from '../domain/featureTranslations';
 import { formatIDEName } from './icons/IDEIcons';
-import { formatAiAdoptionPhase, formatShortDate, generateDateRange } from '../utils/formatters';
+import { formatAiAdoptionPhase, formatAiCreditCost, formatShortDate, generateDateRange } from '../utils/formatters';
 import { padSeriesWithDefaults } from '../utils/timeSeries';
 import ClientActivityChart from './charts/ClientActivityChart';
 import CLISessionChart from './charts/CLISessionChart';
@@ -132,6 +132,7 @@ export default function UserDetailsView({ userDetails, userSummary, userLogin, u
 
   const totalCliPrompts = userDetails.days.reduce((sum, day) => sum + (day.totals_by_cli?.prompt_count ?? 0), 0);
   const daysActive = userSummary.days_active;
+  const aiCreditsUsed = userDetails.total_ai_credits_used;
   const aiAdoptionPhaseLabel = formatAiAdoptionPhase(userSummary.ai_adoption_phase);
   const usedAgent = userSummary.used_agent;
   const usedChat = userSummary.used_chat;
@@ -548,6 +549,8 @@ export default function UserDetailsView({ userDetails, userSummary, userLogin, u
             <span>User ID: {userId}</span>
             <span aria-hidden="true" className="text-gray-300">•</span>
             <span>AI adoption phase: {aiAdoptionPhaseLabel}</span>
+            <span aria-hidden="true" className="text-gray-300">•</span>
+            <span>AI cost: {formatAiCreditCost(aiCreditsUsed)}</span>
           </p>
         </div>
       )}

--- a/src/components/layout/navigationItems.tsx
+++ b/src/components/layout/navigationItems.tsx
@@ -72,7 +72,7 @@ export const NAV_ITEMS: NavItem[] = [
     view: VIEW_MODES.AI_ADOPTION_PHASES,
     icon: (
       <svg className="w-5 h-5" aria-hidden="true" focusable="false" fill="none" stroke="currentColor" strokeWidth={1.5} viewBox="0 0 24 24">
-        <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5M3.75 17.25h16.5M6.75 6.75v10.5M12 6.75v10.5M17.25 6.75v10.5" />
+        <path strokeLinecap="round" strokeLinejoin="round" d="M3 3v1.5M3 21v-6m0 0 2.77-.693a9 9 0 0 1 6.208.682l.108.054a9 9 0 0 0 6.086.71l3.114-.732a48.524 48.524 0 0 1-.005-10.499l-3.11.732a9 9 0 0 1-6.085-.711l-.108-.054a9 9 0 0 0-6.208-.682L3 4.5M3 15V4.5" />
       </svg>
     ),
   },

--- a/src/components/ui/DayDetailsModal.tsx
+++ b/src/components/ui/DayDetailsModal.tsx
@@ -10,6 +10,7 @@ import DayFeatureBreakdown from './DayFeatureBreakdown';
 import DayClientDistributionChart from '../charts/DayClientDistributionChart';
 import type { VoidCallback } from '../../types/events';
 import { getTotalUserInitiatedInteractionCount } from '../../domain/assumedInteractions';
+import { formatAiCreditCost } from '../../utils/formatters';
 
 interface DayDetailsModalProps {
   isOpen: boolean;
@@ -105,8 +106,10 @@ export default function DayDetailsModal({ isOpen, onClose, date, dayMetrics, use
           <div>
             <h2 className="text-xl font-bold text-gray-900">{formatDate(date)}</h2>
             {hasData && userLogin && (
-              <p className="text-sm text-gray-600 mt-1">
-                User: {userLogin}
+              <p className="mt-1 flex flex-wrap items-center gap-2 text-sm text-gray-600">
+                <span>User: {userLogin}</span>
+                <span aria-hidden="true" className="text-gray-300">•</span>
+                <span>AI cost: {formatAiCreditCost(dayMetrics?.ai_credits_used ?? 0)}</span>
               </p>
             )}
           </div>

--- a/src/domain/__tests__/metricsAggregator.test.ts
+++ b/src/domain/__tests__/metricsAggregator.test.ts
@@ -111,6 +111,23 @@ describe('metricsAggregator', () => {
       expect(userSummary.days_active).toBe(2);
     });
 
+    it('should aggregate AI credits per user across days', () => {
+      const day1 = createBasicMetric({
+        user_id: 123,
+        day: '2024-01-15',
+        ai_credits_used: 55.053015,
+      });
+      const day2 = createBasicMetric({
+        user_id: 123,
+        day: '2024-01-16',
+        ai_credits_used: 4.946985,
+      });
+
+      const { aggregated } = aggregateMetrics([day1, day2]);
+
+      expect(aggregated.userSummaries[0].total_ai_credits_used).toBeCloseTo(60);
+    });
+
     it('should track user feature flags correctly', () => {
       const agentUser = createBasicMetric({
         user_id: 1,
@@ -235,6 +252,7 @@ describe('metricsAggregator', () => {
         user_initiated_interaction_count: 10,
         loc_added_sum: 100,
         loc_deleted_sum: 10,
+        ai_credits_used: 10,
         ai_adoption_phase: { phase_number: 1, phase: 'Phase 1', version: 'v1' },
         totals_by_ide: [ideTotal('vscode', 10)],
         totals_by_model_feature: [modelFeature('gpt-4o', 8)],
@@ -246,6 +264,7 @@ describe('metricsAggregator', () => {
         user_initiated_interaction_count: 20,
         loc_added_sum: 50,
         loc_deleted_sum: 5,
+        ai_credits_used: 20,
         ai_adoption_phase: { phase_number: 1, phase: 'Phase 1', version: 'v1' },
         totals_by_ide: [ideTotal('vscode', 4)],
         totals_by_model_feature: [modelFeature('claude-sonnet-4.6', 15)],
@@ -257,6 +276,7 @@ describe('metricsAggregator', () => {
         user_initiated_interaction_count: 10,
         loc_added_sum: 50,
         loc_deleted_sum: 5,
+        ai_credits_used: 50,
         ai_adoption_phase: { phase_number: 1, phase: 'Phase 1', version: 'v1' },
         totals_by_ide: [ideTotal('vscode', 3)],
         totals_by_model_feature: [modelFeature('gpt-4o', 20)],
@@ -268,6 +288,7 @@ describe('metricsAggregator', () => {
         user_initiated_interaction_count: 5,
         loc_added_sum: 30,
         loc_deleted_sum: 3,
+        ai_credits_used: 5,
         ai_adoption_phase: { phase_number: 2, phase: 'Phase 2', version: 'v1' },
         totals_by_ide: [ideTotal('intellij', 7)],
         totals_by_model_feature: [modelFeature('gpt-4o', 10)],
@@ -285,6 +306,7 @@ describe('metricsAggregator', () => {
       expect(phase1.totalLocDeleted).toBe(20);
       expect(phase1.avgLocAdded).toBe(100);
       expect(phase1.avgLocDeleted).toBe(10);
+      expect(phase1.avgAiCreditsUsed).toBe(40);
       expect(phase1.avgDaysActive).toBe(1.5);
       expect(phase1.topModels).toEqual([
         { name: 'gpt-4o', total: 28, uniqueUsers: 2 },
@@ -301,6 +323,7 @@ describe('metricsAggregator', () => {
       const phase2 = aggregated.aiAdoptionPhaseData.find(phase => phase.phase.phase_number === 2)!;
       expect(phase2.userCount).toBe(1);
       expect(phase2.avgUserInitiatedInteractions).toBe(5);
+      expect(phase2.avgAiCreditsUsed).toBe(5);
       expect(phase2.topClients).toEqual([
         { name: 'intellij', total: 7, uniqueUsers: 1 },
       ]);

--- a/src/domain/__tests__/metricsParser.test.ts
+++ b/src/domain/__tests__/metricsParser.test.ts
@@ -19,6 +19,7 @@ describe('metricsParser', () => {
         loc_deleted_sum: 20,
         loc_suggested_to_add_sum: 150,
         loc_suggested_to_delete_sum: 30,
+        ai_credits_used: 55.053015,
         totals_by_ide: [],
         totals_by_feature: [],
         totals_by_language_feature: [],
@@ -42,6 +43,7 @@ describe('metricsParser', () => {
       expect(result?.loc_deleted_sum).toBe(20);
       expect(result?.loc_suggested_to_add_sum).toBe(150);
       expect(result?.loc_suggested_to_delete_sum).toBe(30);
+      expect(result?.ai_credits_used).toBe(55.053015);
       expect(result?.ai_adoption_phase).toEqual({
         phase_number: 2,
         phase: 'Phase 2',
@@ -191,6 +193,66 @@ describe('metricsParser', () => {
 
       expect(result).not.toBeNull();
       expect(result?.used_cli).toBe(false);
+      expect(result?.ai_credits_used).toBe(0);
+    });
+
+    it('should reject lines with invalid ai_credits_used', () => {
+      const invalidCreditsLine = JSON.stringify({
+        report_start_day: '2024-01-01',
+        report_end_day: '2024-01-31',
+        day: '2024-01-15',
+        enterprise_id: 'test-enterprise',
+        user_id: 123,
+        user_login: 'testuser',
+        user_initiated_interaction_count: 10,
+        code_generation_activity_count: 5,
+        code_acceptance_activity_count: 3,
+        loc_added_sum: 100,
+        loc_deleted_sum: 20,
+        loc_suggested_to_add_sum: 150,
+        loc_suggested_to_delete_sum: 30,
+        ai_credits_used: '55.05',
+        totals_by_ide: [],
+        totals_by_feature: [],
+        totals_by_language_feature: [],
+        totals_by_language_model: [],
+        totals_by_model_feature: [],
+        used_agent: false,
+        used_chat: true,
+      });
+
+      expect(parseMetricsLine(invalidCreditsLine)).toBeNull();
+    });
+
+    it('should default null ai_credits_used to zero', () => {
+      const lineWithNullCredits = JSON.stringify({
+        report_start_day: '2024-01-01',
+        report_end_day: '2024-01-31',
+        day: '2024-01-15',
+        enterprise_id: 'test-enterprise',
+        user_id: 123,
+        user_login: 'testuser',
+        user_initiated_interaction_count: 10,
+        code_generation_activity_count: 5,
+        code_acceptance_activity_count: 3,
+        loc_added_sum: 100,
+        loc_deleted_sum: 20,
+        loc_suggested_to_add_sum: 150,
+        loc_suggested_to_delete_sum: 30,
+        ai_credits_used: null,
+        totals_by_ide: [],
+        totals_by_feature: [],
+        totals_by_language_feature: [],
+        totals_by_language_model: [],
+        totals_by_model_feature: [],
+        used_agent: false,
+        used_chat: true,
+      });
+
+      const result = parseMetricsLine(lineWithNullCredits);
+
+      expect(result).not.toBeNull();
+      expect(result?.ai_credits_used).toBe(0);
     });
 
     it('should default used_copilot_coding_agent to false when missing', () => {

--- a/src/domain/calculators/__tests__/cliUsageCalculator.test.ts
+++ b/src/domain/calculators/__tests__/cliUsageCalculator.test.ts
@@ -42,6 +42,7 @@ function makeUserDayData(overrides: Partial<UserDayData> = {}): UserDayData {
     loc_deleted_sum: 0,
     loc_suggested_to_add_sum: 0,
     loc_suggested_to_delete_sum: 0,
+    ai_credits_used: 0,
     used_copilot_coding_agent: false,
     used_copilot_code_review_active: false,
     used_copilot_code_review_passive: false,

--- a/src/domain/calculators/__tests__/userDetailCalculator.test.ts
+++ b/src/domain/calculators/__tests__/userDetailCalculator.test.ts
@@ -131,6 +131,29 @@ describe('userDetailCalculator', () => {
     });
   });
 
+  describe('accumulateUserDetail — AI credits', () => {
+    it('should expose total and daily AI credits in the user detail payload', () => {
+      const acc = createUserDetailAccumulator();
+      acc.reportStartDay = '2024-01-01';
+      acc.reportEndDay = '2024-01-31';
+
+      accumulateUserDetail(acc, createMetric({
+        day: '2024-01-15',
+        ai_credits_used: 55.053015,
+      }));
+      accumulateUserDetail(acc, createMetric({
+        day: '2024-01-16',
+        ai_credits_used: 4.946985,
+      }));
+
+      const result = computeSingleUserDetailedMetrics(acc, 1);
+
+      expect(result).not.toBeNull();
+      expect(result!.total_ai_credits_used).toBeCloseTo(60);
+      expect(result!.days.map(day => day.ai_credits_used)).toEqual([55.053015, 4.946985]);
+    });
+  });
+
   describe('accumulateUserDetail — CLI data stored in days', () => {
     it('should store totals_by_cli in the day entry when present', () => {
       const acc = createUserDetailAccumulator();

--- a/src/domain/calculators/__tests__/userDetailCalculator.test.ts
+++ b/src/domain/calculators/__tests__/userDetailCalculator.test.ts
@@ -149,7 +149,7 @@ describe('userDetailCalculator', () => {
       const result = computeSingleUserDetailedMetrics(acc, 1);
 
       expect(result).not.toBeNull();
-      expect(result!.total_ai_credits_used).toBeCloseTo(60);
+      expect(result!.totalAiCreditsUsed).toBeCloseTo(60);
       expect(result!.days.map(day => day.ai_credits_used)).toEqual([55.053015, 4.946985]);
     });
   });

--- a/src/domain/calculators/aiAdoptionPhaseCalculator.ts
+++ b/src/domain/calculators/aiAdoptionPhaseCalculator.ts
@@ -15,6 +15,7 @@ export interface AiAdoptionPhaseData {
   totalLocDeleted: number;
   avgLocAdded: number;
   avgLocDeleted: number;
+  avgAiCreditsUsed: number;
   avgDaysActive: number;
   topModels: AiAdoptionPhaseTopEntry[];
   topClients: AiAdoptionPhaseTopEntry[];
@@ -27,6 +28,7 @@ interface UserPhaseAccumulatorEntry {
   totalUserInitiatedInteractions: number;
   totalLocAdded: number;
   totalLocDeleted: number;
+  totalAiCreditsUsed: number;
   activeDays: Set<string>;
   models: Map<string, number>;
   clients: Map<string, number>;
@@ -39,6 +41,7 @@ interface PhaseAccumulatorEntry {
   totalUserInitiatedInteractions: number;
   totalLocAdded: number;
   totalLocDeleted: number;
+  totalAiCreditsUsed: number;
   totalDaysActive: number;
   models: Map<string, { total: number; uniqueUsers: number }>;
   clients: Map<string, { total: number; uniqueUsers: number }>;
@@ -70,6 +73,7 @@ function getOrCreateUserEntry(
       totalUserInitiatedInteractions: 0,
       totalLocAdded: 0,
       totalLocDeleted: 0,
+      totalAiCreditsUsed: 0,
       activeDays: new Set(),
       models: new Map(),
       clients: new Map(),
@@ -111,6 +115,7 @@ export function accumulateAiAdoptionPhase(
   entry.totalUserInitiatedInteractions += metric.user_initiated_interaction_count;
   entry.totalLocAdded += metric.loc_added_sum;
   entry.totalLocDeleted += metric.loc_deleted_sum;
+  entry.totalAiCreditsUsed += metric.ai_credits_used;
   entry.activeDays.add(metric.day);
 
   if (metric.ai_adoption_phase) {
@@ -168,6 +173,7 @@ function getOrCreatePhaseEntry(
       totalUserInitiatedInteractions: 0,
       totalLocAdded: 0,
       totalLocDeleted: 0,
+      totalAiCreditsUsed: 0,
       totalDaysActive: 0,
       models: new Map(),
       clients: new Map(),
@@ -205,6 +211,7 @@ export function computeAiAdoptionPhaseData(
     phaseEntry.totalUserInitiatedInteractions += userEntry.totalUserInitiatedInteractions;
     phaseEntry.totalLocAdded += userEntry.totalLocAdded;
     phaseEntry.totalLocDeleted += userEntry.totalLocDeleted;
+    phaseEntry.totalAiCreditsUsed += userEntry.totalAiCreditsUsed;
     phaseEntry.totalDaysActive += userEntry.activeDays.size;
     addUserDimensionsToPhase(phaseEntry.models, userEntry.models);
     addUserDimensionsToPhase(phaseEntry.clients, userEntry.clients);
@@ -220,6 +227,7 @@ export function computeAiAdoptionPhaseData(
       totalLocDeleted: phaseEntry.totalLocDeleted,
       avgLocAdded: phaseEntry.totalLocAdded / phaseEntry.userCount,
       avgLocDeleted: phaseEntry.totalLocDeleted / phaseEntry.userCount,
+      avgAiCreditsUsed: phaseEntry.totalAiCreditsUsed / phaseEntry.userCount,
       avgDaysActive: phaseEntry.totalDaysActive / phaseEntry.userCount,
       topModels: computeTopEntries(phaseEntry.models),
       topClients: computeTopEntries(phaseEntry.clients),

--- a/src/domain/calculators/userDetailCalculator.ts
+++ b/src/domain/calculators/userDetailCalculator.ts
@@ -345,7 +345,7 @@ export function computeSingleUserDetailedMetrics(
 
   return {
     totalModelRequests: state.totalModelRequests,
-    total_ai_credits_used: state.totalAiCreditsUsed,
+    totalAiCreditsUsed: state.totalAiCreditsUsed,
     featureAggregates: Array.from(state.featureMap.values()),
     ideAggregates: Array.from(state.ideMap.values()),
     languageFeatureAggregates: Array.from(state.langFeatureMap.values()),

--- a/src/domain/calculators/userDetailCalculator.ts
+++ b/src/domain/calculators/userDetailCalculator.ts
@@ -84,6 +84,7 @@ interface CliVersionEntry {
 
 interface UserAccState {
   totalModelRequests: number;
+  totalAiCreditsUsed: number;
   featureMap: Map<string, FeatureAgg>;
   ideMap: Map<string, IDEAgg>;
   langFeatureMap: Map<string, LangFeatureAgg>;
@@ -112,6 +113,7 @@ function getOrCreateUserState(accumulator: UserDetailAccumulator, userId: number
   if (!state) {
     state = {
       totalModelRequests: 0,
+      totalAiCreditsUsed: 0,
       featureMap: new Map(),
       ideMap: new Map(),
       langFeatureMap: new Map(),
@@ -198,6 +200,7 @@ export function accumulateUserDetail(
   for (const mf of modelFeatureTotals) {
     state.totalModelRequests += getTotalUserInitiatedInteractionCount(mf);
   }
+  state.totalAiCreditsUsed += metric.ai_credits_used;
 
   for (const f of featureTotals) {
     upsertAggMapEntry(state.featureMap, f.feature, f, accumulateInteractionAggMetricTotals);
@@ -253,6 +256,7 @@ export function accumulateUserDetail(
     loc_deleted_sum: metric.loc_deleted_sum,
     loc_suggested_to_add_sum: metric.loc_suggested_to_add_sum,
     loc_suggested_to_delete_sum: metric.loc_suggested_to_delete_sum,
+    ai_credits_used: metric.ai_credits_used,
     used_copilot_coding_agent: metric.used_copilot_coding_agent ?? false,
     used_copilot_code_review_active: metric.used_copilot_code_review_active ?? false,
     used_copilot_code_review_passive: metric.used_copilot_code_review_passive ?? false,
@@ -341,6 +345,7 @@ export function computeSingleUserDetailedMetrics(
 
   return {
     totalModelRequests: state.totalModelRequests,
+    total_ai_credits_used: state.totalAiCreditsUsed,
     featureAggregates: Array.from(state.featureMap.values()),
     ideAggregates: Array.from(state.ideMap.values()),
     languageFeatureAggregates: Array.from(state.langFeatureMap.values()),

--- a/src/domain/metricsAggregator.ts
+++ b/src/domain/metricsAggregator.ts
@@ -189,6 +189,7 @@ function accumulateUserSummary(
       total_loc_deleted: 0,
       total_loc_suggested_to_add: 0,
       total_loc_suggested_to_delete: 0,
+      total_ai_credits_used: 0,
       net_loc_contribution: 0,
       days_active: 0,
       cloud_agent_days: 0,
@@ -214,6 +215,7 @@ function accumulateUserSummary(
   userSummary.total_loc_deleted += metric.loc_deleted_sum;
   userSummary.total_loc_suggested_to_add += metric.loc_suggested_to_add_sum;
   userSummary.total_loc_suggested_to_delete += metric.loc_suggested_to_delete_sum;
+  userSummary.total_ai_credits_used += metric.ai_credits_used;
   userSummary.used_agent = userSummary.used_agent || metric.used_agent;
   userSummary.used_chat = userSummary.used_chat || metric.used_chat;
   userSummary.used_cli = userSummary.used_cli || metric.used_cli;

--- a/src/domain/metricsParser.ts
+++ b/src/domain/metricsParser.ts
@@ -60,6 +60,15 @@ export function parseMetricsLine(line: string, pool?: StringPool): CopilotMetric
 
     // We rely on upstream schema conformity; at runtime we only soft-validated key fields
     const metric = parsedRaw as unknown as CopilotMetrics;
+    const aiCreditsUsed = parsedRaw['ai_credits_used'];
+    if (aiCreditsUsed === undefined || aiCreditsUsed === null) {
+      metric.ai_credits_used = 0;
+    } else if (typeof aiCreditsUsed === 'number' && Number.isFinite(aiCreditsUsed)) {
+      metric.ai_credits_used = aiCreditsUsed;
+    } else {
+      console.warn('Skipping line with invalid ai_credits_used:', line.substring(0, 200));
+      return null;
+    }
     metric.used_cli = metric.used_cli ?? false;
     metric.used_copilot_code_review_active = metric.used_copilot_code_review_active ?? false;
     metric.used_copilot_code_review_passive = metric.used_copilot_code_review_passive ?? false;

--- a/src/types/aggregatedMetrics.ts
+++ b/src/types/aggregatedMetrics.ts
@@ -8,6 +8,7 @@ import type {
 
 export interface UserDetailedMetrics {
   totalModelRequests: number;
+  total_ai_credits_used: number;
   featureAggregates: Array<{
     feature: string;
     user_initiated_interaction_count: number;

--- a/src/types/aggregatedMetrics.ts
+++ b/src/types/aggregatedMetrics.ts
@@ -8,7 +8,7 @@ import type {
 
 export interface UserDetailedMetrics {
   totalModelRequests: number;
-  total_ai_credits_used: number;
+  totalAiCreditsUsed: number;
   featureAggregates: Array<{
     feature: string;
     user_initiated_interaction_count: number;

--- a/src/types/metrics.ts
+++ b/src/types/metrics.ts
@@ -21,6 +21,7 @@ export interface CopilotMetrics {
   loc_deleted_sum: number;
   loc_suggested_to_add_sum: number;
   loc_suggested_to_delete_sum: number;
+  ai_credits_used: number;
   totals_by_ide: Array<{
     ide: string;
     user_initiated_interaction_count: number;
@@ -126,6 +127,7 @@ export interface UserSummary {
   total_loc_deleted: number;
   total_loc_suggested_to_add: number;
   total_loc_suggested_to_delete: number;
+  total_ai_credits_used: number;
   net_loc_contribution: number;
   days_active: number;
   cloud_agent_days: number;
@@ -226,6 +228,7 @@ export interface UserDayData {
   loc_deleted_sum: number;
   loc_suggested_to_add_sum: number;
   loc_suggested_to_delete_sum: number;
+  ai_credits_used: number;
   used_copilot_coding_agent: boolean;
   used_copilot_code_review_active: boolean;
   used_copilot_code_review_passive: boolean;

--- a/src/utils/formatters.test.ts
+++ b/src/utils/formatters.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { formatAiAdoptionPhase, formatAiAdoptionPhaseName, generateDateRange } from './formatters';
+import { formatAiAdoptionPhase, formatAiAdoptionPhaseName, formatAiCreditCost, generateDateRange } from './formatters';
 
 describe('formatters', () => {
   describe('generateDateRange', () => {
@@ -50,6 +50,13 @@ describe('formatters', () => {
     it('formats missing phase data as not available', () => {
       expect(formatAiAdoptionPhase()).toBe('N/A');
       expect(formatAiAdoptionPhaseName()).toBe('N/A');
+    });
+  });
+
+  describe('formatAiCreditCost', () => {
+    it('formats AI credits as USD cost at one cent per credit', () => {
+      expect(formatAiCreditCost(55.053015)).toBe('$0.55');
+      expect(formatAiCreditCost(60)).toBe('$0.60');
     });
   });
 });

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -94,8 +94,10 @@ export function formatCurrency(
   });
 }
 
+const AI_CREDIT_COST_USD = 0.01;
+
 export function formatAiCreditCost(aiCreditsUsed: number): string {
-  return formatCurrency(aiCreditsUsed * 0.01);
+  return formatCurrency(aiCreditsUsed * AI_CREDIT_COST_USD);
 }
 
 /**

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -94,6 +94,10 @@ export function formatCurrency(
   });
 }
 
+export function formatAiCreditCost(aiCreditsUsed: number): string {
+  return formatCurrency(aiCreditsUsed * 0.01);
+}
+
 /**
  * Format a large number with compact notation (e.g., 1.2K, 3.5M).
  * @param value - Number to format


### PR DESCRIPTION
## Why

The usage reports now include `ai_credits_used`, and reviewers need the app to carry that data through aggregation while showing the business-friendly dollar cost in user and adoption-phase views.

| Commit | Change |
|--------|--------|
| `feat: add AI cost metrics` | Parses `ai_credits_used`, aggregates it per user and phase, and displays AI cost at $0.01 per credit across the user list, user details, day details, and AI adoption phase comparison. |
| `chore: update adoption phases nav icon` | Replaces the AI Adoption Phases nav glyph with a Heroicons flag to better communicate phase milestones. |
| `fix: address AI cost review feedback` | Aligns user detail naming with existing camelCase fields and extracts the USD-per-credit conversion into a named constant. |