### PR TITLE
Fix AI cost detail display

### DIFF
--- a/src/components/UserDetailsView.tsx
+++ b/src/components/UserDetailsView.tsx
@@ -132,7 +132,7 @@ export default function UserDetailsView({ userDetails, userSummary, userLogin, u
 
   const totalCliPrompts = userDetails.days.reduce((sum, day) => sum + (day.totals_by_cli?.prompt_count ?? 0), 0);
   const daysActive = userSummary.days_active;
-  const aiCreditsUsed = userDetails.totalAiCreditsUsed;
+  const aiCreditsUsed = userDetails.total_ai_credits_used;
   const aiAdoptionPhaseLabel = formatAiAdoptionPhase(userSummary.ai_adoption_phase);
   const usedAgent = userSummary.used_agent;
   const usedChat = userSummary.used_chat;

--- a/src/domain/calculators/__tests__/userDetailCalculator.test.ts
+++ b/src/domain/calculators/__tests__/userDetailCalculator.test.ts
@@ -149,7 +149,7 @@ describe('userDetailCalculator', () => {
       const result = computeSingleUserDetailedMetrics(acc, 1);
 
       expect(result).not.toBeNull();
-      expect(result!.totalAiCreditsUsed).toBeCloseTo(60);
+      expect(result!.total_ai_credits_used).toBeCloseTo(60);
       expect(result!.days.map(day => day.ai_credits_used)).toEqual([55.053015, 4.946985]);
     });
   });

--- a/src/domain/calculators/userDetailCalculator.ts
+++ b/src/domain/calculators/userDetailCalculator.ts
@@ -345,7 +345,7 @@ export function computeSingleUserDetailedMetrics(
 
   return {
     totalModelRequests: state.totalModelRequests,
-    totalAiCreditsUsed: state.totalAiCreditsUsed,
+    total_ai_credits_used: state.totalAiCreditsUsed,
     featureAggregates: Array.from(state.featureMap.values()),
     ideAggregates: Array.from(state.ideMap.values()),
     languageFeatureAggregates: Array.from(state.langFeatureMap.values()),

--- a/src/types/aggregatedMetrics.ts
+++ b/src/types/aggregatedMetrics.ts
@@ -8,7 +8,7 @@ import type {
 
 export interface UserDetailedMetrics {
   totalModelRequests: number;
-  totalAiCreditsUsed: number;
+  total_ai_credits_used: number;
   featureAggregates: Array<{
     feature: string;
     user_initiated_interaction_count: number;


### PR DESCRIPTION
The previous review follow-up renamed the user details AI cost field to camelCase, which broke the existing field-name contract and caused the User Details AI cost display to read as zero.

This restores `total_ai_credits_used` as the detail field used by the worker output and `UserDetailsView`, keeping it aligned with the existing AI credits field naming while retaining the named `AI_CREDIT_COST_USD` constant from the review feedback.

Validation:
- `npm run build && npm run lint && npm run test:run`