### PR TITLE
feat: day flip navigation in Day Details Modal

### DIFF
--- a/src/components/UserDetailsView.tsx
+++ b/src/components/UserDetailsView.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState, useMemo } from 'react';
+import React, { useState, useMemo, useCallback } from 'react';
 import type { UserSummary, UserDayData } from '../types/metrics';
 import type { UserDetailedMetrics } from '../types/aggregatedMetrics';
 import { translateFeature } from '../domain/featureTranslations';
@@ -101,6 +101,35 @@ export default function UserDetailsView({ userDetails, userSummary, userLogin, u
       selectedMetrics: undefined,
     });
   };
+
+  const reportDateRange = useMemo(
+    () => generateDateRange(userDetails.reportStartDay, userDetails.reportEndDay),
+    [userDetails.reportStartDay, userDetails.reportEndDay],
+  );
+  const dayMetricsMap = useMemo(
+    () => new Map(userDetails.days.map(d => [d.day, d])),
+    [userDetails.days],
+  );
+
+  const selectedDayIndex = modalState.isOpen ? reportDateRange.indexOf(modalState.selectedDate) : -1;
+  const canNavigatePrevDay = selectedDayIndex > 0;
+  const canNavigateNextDay = selectedDayIndex >= 0 && selectedDayIndex < reportDateRange.length - 1;
+
+  const handleNavigateDay = useCallback((direction: -1 | 1) => {
+    setModalState(prev => {
+      if (!prev.isOpen) return prev;
+      const idx = reportDateRange.indexOf(prev.selectedDate);
+      if (idx === -1) return prev;
+      const nextIdx = idx + direction;
+      if (nextIdx < 0 || nextIdx >= reportDateRange.length) return prev;
+      const nextDate = reportDateRange[nextIdx];
+      return {
+        isOpen: true,
+        selectedDate: nextDate,
+        selectedMetrics: dayMetricsMap.get(nextDate),
+      };
+    });
+  }, [reportDateRange, dayMetricsMap]);
 
   const handleCopyUserLogin = () => {
     if (navigator && navigator.clipboard && typeof navigator.clipboard.writeText === 'function') {
@@ -721,6 +750,9 @@ export default function UserDetailsView({ userDetails, userSummary, userLogin, u
         date={modalState.selectedDate}
         dayMetrics={modalState.selectedMetrics}
         userLogin={userLogin}
+        onNavigateDay={handleNavigateDay}
+        canNavigatePrevDay={canNavigatePrevDay}
+        canNavigateNextDay={canNavigateNextDay}
       />
     </ViewPanel>
   );

--- a/src/components/ui/DayDetailsModal.tsx
+++ b/src/components/ui/DayDetailsModal.tsx
@@ -122,16 +122,16 @@ const languageModelColumns: TableColumn<LanguageModelRow>[] = [
   { id: 'locDeleted', header: 'LOC Deleted', headerClassName: headerRight, className: cellRight, renderCell: (r) => r.loc_deleted_sum.toLocaleString() },
 ];
 
-export default function DayDetailsModal({ isOpen, onClose, date, dayMetrics, userLogin, onNavigateDay, canNavigatePrevDay, canNavigateNextDay }: DayDetailsModalProps) {
+export default function DayDetailsModal({ isOpen, onClose, date, dayMetrics, userLogin, onNavigateDay, canNavigatePrevDay = false, canNavigateNextDay = false }: DayDetailsModalProps) {
   React.useEffect(() => {
     if (!isOpen) return;
     const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'ArrowLeft' && canNavigatePrevDay) {
+      if (event.key === 'ArrowLeft' && onNavigateDay && canNavigatePrevDay) {
         event.preventDefault();
-        onNavigateDay?.(-1);
-      } else if (event.key === 'ArrowRight' && canNavigateNextDay) {
+        onNavigateDay(-1);
+      } else if (event.key === 'ArrowRight' && onNavigateDay && canNavigateNextDay) {
         event.preventDefault();
-        onNavigateDay?.(1);
+        onNavigateDay(1);
       } else if (event.key === 'Escape') {
         onClose();
       }
@@ -193,13 +193,14 @@ export default function DayDetailsModal({ isOpen, onClose, date, dayMetrics, use
           <div className="flex items-center gap-3">
             {onNavigateDay && (
               <button
+                type="button"
                 onClick={() => onNavigateDay(-1)}
                 disabled={!canNavigatePrevDay}
                 aria-label="Previous day"
                 title="Previous day (←)"
                 className="text-gray-400 hover:text-gray-600 transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
               >
-                <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <svg aria-hidden="true" className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
                 </svg>
               </button>
@@ -216,13 +217,14 @@ export default function DayDetailsModal({ isOpen, onClose, date, dayMetrics, use
             </div>
             {onNavigateDay && (
               <button
+                type="button"
                 onClick={() => onNavigateDay(1)}
                 disabled={!canNavigateNextDay}
                 aria-label="Next day"
                 title="Next day (→)"
                 className="text-gray-400 hover:text-gray-600 transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
               >
-                <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <svg aria-hidden="true" className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
                 </svg>
               </button>

--- a/src/components/ui/DayDetailsModal.tsx
+++ b/src/components/ui/DayDetailsModal.tsx
@@ -19,6 +19,9 @@ interface DayDetailsModalProps {
   date: string;
   dayMetrics?: UserDayData;
   userLogin?: string;
+  onNavigateDay?: (direction: -1 | 1) => void;
+  canNavigatePrevDay?: boolean;
+  canNavigateNextDay?: boolean;
 }
 
 type LanguageModelRow = UserDayData['totals_by_language_model'][number];
@@ -119,7 +122,24 @@ const languageModelColumns: TableColumn<LanguageModelRow>[] = [
   { id: 'locDeleted', header: 'LOC Deleted', headerClassName: headerRight, className: cellRight, renderCell: (r) => r.loc_deleted_sum.toLocaleString() },
 ];
 
-export default function DayDetailsModal({ isOpen, onClose, date, dayMetrics, userLogin }: DayDetailsModalProps) {
+export default function DayDetailsModal({ isOpen, onClose, date, dayMetrics, userLogin, onNavigateDay, canNavigatePrevDay, canNavigateNextDay }: DayDetailsModalProps) {
+  React.useEffect(() => {
+    if (!isOpen) return;
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'ArrowLeft' && canNavigatePrevDay) {
+        event.preventDefault();
+        onNavigateDay?.(-1);
+      } else if (event.key === 'ArrowRight' && canNavigateNextDay) {
+        event.preventDefault();
+        onNavigateDay?.(1);
+      } else if (event.key === 'Escape') {
+        onClose();
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [isOpen, canNavigatePrevDay, canNavigateNextDay, onNavigateDay, onClose]);
+
   if (!isOpen) return null;
 
   const formatDate = (dateString: string) => {
@@ -170,14 +190,42 @@ export default function DayDetailsModal({ isOpen, onClose, date, dayMetrics, use
       <div className="bg-white rounded-lg shadow-xl max-w-6xl max-h-[90vh] w-full overflow-hidden">
         {/* Header */}
         <div className="px-6 py-4 border-b border-gray-200 flex items-center justify-between">
-          <div>
-            <h2 className="text-xl font-bold text-gray-900">{formatDate(date)}</h2>
-            {hasData && userLogin && (
-              <p className="mt-1 flex flex-wrap items-center gap-2 text-sm text-gray-600">
-                <span>User: {userLogin}</span>
-                <span aria-hidden="true" className="text-gray-300">•</span>
-                <span>AI cost: {formatAiCreditCost(dayMetrics?.ai_credits_used ?? 0)}</span>
-              </p>
+          <div className="flex items-center gap-3">
+            {onNavigateDay && (
+              <button
+                onClick={() => onNavigateDay(-1)}
+                disabled={!canNavigatePrevDay}
+                aria-label="Previous day"
+                title="Previous day (←)"
+                className="text-gray-400 hover:text-gray-600 transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
+              >
+                <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+                </svg>
+              </button>
+            )}
+            <div>
+              <h2 className="text-xl font-bold text-gray-900">{formatDate(date)}</h2>
+              {hasData && userLogin && (
+                <p className="mt-1 flex flex-wrap items-center gap-2 text-sm text-gray-600">
+                  <span>User: {userLogin}</span>
+                  <span aria-hidden="true" className="text-gray-300">•</span>
+                  <span>AI cost: {formatAiCreditCost(dayMetrics?.ai_credits_used ?? 0)}</span>
+                </p>
+              )}
+            </div>
+            {onNavigateDay && (
+              <button
+                onClick={() => onNavigateDay(1)}
+                disabled={!canNavigateNextDay}
+                aria-label="Next day"
+                title="Next day (→)"
+                className="text-gray-400 hover:text-gray-600 transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
+              >
+                <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+                </svg>
+              </button>
             )}
           </div>
           <button


### PR DESCRIPTION
## Why

Users inspecting a specific day's Copilot activity previously had to close the modal and click another calendar cell to view an adjacent day. This adds quick day-to-day flipping so reviewers can scan activity sequentially without leaving the modal.

| Commit | Change |
|--------|--------|
| `feat:` add day flip navigation to Day Details Modal | Left/right arrow keys and header prev/next buttons navigate across the report date range; bounds-gated; empty days still open with the existing empty state |