### PR TITLE
feat: add daily AI credits charts

### DIFF
--- a/src/components/UserDetailsView.tsx
+++ b/src/components/UserDetailsView.tsx
@@ -11,6 +11,7 @@ import ClientActivityChart from './charts/ClientActivityChart';
 import CLISessionChart from './charts/CLISessionChart';
 import CLITokensChart from './charts/CLITokensChart';
 import CloudAgentsUsageChart from './charts/CloudAgentsUsageChart';
+import AiCreditsChart from './charts/AiCreditsChart';
 import FeatureAdoptionRadarChart from './charts/FeatureAdoptionRadarChart';
 import ModeImpactChart from './charts/ModeImpactChart';
 import UserSummaryChart from './charts/UserSummaryChart';
@@ -22,6 +23,7 @@ import { ViewPanel } from './ui';
 import { VIEW_MODES } from '../types/navigation';
 import { useNavigation } from '../state/NavigationContext';
 import type { ModeImpactData } from '../domain/calculators/metricCalculators';
+import type { DailyAiCreditsData } from '../domain/calculators/metricCalculators';
 import type { TooltipItem } from 'chart.js';
 import { registerChartJS } from './charts/utils/chartSetup';
 import { isActiveAutoModeFeature } from '../domain/autoMode';
@@ -530,6 +532,20 @@ export default function UserDetailsView({ userDetails, userSummary, userLogin, u
   }, [userDetails.days, userDetails.reportStartDay, userDetails.reportEndDay]);
 
   const showCloudAgentsUsage = usedCodingAgent || usedCodeReview;
