### PR TITLE
Improve adoption phase and client activity UI

### DIFF
--- a/src/components/AiAdoptionPhaseView.tsx
+++ b/src/components/AiAdoptionPhaseView.tsx
@@ -11,6 +11,33 @@ interface AiAdoptionPhaseViewProps {
   phaseData: AiAdoptionPhaseData[];
 }
 
+const AI_ADOPTION_PHASE_BLOG_URL = 'https://github.blog/changelog/2026-05-29-copilot-usage-metrics-api-adds-cohorts-for-ai-adoption/#whats-new';
+const PHASE_PILL_CLASS = 'inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-purple-100 text-purple-800';
+
+const PHASE_DEFINITIONS = [
+  {
+    phaseNumber: 0,
+    phase: 'No cohort',
+    description: 'User did not meet the engagement criteria for any phase.',
+  },
+  {
+    phaseNumber: 1,
+    phase: 'Phase 1',
+    description: 'User engaged with code completion and/or IDE agent mode.',
+  },
+  {
+    phaseNumber: 2,
+    phase: 'Phase 2',
+    description:
+      'User engaged with a single GitHub-based agent surface, such as Copilot cloud agent, Copilot code review, or Copilot CLI.',
+  },
+  {
+    phaseNumber: 3,
+    phase: 'Phase 3',
+    description: 'User engaged with two or more GitHub-based agent surfaces, or with the GitHub Copilot app.',
+  },
+] as const;
+
 function formatAverage(value: number): string {
   return formatNumber(value, 1);
 }
@@ -78,7 +105,7 @@ export default function AiAdoptionPhaseView({ phaseData }: AiAdoptionPhaseViewPr
       headerClassName: 'px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider min-w-[180px]',
       className: 'px-6 py-4 whitespace-nowrap',
       renderCell: (phase) => (
-        <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-purple-100 text-purple-800">
+        <span className={PHASE_PILL_CLASS}>
           {formatAiAdoptionPhase(phase.phase)}
         </span>
       ),
@@ -187,6 +214,42 @@ export default function AiAdoptionPhaseView({ phaseData }: AiAdoptionPhaseViewPr
             </div>
           )}
         />
+      </div>
+
+      <div className="bg-white rounded-md border border-[#d1d9e0]">
+        <div className="px-6 py-4 border-b border-gray-200">
+          <h3 className="text-lg font-semibold text-gray-900">How phases are assigned</h3>
+          <p className="mt-1 text-sm text-gray-600">
+            GitHub classifies each engaged user based on the Copilot surfaces used on at least two days in the rolling
+            28-day window.
+          </p>
+        </div>
+        <div className="px-6 py-5">
+          <dl className="space-y-3">
+            {PHASE_DEFINITIONS.map((phaseDefinition) => (
+              <div key={phaseDefinition.phaseNumber} className="rounded-lg border border-gray-200 bg-gray-50 p-4">
+                <dt>
+                  <span className={PHASE_PILL_CLASS}>
+                    {formatAiAdoptionPhase({
+                      phase_number: phaseDefinition.phaseNumber,
+                      phase: phaseDefinition.phase,
+                      version: 'v1',
+                    })}
+                  </span>
+                </dt>
+                <dd className="mt-2 text-sm text-gray-600">{phaseDefinition.description}</dd>
+              </div>
+            ))}
+          </dl>
+          <a
+            href={AI_ADOPTION_PHASE_BLOG_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="mt-4 inline-flex text-sm font-medium text-[#0969da] hover:underline"
+          >
+            Learn More
+          </a>
+        </div>
       </div>
     </ViewPanel>
   );

--- a/src/components/ui/DayDetailsModal.tsx
+++ b/src/components/ui/DayDetailsModal.tsx
@@ -3,7 +3,7 @@
 import React from 'react';
 import type { UserDayData } from '../../types/metrics';
 import { computeCliDayTotals } from '../../domain/calculators/cliUsageCalculator';
