### PR TITLE
Add contextual right-side navigation panel

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { AppHeader, ViewRouter, StickyHeader, SideNav, DataInfoBar } from '../components/layout';
+import { AppHeader, ViewRouter, StickyHeader, SideNav, ContextPanel, DataInfoBar } from '../components/layout';
 import { useMetrics } from '../components/MetricsContext';
 
 export default function Home() {
@@ -10,6 +10,7 @@ export default function Home() {
     <div className="min-h-screen bg-[#f6f8fa] print:bg-white print:min-h-0">
       <StickyHeader />
       {hasData && <SideNav />}
+      {hasData && <ContextPanel />}
       {hasData && <DataInfoBar />}
       <div className={`pt-16 print:pt-0 print:ml-0 ${hasData ? 'lg:ml-64 xl:mr-64' : ''}`}>
         <div className={`px-4 sm:px-6 lg:px-8 pb-6 print:px-0 print:mx-0 ${hasData ? 'py-6 lg:pt-12' : 'py-6'}`}>

--- a/src/components/CLIAdoptionView.tsx
+++ b/src/components/CLIAdoptionView.tsx
@@ -7,6 +7,7 @@ import CLIUsersChart from './charts/CLIUsersChart';
 import CLISessionChart from './charts/CLISessionChart';
 import CLITokensChart from './charts/CLITokensChart';
 import ModelsUsageChart from './charts/ModelsUsageChart';
+import { CLI_ADOPTION_SECTIONS } from './layout/contextSections';
 import type { MetricsStats, ModelDailyUsageEntry } from '../types/metrics';
 import type { DailyCliSessionData, DailyCliTokenData, DailyCliAdoptionTrend } from '../domain/calculators/metricCalculators';
 interface CLIAdoptionViewProps {
@@ -32,6 +33,8 @@ export default function CLIAdoptionView({
     ? Math.round((stats.cliUsers / stats.uniqueUsers) * 1000) / 10
     : 0;
 
+  const [trendSection, usersSection, sessionsSection, tokensSection, modelsSection] = CLI_ADOPTION_SECTIONS;
+
   return (
     <ViewPanel
       headerProps={{
@@ -45,11 +48,21 @@ export default function CLIAdoptionView({
       contentClassName="space-y-8"
     >
 
-      <CLIAdoptionTrendChart data={dailyCliAdoptionTrend} stats={stats} />
-      <CLIUsersChart data={dailyCliSessionData} />
-      <CLISessionChart data={dailyCliSessionData} />
-      <CLITokensChart data={dailyCliTokenData} />
-      <ModelsUsageChart modelEntries={cliModelEntries} dates={cliModelDates} totalInteractions={cliModelTotal} variant="cli" />
+      <div id={trendSection.id} className="scroll-mt-28">
+        <CLIAdoptionTrendChart data={dailyCliAdoptionTrend} stats={stats} />
+      </div>
+      <div id={usersSection.id} className="scroll-mt-28">
+        <CLIUsersChart data={dailyCliSessionData} />
+      </div>
+      <div id={sessionsSection.id} className="scroll-mt-28">
+        <CLISessionChart data={dailyCliSessionData} />
+      </div>
+      <div id={tokensSection.id} className="scroll-mt-28">
+        <CLITokensChart data={dailyCliTokenData} />
+      </div>
+      <div id={modelsSection.id} className="scroll-mt-28">
+        <ModelsUsageChart modelEntries={cliModelEntries} dates={cliModelDates} totalInteractions={cliModelTotal} variant="cli" />
+      </div>
     </ViewPanel>
   );
 }

--- a/src/components/CopilotImpactView.tsx
+++ b/src/components/CopilotImpactView.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import ModeImpactChart from './charts/ModeImpactChart';
 import { ViewPanel } from './ui';
 import InsightsCard from './ui/InsightsCard';
+import { COPILOT_IMPACT_SECTIONS } from './layout/contextSections';
 import type { AgentImpactData, CodeCompletionImpactData, ModeImpactData } from '../domain/calculators/metricCalculators';
 interface CopilotImpactViewProps {
   agentImpactData: AgentImpactData[];
@@ -16,6 +17,16 @@ interface CopilotImpactViewProps {
 }
 
 export default function CopilotImpactView({ agentImpactData, codeCompletionImpactData, editModeImpactData, inlineModeImpactData, askModeImpactData, cliImpactData, joinedImpactData }: CopilotImpactViewProps) {
+  const [
+    combinedSection,
+    agentSection,
+    cliSection,
+    codeCompletionSection,
+    askSection,
+    inlineSection,
+    editSection,
+  ] = COPILOT_IMPACT_SECTIONS;
+
   return (
     <ViewPanel
       headerProps={{
@@ -25,53 +36,67 @@ export default function CopilotImpactView({ agentImpactData, codeCompletionImpac
       }}
       contentClassName="space-y-8"
     >
-      <ModeImpactChart
-        data={joinedImpactData || []}
-        title="Combined Copilot Impact"
-        description="Aggregate impact across Code Completion, Ask Mode, Agent Mode, Edit Mode, Inline Mode, and CLI activities."
-        emptyStateMessage="No combined impact data available."
-      />
-      <ModeImpactChart
-        data={agentImpactData || []}
-        title="Copilot Agent Mode Impact"
-        description="Daily lines of code added and deleted through Copilot Agent Mode sessions."
-        emptyStateMessage="No agent mode impact data available."
-      />
-      <ModeImpactChart
-        data={cliImpactData || []}
-        title="Copilot CLI Impact"
-        description="Daily lines of code added and deleted through Copilot CLI sessions."
-        emptyStateMessage="No CLI impact data available."
-      />
-      <ModeImpactChart
-        data={codeCompletionImpactData || []}
-        title="Code Completion Impact"
-        description="Daily lines of code added and deleted when developers accept Copilot code completions."
-        emptyStateMessage="No code completion impact data available."
-      />
-      <ModeImpactChart
-        data={askModeImpactData || []}
-        title="Copilot Ask Mode Impact"
-        description="Daily lines of code added and deleted through Copilot Chat Ask Mode sessions."
-        emptyStateMessage="No Ask Mode impact data available."
-      />
-      <ModeImpactChart
-        data={inlineModeImpactData || []}
-        title="Copilot Inline Mode Impact"
-        description="Daily lines of code added and deleted when developers work inline with Copilot."
-        emptyStateMessage="No Inline Mode impact data available."
-      />
-      <ModeImpactChart
-        data={editModeImpactData || []}
-        title="Copilot Edit Mode Impact"
-        description="Daily lines of code added and deleted through Copilot's Edit Mode sessions."
-        emptyStateMessage="No Edit Mode impact data available."
-        footer={
-          <InsightsCard title="Edit Mode Deprecation" variant="orange">
-            Edit mode is deprecated and will be removed in newer versions of IDE clients.
-          </InsightsCard>
-        }
-      />
+      <div id={combinedSection.id} className="scroll-mt-28">
+        <ModeImpactChart
+          data={joinedImpactData || []}
+          title="Combined Copilot Impact"
+          description="Aggregate impact across Code Completion, Ask Mode, Agent Mode, Edit Mode, Inline Mode, and CLI activities."
+          emptyStateMessage="No combined impact data available."
+        />
+      </div>
+      <div id={agentSection.id} className="scroll-mt-28">
+        <ModeImpactChart
+          data={agentImpactData || []}
+          title="Copilot Agent Mode Impact"
+          description="Daily lines of code added and deleted through Copilot Agent Mode sessions."
+          emptyStateMessage="No agent mode impact data available."
+        />
+      </div>
+      <div id={cliSection.id} className="scroll-mt-28">
+        <ModeImpactChart
+          data={cliImpactData || []}
+          title="Copilot CLI Impact"
+          description="Daily lines of code added and deleted through Copilot CLI sessions."
+          emptyStateMessage="No CLI impact data available."
+        />
+      </div>
+      <div id={codeCompletionSection.id} className="scroll-mt-28">
+        <ModeImpactChart
+          data={codeCompletionImpactData || []}
+          title="Code Completion Impact"
+          description="Daily lines of code added and deleted when developers accept Copilot code completions."
+          emptyStateMessage="No code completion impact data available."
+        />
+      </div>
+      <div id={askSection.id} className="scroll-mt-28">
+        <ModeImpactChart
+          data={askModeImpactData || []}
+          title="Copilot Ask Mode Impact"
+          description="Daily lines of code added and deleted through Copilot Chat Ask Mode sessions."
+          emptyStateMessage="No Ask Mode impact data available."
+        />
+      </div>
+      <div id={inlineSection.id} className="scroll-mt-28">
+        <ModeImpactChart
+          data={inlineModeImpactData || []}
+          title="Copilot Inline Mode Impact"
+          description="Daily lines of code added and deleted when developers work inline with Copilot."
+          emptyStateMessage="No Inline Mode impact data available."
+        />
+      </div>
+      <div id={editSection.id} className="scroll-mt-28">
+        <ModeImpactChart
+          data={editModeImpactData || []}
+          title="Copilot Edit Mode Impact"
+          description="Daily lines of code added and deleted through Copilot's Edit Mode sessions."
+          emptyStateMessage="No Edit Mode impact data available."
+          footer={
+            <InsightsCard title="Edit Mode Deprecation" variant="orange">
+              Edit mode is deprecated and will be removed in newer versions of IDE clients.
+            </InsightsCard>
+          }
+        />
+      </div>
     </ViewPanel>
   );
 }

--- a/src/components/features/overview/OverviewDashboard.tsx
+++ b/src/components/features/overview/OverviewDashboard.tsx
@@ -7,6 +7,9 @@ import EngagementChart from '../../charts/EngagementChart';
 import ChatUsersChart from '../../charts/ChatUsersChart';
 import ChatRequestsChart from '../../charts/ChatRequestsChart';
 import AiCreditsChart from '../../charts/AiCreditsChart';
+import { OVERVIEW_SECTIONS } from './overviewSections';
+
+const [engagementSection, chatUsersSection, chatRequestsSection] = OVERVIEW_SECTIONS;
 
 interface OverviewDashboardProps {
   stats: MetricsStats;
@@ -44,15 +47,15 @@ const OverviewDashboard: React.FC<OverviewDashboardProps> = ({
         </h2>
       </div>
 
-      <div className="w-full">
+      <div id={engagementSection.id} className="w-full scroll-mt-28">
         <EngagementChart data={engagementData} />
       </div>
 
-      <div className="w-full">
+      <div id={chatUsersSection.id} className="w-full scroll-mt-28">
         <ChatUsersChart data={chatUsersData} />
       </div>
 
-      <div className="w-full">
+      <div id={chatRequestsSection.id} className="w-full scroll-mt-28">
         <ChatRequestsChart data={chatRequestsData} />
       </div>
 

--- a/src/components/features/overview/overviewSections.ts
+++ b/src/components/features/overview/overviewSections.ts
@@ -1,0 +1,10 @@
+export interface OverviewSection {
+  id: string;
+  label: string;
+}
+
+export const OVERVIEW_SECTIONS: OverviewSection[] = [
+  { id: 'chart-daily-user-engagement', label: 'Daily User Engagement' },
+  { id: 'chart-daily-chat-users', label: 'Daily Chat Users Trends' },
+  { id: 'chart-daily-chat-requests', label: 'Daily Chat Requests' },
+];

--- a/src/components/layout/ContextPanel.tsx
+++ b/src/components/layout/ContextPanel.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import React from 'react';
+import { useNavigation } from '../../state/NavigationContext';
+import { useActiveSection } from '../../hooks/useActiveSection';
+import { CONTEXT_SECTIONS } from './contextSections';
+
+const ContextPanel: React.FC = () => {
+  const { currentView } = useNavigation();
+  const sections = CONTEXT_SECTIONS[currentView] ?? [];
+  const activeId = useActiveSection(sections.map((section) => section.id));
+
+  if (sections.length === 0) {
+    return null;
+  }
+
+  const handleNavigate = (id: string) => {
+    const element = document.getElementById(id);
+    if (element) {
+      element.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    }
+  };
+
+  return (
+    <aside
+      className="fixed bottom-0 right-0 top-[100px] z-40 hidden w-64 overflow-y-auto py-3 pl-3 pr-4 print:hidden xl:block xl:pr-8"
+      aria-label="On this page"
+    >
+      <div className="bg-white border border-[#d1d9e0] rounded-md">
+        <p className="px-3 pt-3 pb-1 text-xs font-semibold uppercase tracking-wide text-[#636c76]">
+          On this page
+        </p>
+        <ul className="p-2 pt-1 space-y-0.5">
+          {sections.map(({ id, label }) => {
+            const isActive = activeId === id;
+            return (
+              <li key={id}>
+                <button
+                  type="button"
+                  onClick={() => handleNavigate(id)}
+                  aria-current={isActive ? 'true' : undefined}
+                  className={`w-full text-left px-3 py-2.5 rounded-md text-sm font-medium transition-all duration-150 ${
+                    isActive
+                      ? 'bg-[#f6f8fa] text-[#1f2328] font-semibold'
+                      : 'text-[#636c76] hover:bg-[#f6f8fa] hover:text-[#1f2328] cursor-pointer'
+                  }`}
+                >
+                  {label}
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      </div>
+    </aside>
+  );
+};
+
+export default ContextPanel;

--- a/src/components/layout/ContextPanel.tsx
+++ b/src/components/layout/ContextPanel.tsx
@@ -16,9 +16,14 @@ const ContextPanel: React.FC = () => {
 
   const handleNavigate = (id: string) => {
     const element = document.getElementById(id);
-    if (element) {
-      element.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    if (!element) {
+      return;
     }
+    const prefersReducedMotion =
+      typeof window !== 'undefined' &&
+      window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    element.scrollIntoView({ behavior: prefersReducedMotion ? 'auto' : 'smooth', block: 'start' });
+    window.history.replaceState(null, '', `#${id}`);
   };
 
   return (
@@ -38,7 +43,7 @@ const ContextPanel: React.FC = () => {
                 <button
                   type="button"
                   onClick={() => handleNavigate(id)}
-                  aria-current={isActive ? 'true' : undefined}
+                  aria-current={isActive ? 'location' : undefined}
                   className={`w-full text-left px-3 py-2.5 rounded-md text-sm font-medium transition-all duration-150 ${
                     isActive
                       ? 'bg-[#f6f8fa] text-[#1f2328] font-semibold'

--- a/src/components/layout/contextSections.ts
+++ b/src/components/layout/contextSections.ts
@@ -1,0 +1,31 @@
+import { VIEW_MODES, type ViewMode } from '../../types/navigation';
+import { OVERVIEW_SECTIONS } from '../features/overview/overviewSections';
+
+export interface ContextSection {
+  id: string;
+  label: string;
+}
+
+export const COPILOT_IMPACT_SECTIONS: ContextSection[] = [
+  { id: 'impact-combined', label: 'Combined Copilot Impact' },
+  { id: 'impact-agent', label: 'Copilot Agent Mode Impact' },
+  { id: 'impact-cli', label: 'Copilot CLI Impact' },
+  { id: 'impact-code-completion', label: 'Code Completion Impact' },
+  { id: 'impact-ask', label: 'Copilot Ask Mode Impact' },
+  { id: 'impact-inline', label: 'Copilot Inline Mode Impact' },
+  { id: 'impact-edit', label: 'Copilot Edit Mode Impact' },
+];
+
+export const CLI_ADOPTION_SECTIONS: ContextSection[] = [
+  { id: 'cli-adoption-trend', label: 'CLI Adoption Trend' },
+  { id: 'cli-daily-users', label: 'Daily CLI Users' },
+  { id: 'cli-daily-sessions', label: 'Daily CLI Sessions' },
+  { id: 'cli-daily-tokens', label: 'Daily CLI Token Usage' },
+  { id: 'cli-models-usage', label: 'CLI Models Daily Usage' },
+];
+
+export const CONTEXT_SECTIONS: Partial<Record<ViewMode, ContextSection[]>> = {
+  [VIEW_MODES.OVERVIEW]: OVERVIEW_SECTIONS,
+  [VIEW_MODES.COPILOT_IMPACT]: COPILOT_IMPACT_SECTIONS,
+  [VIEW_MODES.CLI_ADOPTION]: CLI_ADOPTION_SECTIONS,
+};

--- a/src/components/layout/index.ts
+++ b/src/components/layout/index.ts
@@ -2,4 +2,5 @@ export { default as AppHeader } from './AppHeader';
 export { default as ViewRouter } from './ViewRouter';
 export { default as StickyHeader } from './StickyHeader';
 export { default as SideNav } from './SideNav';
+export { default as ContextPanel } from './ContextPanel';
 export { default as DataInfoBar } from './DataInfoBar';

--- a/src/hooks/useActiveSection.ts
+++ b/src/hooks/useActiveSection.ts
@@ -11,6 +11,8 @@ export function useActiveSection(ids: string[]): string | null {
   const [activeId, setActiveId] = useState<string | null>(ids[0] ?? null);
 
   useEffect(() => {
+    setActiveId(ids[0] ?? null);
+
     if (ids.length === 0 || typeof IntersectionObserver === 'undefined') {
       return;
     }

--- a/src/hooks/useActiveSection.ts
+++ b/src/hooks/useActiveSection.ts
@@ -1,0 +1,57 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+/**
+ * Tracks which of the given section element ids is currently the most
+ * prominent one in the viewport, so contextual navigation can highlight it.
+ */
+export function useActiveSection(ids: string[]): string | null {
+  const key = ids.join('|');
+  const [activeId, setActiveId] = useState<string | null>(ids[0] ?? null);
+
+  useEffect(() => {
+    if (ids.length === 0 || typeof IntersectionObserver === 'undefined') {
+      return;
+    }
+
+    const elements = ids
+      .map((id) => document.getElementById(id))
+      .filter((el): el is HTMLElement => el !== null);
+
+    if (elements.length === 0) {
+      return;
+    }
+
+    const visibility = new Map<string, number>();
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          visibility.set(entry.target.id, entry.isIntersecting ? entry.intersectionRatio : 0);
+        }
+
+        let topId: string | null = null;
+        let topRatio = 0;
+        for (const id of ids) {
+          const ratio = visibility.get(id) ?? 0;
+          if (ratio > topRatio) {
+            topRatio = ratio;
+            topId = id;
+          }
+        }
+
+        if (topId) {
+          setActiveId(topId);
+        }
+      },
+      { rootMargin: '-120px 0px -55% 0px', threshold: [0, 0.25, 0.5, 0.75, 1] }
+    );
+
+    elements.forEach((el) => observer.observe(el));
+
+    return () => observer.disconnect();
+  }, [key]);
+
+  return activeId;
+}


### PR DESCRIPTION
## Why

Long analytics views stack many charts vertically, so finding a specific chart means scrolling and scanning. This adds an "on this page" panel on the right so users can jump straight to a chart and always see where they are in the view.

## What

- New `ContextPanel` that mirrors the left `SideNav` dimensions and renders fixed on the right (`xl` breakpoint, matching the space the layout already reserved via `xl:mr-64`).
- Clicking a link smooth-scrolls to the target chart; a new `useActiveSection` hook (IntersectionObserver) highlights whichever section is currently in view.
- A central `CONTEXT_SECTIONS` registry maps each view to its chart sections. Wired up for **Metrics Overview**, **Copilot Impact**, and **CLI Adoption**.
- Each chart on those views got a matching anchor `id` plus `scroll-mt-28` so the sticky header does not overlap the scroll target.

## Notes for reviewers

- The panel is purely additive: it returns `null` for views without registered sections, and is hidden below `xl` and in print.
- Adding a future view to the panel is a single entry in `contextSections.ts` plus anchor ids on that view's chart wrappers; no `ContextPanel` changes needed.
- Section labels are kept in sync by hand with the chart `title`s they point to.

Build, lint, and the full test suite (503 tests) pass.