+  const dailyAiCreditsData = useMemo<DailyAiCreditsData[]>(() => {
+    const creditsByDay = new Map<string, number>();
+    for (const day of userDetails.days) {
+      creditsByDay.set(day.day, (creditsByDay.get(day.day) ?? 0) + day.ai_credits_used);
+    }
+
+    return Array.from(creditsByDay.entries())
+      .map(([date, aiCreditsUsed]) => ({
+        date,
+        aiCreditsUsed,
+        users: aiCreditsUsed > 0 ? 1 : 0,
+      }))
+      .sort((a, b) => a.date.localeCompare(b.date));
+  }, [userDetails.days]);
 
   return (
     <ViewPanel
@@ -607,6 +623,14 @@ export default function UserDetailsView({ userDetails, userSummary, userLogin, u
           />
         </div>
       </div>
+
+      <AiCreditsChart
+        data={dailyAiCreditsData}
+        reportStartDay={userDetails.reportStartDay}
+        reportEndDay={userDetails.reportEndDay}
+        description="AI credits consumed by this user each day during the reporting period"
+        showUsers={false}
+      />
 
       <ModeImpactChart
         data={filledCombinedImpact}

--- a/src/components/charts/AiCreditsChart.tsx
+++ b/src/components/charts/AiCreditsChart.tsx
@@ -1,0 +1,124 @@
+'use client';
+
+import { TooltipItem } from 'chart.js';
+import { Bar } from 'react-chartjs-2';
+import { DailyAiCreditsData } from '../../domain/calculators/metricCalculators';
+import { calculateStats } from '../../domain/calculators/statsCalculators';
+import { formatAiCreditCost, formatNumber, formatShortDate, generateDateRange } from '../../utils/formatters';
+import ChartContainer from '../ui/ChartContainer';
+import { chartColors } from './utils/chartColors';
+import { createBaseChartOptions, yAxisFormatters } from './utils/chartOptions';
+import { registerChartJS } from './utils/chartSetup';
+import { createBarDataset } from './utils/chartStyles';
+
+registerChartJS();
+
+interface AiCreditsChartProps {
+  data: DailyAiCreditsData[];
+  reportStartDay: string;
+  reportEndDay: string;
+  title?: string;
+  description?: string;
+  showUsers?: boolean;
+  usageCountLabel?: string;
+}
+
+function createDisplayData(
+  data: DailyAiCreditsData[],
+  reportStartDay: string,
+  reportEndDay: string
+): DailyAiCreditsData[] {
+  const dataByDate = new Map(data.map(entry => [entry.date, entry]));
+
+  return generateDateRange(reportStartDay, reportEndDay).map(date => (
+    dataByDate.get(date) ?? { date, aiCreditsUsed: 0, users: 0 }
+  ));
+}
+
+export default function AiCreditsChart({
+  data,
+  reportStartDay,
+  reportEndDay,
+  title = 'Daily AI Credits Consumption',
+  description = 'Total AI credits consumed by users each day during the reporting period',
+  showUsers = true,
+  usageCountLabel = 'User-days',
+}: AiCreditsChartProps) {
+  const displayData = createDisplayData(data, reportStartDay, reportEndDay);
+  const activeData = data.filter(entry => entry.aiCreditsUsed > 0);
+  const stats = calculateStats(activeData, entry => entry.aiCreditsUsed);
+  if (stats.total === 0) {
+    return null;
+  }
+
+  const creditUserDays = data.reduce((total, entry) => total + entry.users, 0);
+  const footerGridClassName = showUsers
+    ? 'grid grid-cols-1 gap-4 text-xs text-gray-500 sm:grid-cols-3'
+    : 'grid grid-cols-1 gap-4 text-xs text-gray-500 sm:grid-cols-2';
+  const peakEntry = activeData.reduce<DailyAiCreditsData | undefined>(
+    (peak, entry) => !peak || entry.aiCreditsUsed > peak.aiCreditsUsed ? entry : peak,
+    undefined
+  );
+
+  const chartData = {
+    labels: displayData.map(entry => formatShortDate(entry.date)),
+    datasets: [
+      createBarDataset(
+        chartColors.violet.alpha60,
+        'AI Credits Used',
+        displayData.map(entry => entry.aiCreditsUsed),
+        {
+          borderColor: chartColors.violet.solid,
+        }
+      ),
+    ],
+  };
+
+  const options = createBaseChartOptions({
+    xAxisLabel: 'Date',
+    yAxisLabel: 'AI Credits Used',
+    showLegend: false,
+    yTicksCallback: yAxisFormatters.localeNumber,
+    tooltipLabelCallback: (context: TooltipItem<'line' | 'bar'>) => {
+      const dayData = displayData[context.dataIndex];
+      const labels = [
+        `AI credits: ${formatNumber(dayData.aiCreditsUsed, 2)}`,
+        `Estimated cost: ${formatAiCreditCost(dayData.aiCreditsUsed)}`,
+      ];
+      if (showUsers) {
+        labels.push(`Users with credits: ${dayData.users}`);
+      }
+      return labels;
+    },
+  });
+
+  return (
+    <ChartContainer
+      title={title}
+      description={description}
+      stats={[
+        { label: 'Total', value: formatNumber(stats.total, 2) },
+        { label: 'Avg active day', value: formatNumber(stats.average, 2) },
+        { label: 'Cost', value: formatAiCreditCost(stats.total) },
+      ]}
+      footer={
+        <div className={footerGridClassName}>
+          <div>
+            <span className="font-medium text-violet-600">Active days:</span> {activeData.length}
+          </div>
+          <div>
+            <span className="font-medium text-violet-600">Peak day:</span>{' '}
+            {peakEntry ? `${peakEntry.date} (${formatNumber(peakEntry.aiCreditsUsed, 2)} credits)` : 'N/A'}
+          </div>
+          {showUsers && (
+            <div>
+              <span className="font-medium text-violet-600">{usageCountLabel}:</span> {creditUserDays}
+            </div>
+          )}
+        </div>
+      }
+    >
+      <Bar data={chartData} options={options} />
+    </ChartContainer>
+  );
+}

--- a/src/components/charts/index.ts
+++ b/src/components/charts/index.ts
@@ -5,6 +5,7 @@
 
 export { default as ActivityBreakdownChart } from './ActivityBreakdownChart';
 export { default as AgentModeHeatmapChart } from './AgentModeHeatmapChart';
+export { default as AiCreditsChart } from './AiCreditsChart';
 export { default as ChatRequestsChart } from './ChatRequestsChart';
 export { default as ChatUsersChart } from './ChatUsersChart';
 export { default as CLISessionChart } from './CLISessionChart';

--- a/src/components/features/overview/OverviewDashboard.tsx
+++ b/src/components/features/overview/OverviewDashboard.tsx
@@ -2,10 +2,11 @@
 
 import React from 'react';
 import { MetricsStats } from '../../../types/metrics';
-import { DailyEngagementData, DailyChatUsersData, DailyChatRequestsData } from '../../../domain/calculators/metricCalculators';
+import { DailyEngagementData, DailyChatUsersData, DailyChatRequestsData, DailyAiCreditsData } from '../../../domain/calculators/metricCalculators';
 import EngagementChart from '../../charts/EngagementChart';
 import ChatUsersChart from '../../charts/ChatUsersChart';
 import ChatRequestsChart from '../../charts/ChatRequestsChart';
+import AiCreditsChart from '../../charts/AiCreditsChart';
 
 interface OverviewDashboardProps {
   stats: MetricsStats;
@@ -13,6 +14,7 @@ interface OverviewDashboardProps {
   engagementData: DailyEngagementData[];
   chatUsersData: DailyChatUsersData[];
   chatRequestsData: DailyChatRequestsData[];
+  dailyAiCreditsData: DailyAiCreditsData[];
 }
 
 const OverviewDashboard: React.FC<OverviewDashboardProps> = ({
@@ -21,6 +23,7 @@ const OverviewDashboard: React.FC<OverviewDashboardProps> = ({
   engagementData,
   chatUsersData,
   chatRequestsData,
+  dailyAiCreditsData,
 }) => {
   const formatDate = (dateString: string) => {
     return new Date(dateString).toLocaleDateString('en-US', {
@@ -29,6 +32,7 @@ const OverviewDashboard: React.FC<OverviewDashboardProps> = ({
       day: 'numeric'
     });
   };
+  const hasAiCreditsData = dailyAiCreditsData.some(entry => entry.aiCreditsUsed > 0);
 
   return (
     <div className="space-y-8">
@@ -51,6 +55,16 @@ const OverviewDashboard: React.FC<OverviewDashboardProps> = ({
       <div className="w-full">
         <ChatRequestsChart data={chatRequestsData} />
       </div>
+
+      {hasAiCreditsData && (
+        <div className="w-full">
+          <AiCreditsChart
+            data={dailyAiCreditsData}
+            reportStartDay={stats.reportStartDay}
+            reportEndDay={stats.reportEndDay}
+          />
+        </div>
+      )}
     </div>
   );
 };

--- a/src/components/layout/ViewRouter.tsx
+++ b/src/components/layout/ViewRouter.tsx
@@ -141,6 +141,7 @@ const ViewRouter: React.FC = () => {
     dailyCloudAgentAdoptionData = [],
     dailyCodeReviewAdoptionData = [],
     aiAdoptionPhaseData = [],
+    dailyAiCreditsData = [],
   } = aggregatedMetrics;
 
   switch (currentView) {
@@ -294,6 +295,7 @@ const ViewRouter: React.FC = () => {
           engagementData={engagementData}
           chatUsersData={chatUsersData}
           chatRequestsData={chatRequestsData}
+          dailyAiCreditsData={dailyAiCreditsData}
         />
       );
   }

--- a/src/domain/__tests__/metricsAggregator.test.ts
+++ b/src/domain/__tests__/metricsAggregator.test.ts
@@ -128,6 +128,31 @@ describe('metricsAggregator', () => {
       expect(aggregated.userSummaries[0].total_ai_credits_used).toBeCloseTo(60);
     });
 
+    it('should aggregate AI credits by day across users', () => {
+      const day1User1 = createBasicMetric({
+        user_id: 123,
+        day: '2024-01-15',
+        ai_credits_used: 55.053015,
+      });
+      const day1User2 = createBasicMetric({
+        user_id: 456,
+        day: '2024-01-15',
+        ai_credits_used: 4.946985,
+      });
+      const day2User1 = createBasicMetric({
+        user_id: 123,
+        day: '2024-01-16',
+        ai_credits_used: 10,
+      });
+
+      const { aggregated } = aggregateMetrics([day2User1, day1User1, day1User2]);
+
+      expect(aggregated.dailyAiCreditsData).toEqual([
+        { date: '2024-01-15', aiCreditsUsed: 60, users: 2 },
+        { date: '2024-01-16', aiCreditsUsed: 10, users: 1 },
+      ]);
+    });
+
     it('should track user feature flags correctly', () => {
       const agentUser = createBasicMetric({
         user_id: 1,

--- a/src/domain/__tests__/metricsAggregator.test.ts
+++ b/src/domain/__tests__/metricsAggregator.test.ts
@@ -147,10 +147,11 @@ describe('metricsAggregator', () => {
 
       const { aggregated } = aggregateMetrics([day2User1, day1User1, day1User2]);
 
-      expect(aggregated.dailyAiCreditsData).toEqual([
-        { date: '2024-01-15', aiCreditsUsed: 60, users: 2 },
-        { date: '2024-01-16', aiCreditsUsed: 10, users: 1 },
-      ]);
+      expect(aggregated.dailyAiCreditsData).toHaveLength(2);
+      expect(aggregated.dailyAiCreditsData[0].date).toBe('2024-01-15');
+      expect(aggregated.dailyAiCreditsData[0].aiCreditsUsed).toBeCloseTo(60);
+      expect(aggregated.dailyAiCreditsData[0].users).toBe(2);
+      expect(aggregated.dailyAiCreditsData[1]).toEqual({ date: '2024-01-16', aiCreditsUsed: 10, users: 1 });
     });
 
     it('should track user feature flags correctly', () => {

--- a/src/domain/calculators/__tests__/userDetailCalculator.test.ts
+++ b/src/domain/calculators/__tests__/userDetailCalculator.test.ts
@@ -152,6 +152,7 @@ describe('userDetailCalculator', () => {
       expect(result!.total_ai_credits_used).toBeCloseTo(60);
       expect(result!.days.map(day => day.ai_credits_used)).toEqual([55.053015, 4.946985]);
     });
+
   });
 
   describe('accumulateUserDetail — CLI data stored in days', () => {

--- a/src/domain/calculators/aiCreditsCalculator.ts
+++ b/src/domain/calculators/aiCreditsCalculator.ts
@@ -1,0 +1,51 @@
+import type { CopilotMetrics } from '../../types/metrics';
+import { compareByDateAsc } from './statsCalculators';
+
+export interface DailyAiCreditsData {
+  date: string;
+  aiCreditsUsed: number;
+  users: number;
+}
+
+export interface AiCreditsAccumulator {
+  dailyCredits: Map<string, {
+    aiCreditsUsed: number;
+    users: Set<number>;
+  }>;
+}
+
+export function createAiCreditsAccumulator(): AiCreditsAccumulator {
+  return {
+    dailyCredits: new Map(),
+  };
+}
+
+export function accumulateAiCredits(
+  accumulator: AiCreditsAccumulator,
+  metric: CopilotMetrics
+): void {
+  if (!accumulator.dailyCredits.has(metric.day)) {
+    accumulator.dailyCredits.set(metric.day, {
+      aiCreditsUsed: 0,
+      users: new Set(),
+    });
+  }
+
+  const dailyCredits = accumulator.dailyCredits.get(metric.day)!;
+  dailyCredits.aiCreditsUsed += metric.ai_credits_used;
+  if (metric.ai_credits_used > 0) {
+    dailyCredits.users.add(metric.user_id);
+  }
+}
+
+export function computeDailyAiCreditsData(
+  accumulator: AiCreditsAccumulator
+): DailyAiCreditsData[] {
+  return Array.from(accumulator.dailyCredits.entries())
+    .map(([date, data]) => ({
+      date,
+      aiCreditsUsed: data.aiCreditsUsed,
+      users: data.users.size,
+    }))
+    .sort(compareByDateAsc);
+}

--- a/src/domain/calculators/index.ts
+++ b/src/domain/calculators/index.ts
@@ -163,4 +163,12 @@ export {
   computeAiAdoptionPhaseData,
 } from './aiAdoptionPhaseCalculator';
 
+export {
+  type DailyAiCreditsData,
+  type AiCreditsAccumulator,
+  createAiCreditsAccumulator,
+  accumulateAiCredits,
+  computeDailyAiCreditsData,
+} from './aiCreditsCalculator';
+
 export { compareDatesAsc, compareByDateAsc } from './statsCalculators';

--- a/src/domain/calculators/metricCalculators.ts
+++ b/src/domain/calculators/metricCalculators.ts
@@ -48,6 +48,10 @@ export type {
   AiAdoptionPhaseTopEntry,
 } from './aiAdoptionPhaseCalculator';
 
+export type {
+  DailyAiCreditsData,
+} from './aiCreditsCalculator';
+
 export const calculateStats = calculateStatsFromMetrics;
 
 export const calculateDailyModelUsage = calculateDailyModelUsageFromMetrics;

--- a/src/domain/metricsAggregator.ts
+++ b/src/domain/metricsAggregator.ts
@@ -111,6 +111,11 @@ import {
   createAiAdoptionPhaseAccumulator,
   accumulateAiAdoptionPhase,
   computeAiAdoptionPhaseData,
+
+  DailyAiCreditsData,
+  createAiCreditsAccumulator,
+  accumulateAiCredits,
+  computeDailyAiCreditsData,
 } from './calculators';
 import { isActiveAutoModeFeature } from './autoMode';
 
@@ -146,6 +151,7 @@ export interface AggregatedMetrics {
   dailyCloudAgentAdoptionData: DailyCloudAgentAdoptionData[];
   dailyCodeReviewAdoptionData: DailyCodeReviewAdoptionData[];
   aiAdoptionPhaseData: AiAdoptionPhaseData[];
+  dailyAiCreditsData: DailyAiCreditsData[];
 }
 
 interface UserSummaryAccumulator {
@@ -271,6 +277,7 @@ export function aggregateMetrics(
   const cliUsageAccumulator = createCliUsageAccumulator();
   const advancedAdoptionAccumulator = createAdvancedAdoptionAccumulator();
   const aiAdoptionPhaseAccumulator = createAiAdoptionPhaseAccumulator();
+  const aiCreditsAccumulator = createAiCreditsAccumulator();
   const userDetailAccumulator = createUserDetailAccumulator();
 
   for (const metric of metrics) {
@@ -289,6 +296,7 @@ export function aggregateMetrics(
 
     accumulateUserSummary(userSummaryAccumulator, metric, usedCopilotCloudAgent);
     accumulateAiAdoptionPhase(aiAdoptionPhaseAccumulator, metric);
+    accumulateAiCredits(aiCreditsAccumulator, metric);
     accumulateUserDetail(userDetailAccumulator, metric);
 
     accumulateUserUsage(statsAccumulator, userId, metric.used_chat, metric.used_agent, metric.used_cli, usedCopilotCloudAgent);
@@ -428,6 +436,7 @@ export function aggregateMetrics(
     dailyCloudAgentAdoptionData: computeDailyCloudAgentAdoptionData(advancedAdoptionAccumulator),
     dailyCodeReviewAdoptionData: computeDailyCodeReviewAdoptionData(advancedAdoptionAccumulator),
     aiAdoptionPhaseData: computeAiAdoptionPhaseData(aiAdoptionPhaseAccumulator),
+    dailyAiCreditsData: computeDailyAiCreditsData(aiCreditsAccumulator),
     },
     userDetailAccumulator,
   };


### PR DESCRIPTION
## Why

This change adds visibility into AI Credits consumption at both the overall metrics overview and individual user levels. It helps reviewers and users understand daily credit usage without showing empty chart slots when no AI credits were consumed.

| Commit | Change |
|--------|--------|
| `feat: add daily AI credits charts` | Adds worker-side daily AI credits aggregation and renders the chart on Metrics Overview and User Details when the selected slice has AI credits data. |