### PR TITLE
feat: add CLion and RustRover client support

### DIFF
--- a/src/components/icons/IDEIcons.tsx
+++ b/src/components/icons/IDEIcons.tsx
@@ -138,7 +138,7 @@ const CLionIcon = () => (
 // RustRover — JetBrains-style mark (no official Simple Icons vector available),
 // drawn to match the family's black square with white lettering.
 const RustRoverIcon = () => (
-  <svg className="w-5 h-5" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+  <svg className="w-5 h-5" viewBox="0 0 24 24" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg">
     <path d="M0 0v24h24V0H0z" fill="#000" />
     <text
       x="12"

--- a/src/components/icons/IDEIcons.tsx
+++ b/src/components/icons/IDEIcons.tsx
@@ -128,6 +128,33 @@ const RStudioIcon = () => (
   </svg>
 );
 
+// CLion — from Simple Icons (CC0)
+const CLionIcon = () => (
+  <svg className="w-5 h-5" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+    <path d="M0 0v24h24V0H0zm7.041 3a5.049 5.049 0 0 1 .219 0c1.86 0 3 .6 3.9 1.56L9.78 6.18C9 5.46 8.22 5.04 7.26 5.04c-1.68 0-2.88 1.38-2.88 3.12 0 1.68 1.2 3.12 2.88 3.12 1.14 0 1.86-.48 2.64-1.14l1.38 1.38c-1.02 1.08-2.16 1.8-4.08 1.8a5.1 5.1 0 0 1-5.1-5.16A5.049 5.049 0 0 1 7.04 3zm5.738.12H15v8.1h4.32v1.86h-6.54V3.12zM2.28 19.5h9V21h-9v-1.5Z" fill="#000"/>
+  </svg>
+);
+
+// RustRover — JetBrains-style mark (no official Simple Icons vector available),
+// drawn to match the family's black square with white lettering.
+const RustRoverIcon = () => (
+  <svg className="w-5 h-5" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+    <path d="M0 0v24h24V0H0z" fill="#000" />
+    <text
+      x="12"
+      y="13.4"
+      textAnchor="middle"
+      fontFamily="Arial, Helvetica, sans-serif"
+      fontSize="8.5"
+      fontWeight="700"
+      fill="#fff"
+    >
+      RR
+    </text>
+    <path d="M2.28 19.5h9V21h-9z" fill="#fff" />
+  </svg>
+);
+
 const DefaultIDEIcon = () => (
   <svg className="w-5 h-5" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
     <path d="M3 3h18a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2z" stroke="#6B7280" strokeWidth="2" fill="none"/>
@@ -148,6 +175,8 @@ const ideIconMap: Record<string, React.ComponentType> = {
   android_studio: AndroidStudioIcon,
   goland: GoLandIcon,
   phpstorm: PhpStormIcon,
+  clion: CLionIcon,
+  rustrover: RustRoverIcon,
   rstudio: RStudioIcon,
   emacs: EmacsIcon,
   neovim: NeovimIcon,

--- a/src/domain/__tests__/ideInsights.test.ts
+++ b/src/domain/__tests__/ideInsights.test.ts
@@ -116,8 +116,10 @@ describe('computeIDEInsights', () => {
         makeIDE('intellij', 30, 500, 200, 0),
         makeIDE('pycharm', 20, 300, 100, 0),
         makeIDE('goland', 10, 100, 40, 0),
+        makeIDE('clion', 15, 150, 60, 0),
+        makeIDE('rustrover', 15, 150, 60, 0),
       ];
-      const insights = computeIDEInsights(stats, 0, 110, 10);
+      const insights = computeIDEInsights(stats, 0, 140, 10);
       expect(insights.find((i) => i.title === 'CLI Opportunity')).toBeUndefined();
     });
 

--- a/src/domain/ideInsights.ts
+++ b/src/domain/ideInsights.ts
@@ -66,6 +66,8 @@ export function computeIDEInsights(
       'android_studio',
       'goland',
       'phpstorm',
+      'clion',
+      'rustrover',
     ]);
     const limitedAgenticIDEs = ideStats.filter(
       (s) => !strongAgenticIDEs.has(s.ide) && s.uniqueUsers > 0,

--- a/src/utils/ideNames.ts
+++ b/src/utils/ideNames.ts
@@ -11,6 +11,8 @@ const FORMAT_MAP: Record<string, string> = {
   android_studio: 'Android Studio',
   goland: 'GoLand',
   phpstorm: 'PhpStorm',
+  clion: 'CLion',
+  rustrover: 'RustRover',
   rstudio: 'RStudio',
   emacs: 'Emacs',
   neovim: 'Neovim',


### PR DESCRIPTION
## Why

Two more JetBrains IDEs, CLion and RustRover, showed up in usage data without proper names or icons, so they rendered with the raw id and the generic placeholder icon and were still flagged by the CLI Opportunity insight. This brings them in line with the rest of the JetBrains family.

## What

- Add display names for `clion` ("CLion") and `rustrover` ("RustRover").
- Add icons: CLion uses the official Simple Icons (CC0) mark. RustRover has no CC0 vector available yet, so it uses a JetBrains-style black square with white "RR" lettering to stay consistent with the family branding.
- Add both keys to the strong-agentic IDE set so they are excluded from the "CLI Opportunity" recommendation, since JetBrains ships a Copilot SDK-based agentic harness on par with VS Code/CLI.

Icons were verified visually against the existing JetBrains icons before committing.