-import { formatIDEName } from '../icons/IDEIcons';
+import { formatIDEName, getIDEIcon } from '../icons/IDEIcons';
 import MetricsTable, { type TableColumn } from './MetricsTable';
 import DayImpactCard from './DayImpactCard';
 import DayFeatureBreakdown from './DayFeatureBreakdown';
@@ -24,6 +24,7 @@ type LanguageModelRow = UserDayData['totals_by_language_model'][number];
 
 interface ClientRow {
   name: string;
+  iconName: string;
   user_initiated_interaction_count: number;
   code_generation_activity_count: number;
   code_acceptance_activity_count: number;
@@ -38,7 +39,23 @@ const headerLeft = 'px-4 py-3 text-left text-xs font-medium text-gray-500 upperc
 const headerRight = 'px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider';
 
 const clientColumns: TableColumn<ClientRow>[] = [
-  { id: 'name', header: 'Client', headerClassName: headerLeft, className: cellLeft, renderCell: (r) => r.name },
+  {
+    id: 'name',
+    header: 'Client',
+    headerClassName: headerLeft,
+    className: cellLeft,
+    renderCell: (r) => {
+      const ClientIcon = getIDEIcon(r.iconName);
+      return (
+        <div className="flex items-center gap-2">
+          <span className="flex-shrink-0">
+            <ClientIcon />
+          </span>
+          <span>{r.name}</span>
+        </div>
+      );
+    },
+  },
   { id: 'interactions', header: 'Interactions', headerClassName: headerRight, className: cellRight, renderCell: (r) => r.user_initiated_interaction_count.toLocaleString() },
   { id: 'generation', header: 'Generation', headerClassName: headerRight, className: cellRight, renderCell: (r) => r.code_generation_activity_count.toLocaleString() },
   { id: 'acceptance', header: 'Acceptance', headerClassName: headerRight, className: cellRight, renderCell: (r) => r.code_acceptance_activity_count.toLocaleString() },
@@ -76,6 +93,7 @@ export default function DayDetailsModal({ isOpen, onClose, date, dayMetrics, use
   const clientRows: ClientRow[] = hasData ? [
     ...dayMetrics!.totals_by_ide.map((ide) => ({
       name: formatIDEName(ide.ide),
+      iconName: ide.ide,
       user_initiated_interaction_count: getTotalUserInitiatedInteractionCount(ide),
       code_generation_activity_count: ide.code_generation_activity_count,
       code_acceptance_activity_count: ide.code_acceptance_activity_count,
@@ -87,6 +105,7 @@ export default function DayDetailsModal({ isOpen, onClose, date, dayMetrics, use
     })),
     ...(hasCliActivity ? [{
       name: 'Copilot CLI',
+      iconName: 'copilot_cli',
       user_initiated_interaction_count: cliInteractionCount,
       code_generation_activity_count: cliDayTotals.generations,
       code_acceptance_activity_count: cliDayTotals.acceptances,

--- a/src/components/ui/DayDetailsModal.tsx
+++ b/src/components/ui/DayDetailsModal.tsx
@@ -48,7 +48,7 @@ const clientColumns: TableColumn<ClientRow>[] = [
       const ClientIcon = getIDEIcon(r.iconName);
       return (
         <div className="flex items-center gap-2">
-          <span className="flex-shrink-0">
+          <span className="flex-shrink-0" aria-hidden="true">
             <ClientIcon />
           </span>
           <span>{r.name}</span>


### PR DESCRIPTION
## Why

The adoption phase and day details views needed clearer context and visual cues so users can interpret cohort definitions and client activity faster. This adds the requested phase explanation and client icon affordances without changing metric aggregation.

| Commit | Change |
|--------|--------|
| `feat: explain AI adoption phases` | Adds a separate How phases are assigned card with phase definitions, matching phase pills, and a Learn More link to the GitHub changelog. |
| `feat: add client icons to day details` | Renders matching IDE and Copilot CLI icons in the Activity by Client table while preserving the formatted client names. |