### PR TITLE
Add context panels across detail views

### DIFF
--- a/src/components/AiAdoptionPhaseView.tsx
+++ b/src/components/AiAdoptionPhaseView.tsx
@@ -3,6 +3,7 @@
 import React from 'react';
 import MetricsTable, { TableColumn } from './ui/MetricsTable';
 import { ViewPanel } from './ui';
+import { AI_ADOPTION_PHASE_SECTIONS } from './layout/contextSections';
 import type { AiAdoptionPhaseData, AiAdoptionPhaseTopEntry } from '../domain/calculators/metricCalculators';
 import { formatAiAdoptionPhase, formatAiCreditCost, formatModelDisplayName, formatNumber } from '../utils/formatters';
 import { formatIDEName, getIDEIcon } from './icons/IDEIcons';
@@ -98,6 +99,7 @@ function renderTopClientEntries(entries: AiAdoptionPhaseTopEntry[]) {
 export default function AiAdoptionPhaseView({ phaseData }: AiAdoptionPhaseViewProps) {
   const rightHeaderClass = 'px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider';
   const rightCellClass = 'px-6 py-4 whitespace-nowrap text-sm text-gray-900 text-right';
+  const [comparisonSection, assignmentSection] = AI_ADOPTION_PHASE_SECTIONS;
   const columns: TableColumn<AiAdoptionPhaseData>[] = [
     {
       id: 'phase',
@@ -195,7 +197,7 @@ export default function AiAdoptionPhaseView({ phaseData }: AiAdoptionPhaseViewPr
       }}
       contentClassName="space-y-8"
     >
-      <div className="bg-white rounded-md border border-[#d1d9e0]">
+      <div id={comparisonSection.id} className="bg-white rounded-md border border-[#d1d9e0] scroll-mt-28">
         <div className="px-6 py-4 border-b border-gray-200">
           <h3 className="text-lg font-semibold text-gray-900">Phase comparison</h3>
           <p className="mt-1 text-sm text-gray-600">Averages are calculated per user in each phase.</p>
@@ -216,7 +218,7 @@ export default function AiAdoptionPhaseView({ phaseData }: AiAdoptionPhaseViewPr
         />
       </div>
 
-      <div className="bg-white rounded-md border border-[#d1d9e0]">
+      <div id={assignmentSection.id} className="bg-white rounded-md border border-[#d1d9e0] scroll-mt-28">
         <div className="px-6 py-4 border-b border-gray-200">
           <h3 className="text-lg font-semibold text-gray-900">How phases are assigned</h3>
           <p className="mt-1 text-sm text-gray-600">

--- a/src/components/ClientVersionsView.tsx
+++ b/src/components/ClientVersionsView.tsx
@@ -7,6 +7,7 @@ import MetricsTable, { TableColumn } from './ui/MetricsTable';
 import InsightsCard from './ui/InsightsCard';
 import { usePluginVersions } from '../hooks/usePluginVersions';
 import { classifyVsCodeVersion, parseReportDayInclusiveEnd, resolveCurrentStableMinorAtDate } from '../domain/vscodeVersionClassifier';
+import { CLIENT_VERSIONS_SECTIONS } from './layout/contextSections';
 import type { VsCodeVersionClassification } from '../domain/vscodeVersionClassifier';
 import type { MetricsStats, PluginVersionAnalysisData } from '../types/metrics';
 
@@ -30,6 +31,7 @@ export default function ClientVersionsView({ pluginVersionData, stats }: ClientV
   const totalUniqueIntellijUsers = pluginVersionData.totalUniqueIntellijUsers;
   const vscodeVersionAnalysis = pluginVersionData.vscode;
   const totalUniqueVsCodeUsers = pluginVersionData.totalUniqueVsCodeUsers;
+  const [jetbrainsSection, vsCodeSection] = CLIENT_VERSIONS_SECTIONS;
 
   const latestTwentyUpdates = React.useMemo(() => {
     const stable = jetbrainsUpdates.filter(u => !u.version.toLowerCase().endsWith('-nightly'));
@@ -319,7 +321,7 @@ export default function ClientVersionsView({ pluginVersionData, stats }: ClientV
       contentClassName="space-y-10"
     >
       <div className="space-y-4">
-        <div>
+        <div id={jetbrainsSection.id} className="scroll-mt-28">
           <h4 className="text-md font-semibold text-gray-900 mb-1">JetBrains</h4>
           <p className="text-gray-600 text-xs mb-4 max-w-2xl">
             IntelliJ-based IDEs using the GitHub Copilot JetBrains plugin.
@@ -457,7 +459,7 @@ export default function ClientVersionsView({ pluginVersionData, stats }: ClientV
           </div>
         )}
 
-        <div>
+        <div id={vsCodeSection.id} className="scroll-mt-28">
           <h4 className="text-md font-semibold text-gray-900 mb-1 mt-6">Visual Studio Code</h4>
           <p className="text-gray-600 text-xs mb-4 max-w-2xl">
             VS Code using the GitHub Copilot extension. When release history is available, version status is evaluated against the stable train available at the start of the report window; if not, it falls back to the currently bundled stable train. Timestamp builds are treated as pre-release channels.

--- a/src/components/ClientsView.tsx
+++ b/src/components/ClientsView.tsx
@@ -9,6 +9,7 @@ import { useSortableTable } from '../hooks/useSortableTable';
 import IDEDistributionChart from './charts/IDEDistributionChart';
 import CLIOverlapChart from './charts/CLIOverlapChart';
 import IDEInsights from './IDEInsights';
+import { CLIENT_ANALYSIS_SECTIONS } from './layout/contextSections';
 
 type IDEStats = IDEStatsData;
 
@@ -169,6 +170,7 @@ export default function ClientsView({
 
   const usersColumns = createColumns({ field: 'uniqueUsers', label: 'UNIQUE USERS' });
   const engagementsColumns = createColumns({ field: 'totalEngagements', label: 'ENGAGEMENTS' });
+  const [distributionSection, insightsSection, usersSection, engagementsSection] = CLIENT_ANALYSIS_SECTIONS;
 
   return (
     <ViewPanel
@@ -179,12 +181,12 @@ export default function ClientsView({
       contentClassName="space-y-8"
     >
       <div className="space-y-8">
-        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <div id={distributionSection.id} className="grid grid-cols-1 lg:grid-cols-2 gap-6 scroll-mt-28">
           <IDEDistributionChart ideStats={ideStats} cliUsers={cliUsers} />
           <CLIOverlapChart ideStats={ideStats} />
         </div>
 
-        <div className="bg-white rounded-md border border-[#d1d9e0]">
+        <div id={insightsSection.id} className="bg-white rounded-md border border-[#d1d9e0] scroll-mt-28">
           <div className="px-6 py-4 border-b border-gray-200">
             <h3 className="text-lg font-semibold text-gray-900">Insights</h3>
           </div>
@@ -198,7 +200,7 @@ export default function ClientsView({
           </div>
         </div>
 
-        <div className="bg-white rounded-md border border-[#d1d9e0]">
+        <div id={usersSection.id} className="bg-white rounded-md border border-[#d1d9e0] scroll-mt-28">
           <div className="px-6 py-4 border-b border-gray-200">
             <h3 className="text-lg font-semibold text-gray-900">Clients Ordered by Number of Users</h3>
           </div>
@@ -213,7 +215,7 @@ export default function ClientsView({
           />
         </div>
 
-        <div className="bg-white rounded-md border border-[#d1d9e0]">
+        <div id={engagementsSection.id} className="bg-white rounded-md border border-[#d1d9e0] scroll-mt-28">
           <div className="px-6 py-4 border-b border-gray-200">
             <h3 className="text-lg font-semibold text-gray-900">Clients Ordered by Number of Engagements</h3>
           </div>

--- a/src/components/CopilotAdoptionView.tsx
+++ b/src/components/CopilotAdoptionView.tsx
@@ -7,6 +7,7 @@ import AdoptionTrendChart from './charts/AdoptionTrendChart';
 import CloudAgentAdoptionChart from './charts/CloudAgentAdoptionChart';
 import CodeReviewAdoptionChart from './charts/CodeReviewAdoptionChart';
 import { ViewPanel } from './ui';
+import { COPILOT_ADOPTION_SECTIONS } from './layout/contextSections';
 import type {
   FeatureAdoptionData,
   AgentModeHeatmapData,
@@ -51,6 +52,7 @@ export default function CopilotAdoptionView({
   const adoptionData = featureAdoptionData ?? EMPTY_FEATURE_ADOPTION_DATA;
   const hasCloudAgentAdoption = adoptionData.codingAgentUsers > 0;
   const hasCodeReviewAdoption = adoptionData.codeReviewUsers > 0;
+  const [featureSection, heatmapSection, trendSection] = COPILOT_ADOPTION_SECTIONS;
 
   return (
     <ViewPanel
@@ -60,10 +62,14 @@ export default function CopilotAdoptionView({
       }}
       contentClassName="space-y-10"
     >
-      <FeatureAdoptionChart
-        data={adoptionData}
-      />
-      <AgentModeHeatmapChart data={agentModeHeatmapData || []} />
+      <div id={featureSection.id} className="scroll-mt-28">
+        <FeatureAdoptionChart
+          data={adoptionData}
+        />
+      </div>
+      <div id={heatmapSection.id} className="scroll-mt-28">
+        <AgentModeHeatmapChart data={agentModeHeatmapData || []} />
+      </div>
       {hasCloudAgentAdoption && (
         <CloudAgentAdoptionChart
           data={dailyCloudAgentAdoptionData}
@@ -78,11 +84,13 @@ export default function CopilotAdoptionView({
           reportEndDay={stats.reportEndDay}
         />
       )}
-      <AdoptionTrendChart
-        data={dailyAdoptionTrend}
-        reportStartDay={stats.reportStartDay}
-        reportEndDay={stats.reportEndDay}
-      />
+      <div id={trendSection.id} className="scroll-mt-28">
+        <AdoptionTrendChart
+          data={dailyAdoptionTrend}
+          reportStartDay={stats.reportStartDay}
+          reportEndDay={stats.reportEndDay}
+        />
+      </div>
     </ViewPanel>
   );
 }

--- a/src/components/LanguagesView.tsx
+++ b/src/components/LanguagesView.tsx
@@ -8,6 +8,7 @@ import type { LanguageFeatureImpactData, DailyLanguageChartData } from '../types
 import LanguageDailyChart from './charts/LanguageDailyChart';
 import { translateFeature } from '../domain/featureTranslations';
 import { sortBySelector, rankBySelector } from '../utils/sorting';
+import { LANGUAGES_SECTIONS } from './layout/contextSections';
 
 interface LanguagesViewProps {
   languages: LanguageStats[];
@@ -362,6 +363,14 @@ export default function LanguagesView({ languages, languageFeatureImpactData, da
     },
   ];
   const maxItemsToShow = 10;
+  const [
+    summarySection,
+    dailyChartsSection,
+    topListsSection,
+    netImpactSection,
+    completeBreakdownSection,
+  ] = LANGUAGES_SECTIONS;
+
   return (
     <ViewPanel
       headerProps={{
@@ -372,15 +381,17 @@ export default function LanguagesView({ languages, languageFeatureImpactData, da
       contentClassName="space-y-6"
     >
       {/* Summary Stats */}
-      <DashboardStatsCardGroup
-        className="mb-6"
-        columns={{ base: 2, md: 5 }}
-        gapClassName="gap-4"
-        items={summaryCards}
-      />
+      <div id={summarySection.id} className="scroll-mt-28">
+        <DashboardStatsCardGroup
+          className="mb-6"
+          columns={{ base: 2, md: 5 }}
+          gapClassName="gap-4"
+          items={summaryCards}
+        />
+      </div>
 
       {/* Daily Language Charts */}
-      <div className="space-y-6 mt-6 pt-6 border-t border-gray-200">
+      <div id={dailyChartsSection.id} className="space-y-6 mt-6 pt-6 border-t border-gray-200 scroll-mt-28">
         <LanguageDailyChart chartData={dailyLanguageGenerationsData} variant="generations" />
         <LanguageDailyChart chartData={dailyLanguageLocData} variant="loc" />
       </div>
@@ -438,7 +449,7 @@ export default function LanguagesView({ languages, languageFeatureImpactData, da
       )}
 
       {/* Two Column Layout for Tables */}
-      <div className="grid grid-cols-1 xl:grid-cols-2 gap-6 mt-6 pt-6 border-t border-gray-200">
+      <div id={topListsSection.id} className="grid grid-cols-1 xl:grid-cols-2 gap-6 mt-6 pt-6 border-t border-gray-200 scroll-mt-28">
         {/* Languages by Number of Generations */}
         <div>
           <h3 className="text-lg font-semibold text-gray-900 mb-4">Languages by Code Generations</h3>
@@ -473,7 +484,7 @@ export default function LanguagesView({ languages, languageFeatureImpactData, da
       </div>
 
       {/* Net Productivity Impact by Language */}
-      <div className="mt-6 pt-6 border-t border-gray-200">
+      <div id={netImpactSection.id} className="mt-6 pt-6 border-t border-gray-200 scroll-mt-28">
         <h3 className="text-lg font-semibold text-gray-900 mb-2">Net Productivity Impact by Language</h3>
         <p className="text-sm text-gray-500 mb-4">
           Net LOC impact estimates how much accepted code Copilot is changing per language, combining lines of code added and deleted.
@@ -492,7 +503,7 @@ export default function LanguagesView({ languages, languageFeatureImpactData, da
       </div>
 
       {/* Full Languages Table */}
-      <div className="mt-6 pt-6 border-t border-gray-200">
+      <div id={completeBreakdownSection.id} className="mt-6 pt-6 border-t border-gray-200 scroll-mt-28">
         <h3 className="text-lg font-semibold text-gray-900 mb-4">Complete Languages Breakdown</h3>
         <MetricsTable
           data={sortedLanguages}

--- a/src/components/ModelDetailsView.tsx
+++ b/src/components/ModelDetailsView.tsx
@@ -5,6 +5,7 @@ import ModelsUsageChart from './charts/ModelsUsageChart';
 import AutoModeAdoptionTrendChart from './charts/AutoModeAdoptionTrendChart';
 import type { ModelBreakdownData } from '../types/metrics';
 import { ViewPanel } from './ui';
+import { MODEL_DETAILS_SECTIONS } from './layout/contextSections';
 
 interface ModelDetailsViewProps {
   modelBreakdownData: ModelBreakdownData;
@@ -20,6 +21,7 @@ export default function ModelDetailsView({ modelBreakdownData }: ModelDetailsVie
     () => autoModels.reduce((sum, entry) => sum + entry.total, 0),
     [autoModels]
   );
+  const [allModelsSection, autoModelsSection, autoAdoptionSection] = MODEL_DETAILS_SECTIONS;
 
   return (
     <ViewPanel
@@ -41,9 +43,15 @@ export default function ModelDetailsView({ modelBreakdownData }: ModelDetailsVie
             Read the announcement.
           </a>
         </div>
-        <ModelsUsageChart modelEntries={modelEntries} dates={modelBreakdownData.dates} totalInteractions={modelTotal} variant="all" />
-        <ModelsUsageChart modelEntries={autoModels} dates={modelBreakdownData.dates} totalInteractions={autoTotal} variant="auto" />
-        <AutoModeAdoptionTrendChart data={autoModeAdoptionTrend} />
+        <div id={allModelsSection.id} className="scroll-mt-28">
+          <ModelsUsageChart modelEntries={modelEntries} dates={modelBreakdownData.dates} totalInteractions={modelTotal} variant="all" />
+        </div>
+        <div id={autoModelsSection.id} className="scroll-mt-28">
+          <ModelsUsageChart modelEntries={autoModels} dates={modelBreakdownData.dates} totalInteractions={autoTotal} variant="auto" />
+        </div>
+        <div id={autoAdoptionSection.id} className="scroll-mt-28">
+          <AutoModeAdoptionTrendChart data={autoModeAdoptionTrend} />
+        </div>
       </div>
     </ViewPanel>
   );

--- a/src/components/UserDetailsView.tsx
+++ b/src/components/UserDetailsView.tsx
@@ -710,7 +710,7 @@ export default function UserDetailsView({ userDetails, userSummary, userLogin, u
           </div>
         </div>
       )}
-       
+
       <div id={summarySection.id} className="scroll-mt-28">
         <UserSummaryChart
           usedChat={usedChat}

--- a/src/components/UserDetailsView.tsx
+++ b/src/components/UserDetailsView.tsx
@@ -28,6 +28,7 @@ import type { TooltipItem } from 'chart.js';
 import { registerChartJS } from './charts/utils/chartSetup';
 import { isActiveAutoModeFeature } from '../domain/autoMode';
 import { getTotalUserInitiatedInteractionCount } from '../domain/assumedInteractions';
+import { USER_DETAILS_SECTIONS } from './layout/contextSections';
 
 registerChartJS();
 
@@ -546,6 +547,17 @@ export default function UserDetailsView({ userDetails, userSummary, userLogin, u
       }))
       .sort((a, b) => a.date.localeCompare(b.date));
   }, [userDetails.days]);
+  const [
+    overviewSection,
+    aiCreditsSection,
+    combinedImpactSection,
+    impactBreakdownSection,
+    summarySection,
+    clientActivitySection,
+    featureActivitySection,
+    languageActivitySection,
+    modelActivitySection,
+  ] = USER_DETAILS_SECTIONS;
 
   return (
     <ViewPanel
@@ -601,7 +613,7 @@ export default function UserDetailsView({ userDetails, userSummary, userLogin, u
       )}
       contentClassName="space-y-8"
     >
-      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+      <div id={overviewSection.id} className="grid grid-cols-1 lg:grid-cols-3 gap-6 scroll-mt-28">
         <div className="lg:col-span-2">
           <ActivityCalendar
             days={userDetails.days}
@@ -624,23 +636,27 @@ export default function UserDetailsView({ userDetails, userSummary, userLogin, u
         </div>
       </div>
 
-      <AiCreditsChart
-        data={dailyAiCreditsData}
-        reportStartDay={userDetails.reportStartDay}
-        reportEndDay={userDetails.reportEndDay}
-        description="AI credits consumed by this user each day during the reporting period"
-        showUsers={false}
-      />
+      <div id={aiCreditsSection.id} className="scroll-mt-28">
+        <AiCreditsChart
+          data={dailyAiCreditsData}
+          reportStartDay={userDetails.reportStartDay}
+          reportEndDay={userDetails.reportEndDay}
+          description="AI credits consumed by this user each day during the reporting period"
+          showUsers={false}
+        />
+      </div>
 
-      <ModeImpactChart
-        data={filledCombinedImpact}
-        title="Combined Copilot Impact"
-        description="Daily lines of code added and deleted across Code Completion, Ask Mode, Agent Mode, Edit Mode, and Inline Mode activities."
-        emptyStateMessage="No combined impact data available."
-      />
+      <div id={combinedImpactSection.id} className="scroll-mt-28">
+        <ModeImpactChart
+          data={filledCombinedImpact}
+          title="Combined Copilot Impact"
+          description="Daily lines of code added and deleted across Code Completion, Ask Mode, Agent Mode, Edit Mode, and Inline Mode activities."
+          emptyStateMessage="No combined impact data available."
+        />
+      </div>
 
       {/* Impact Breakdown Section */}
-      <div className="border-t border-gray-200 pt-6">
+      <div id={impactBreakdownSection.id} className="border-t border-gray-200 pt-6 scroll-mt-28">
         <div className="flex items-center justify-between mb-4">
           <div>
             <h3 className="text-lg font-semibold text-gray-900">Impact Breakdown</h3>
@@ -694,35 +710,39 @@ export default function UserDetailsView({ userDetails, userSummary, userLogin, u
           </div>
         </div>
       )}
-      
-      <UserSummaryChart
-        usedChat={usedChat}
-        usedAgent={usedAgent}
-        usedCli={usedCli}
-        usedCodingAgent={usedCodingAgent}
-        usedCodeReview={usedCodeReview}
-        usedAutoMode={usedAutoMode}
-        ideChartData={ideAggregates.length > 0 || totalCliPrompts > 0 ? ideChartData : undefined}
-        languageChartData={Object.keys(languageGenerations).length > 0 ? languageChartData : undefined}
-        modelChartData={Object.keys(modelInteractions).length > 0 ? modelChartData : undefined}
-        chartOptions={chartOptions}
-      />
+       
+      <div id={summarySection.id} className="scroll-mt-28">
+        <UserSummaryChart
+          usedChat={usedChat}
+          usedAgent={usedAgent}
+          usedCli={usedCli}
+          usedCodingAgent={usedCodingAgent}
+          usedCodeReview={usedCodeReview}
+          usedAutoMode={usedAutoMode}
+          ideChartData={ideAggregates.length > 0 || totalCliPrompts > 0 ? ideChartData : undefined}
+          languageChartData={Object.keys(languageGenerations).length > 0 ? languageChartData : undefined}
+          modelChartData={Object.keys(modelInteractions).length > 0 ? modelChartData : undefined}
+          chartOptions={chartOptions}
+        />
+      </div>
 
       {showCloudAgentsUsage && (
         <CloudAgentsUsageChart data={cloudAgentsUsageData} />
       )}
 
-      <ClientActivityChart
-        ideAggregates={ideAggregates}
-        days={userDetails.days}
-        reportStartDay={userDetails.reportStartDay}
-        reportEndDay={userDetails.reportEndDay}
-        pluginVersions={userDetails.pluginVersions}
-        cliVersions={userDetails.cliVersions}
+      <div id={clientActivitySection.id} className="scroll-mt-28">
+        <ClientActivityChart
+          ideAggregates={ideAggregates}
+          days={userDetails.days}
+          reportStartDay={userDetails.reportStartDay}
+          reportEndDay={userDetails.reportEndDay}
+          pluginVersions={userDetails.pluginVersions}
+          cliVersions={userDetails.cliVersions}
         />
+      </div>
 
       {/* Totals by Feature */}
-      <div className="mt-8 pt-6 border-t border-gray-200">
+      <div id={featureActivitySection.id} className="mt-8 pt-6 border-t border-gray-200 scroll-mt-28">
         <h3 className="text-lg font-semibold text-gray-900 mb-4">Activity by Feature</h3>
         <div className="overflow-x-auto border border-gray-200">
           <table className="w-full divide-y divide-gray-200">
@@ -756,17 +776,21 @@ export default function UserDetailsView({ userDetails, userSummary, userLogin, u
         </div>
       </div>
 
-      <UserActivityByLanguageAndFeatureChart
-        languageFeatureAggregates={languageFeatureAggregates}
-        languageBarChartData={languageBarChartData}
-        languageBarChartOptions={languageBarChartOptions}
+      <div id={languageActivitySection.id} className="scroll-mt-28">
+        <UserActivityByLanguageAndFeatureChart
+          languageFeatureAggregates={languageFeatureAggregates}
+          languageBarChartData={languageBarChartData}
+          languageBarChartOptions={languageBarChartOptions}
         />
+      </div>
 
-      <UserActivityByModelAndFeatureChart
-        modelFeatureAggregates={modelFeatureAggregates}
-        modelBarChartData={modelBarChartData}
-        modelBarChartOptions={modelBarChartOptions}
-      />
+      <div id={modelActivitySection.id} className="scroll-mt-28">
+        <UserActivityByModelAndFeatureChart
+          modelFeatureAggregates={modelFeatureAggregates}
+          modelBarChartData={modelBarChartData}
+          modelBarChartOptions={modelBarChartOptions}
+        />
+      </div>
 
       <DayDetailsModal
         isOpen={modalState.isOpen}

--- a/src/components/layout/contextSections.ts
+++ b/src/components/layout/contextSections.ts
@@ -7,13 +7,13 @@ export interface ContextSection {
 }
 
 export const COPILOT_IMPACT_SECTIONS: ContextSection[] = [
-  { id: 'impact-combined', label: 'Combined Copilot Impact' },
-  { id: 'impact-agent', label: 'Copilot Agent Mode Impact' },
-  { id: 'impact-cli', label: 'Copilot CLI Impact' },
-  { id: 'impact-code-completion', label: 'Code Completion Impact' },
-  { id: 'impact-ask', label: 'Copilot Ask Mode Impact' },
-  { id: 'impact-inline', label: 'Copilot Inline Mode Impact' },
-  { id: 'impact-edit', label: 'Copilot Edit Mode Impact' },
+  { id: 'impact-combined', label: 'Combined' },
+  { id: 'impact-agent', label: 'Agent Mode' },
+  { id: 'impact-cli', label: 'CLI' },
+  { id: 'impact-code-completion', label: 'Code Completion' },
+  { id: 'impact-ask', label: 'Ask Mode' },
+  { id: 'impact-inline', label: 'Inline Mode' },
+  { id: 'impact-edit', label: 'Edit Mode' },
 ];
 
 export const CLI_ADOPTION_SECTIONS: ContextSection[] = [
@@ -24,8 +24,64 @@ export const CLI_ADOPTION_SECTIONS: ContextSection[] = [
   { id: 'cli-models-usage', label: 'CLI Models Daily Usage' },
 ];
 
+export const CLIENT_ANALYSIS_SECTIONS: ContextSection[] = [
+  { id: 'client-distribution', label: 'Client Distribution' },
+  { id: 'client-insights', label: 'Insights' },
+  { id: 'clients-by-users', label: 'Clients by Users' },
+  { id: 'clients-by-engagements', label: 'Clients by Engagements' },
+];
+
+export const COPILOT_ADOPTION_SECTIONS: ContextSection[] = [
+  { id: 'copilot-feature-adoption', label: 'Feature Adoption' },
+  { id: 'copilot-agent-mode-heatmap', label: 'Agent Mode Heatmap' },
+  { id: 'copilot-adoption-trend', label: 'Adoption Trend' },
+];
+
+export const AI_ADOPTION_PHASE_SECTIONS: ContextSection[] = [
+  { id: 'ai-adoption-phase-comparison', label: 'Phase Comparison' },
+  { id: 'ai-adoption-phase-assignment', label: 'How Phases Are Assigned' },
+];
+
+export const LANGUAGES_SECTIONS: ContextSection[] = [
+  { id: 'languages-summary', label: 'Summary' },
+  { id: 'languages-daily-charts', label: 'Daily Language Charts' },
+  { id: 'languages-top-lists', label: 'Top Language Lists' },
+  { id: 'languages-net-impact', label: 'Net Productivity Impact' },
+  { id: 'languages-complete-breakdown', label: 'Complete Breakdown' },
+];
+
+export const CLIENT_VERSIONS_SECTIONS: ContextSection[] = [
+  { id: 'client-versions-jetbrains', label: 'JetBrains' },
+  { id: 'client-versions-vscode', label: 'Visual Studio Code' },
+];
+
+export const USER_DETAILS_SECTIONS: ContextSection[] = [
+  { id: 'user-details-overview', label: 'Activity Overview' },
+  { id: 'user-details-ai-credits', label: 'AI Credits' },
+  { id: 'user-details-combined-impact', label: 'Combined Impact' },
+  { id: 'user-details-impact-breakdown', label: 'Impact Breakdown' },
+  { id: 'user-details-summary', label: 'Usage Summary' },
+  { id: 'user-details-client-activity', label: 'Client Activity' },
+  { id: 'user-details-feature-activity', label: 'Activity by Feature' },
+  { id: 'user-details-language-activity', label: 'Language Activity' },
+  { id: 'user-details-model-activity', label: 'Model Activity' },
+];
+
+export const MODEL_DETAILS_SECTIONS: ContextSection[] = [
+  { id: 'model-usage-all', label: 'All Models' },
+  { id: 'model-usage-auto', label: 'Auto Models' },
+  { id: 'model-auto-adoption', label: 'Auto Adoption' },
+];
+
 export const CONTEXT_SECTIONS: Partial<Record<ViewMode, ContextSection[]>> = {
   [VIEW_MODES.OVERVIEW]: OVERVIEW_SECTIONS,
+  [VIEW_MODES.CLIENT_ANALYSIS]: CLIENT_ANALYSIS_SECTIONS,
   [VIEW_MODES.COPILOT_IMPACT]: COPILOT_IMPACT_SECTIONS,
+  [VIEW_MODES.COPILOT_ADOPTION]: COPILOT_ADOPTION_SECTIONS,
+  [VIEW_MODES.AI_ADOPTION_PHASES]: AI_ADOPTION_PHASE_SECTIONS,
   [VIEW_MODES.CLI_ADOPTION]: CLI_ADOPTION_SECTIONS,
+  [VIEW_MODES.LANGUAGES]: LANGUAGES_SECTIONS,
+  [VIEW_MODES.CLIENT_VERSIONS]: CLIENT_VERSIONS_SECTIONS,
+  [VIEW_MODES.USER_DETAILS]: USER_DETAILS_SECTIONS,
+  [VIEW_MODES.MODEL_DETAILS]: MODEL_DETAILS_SECTIONS,
 };

--- a/src/hooks/useActiveSection.ts
+++ b/src/hooks/useActiveSection.ts
@@ -17,42 +17,62 @@ export function useActiveSection(ids: string[]): string | null {
       return;
     }
 
-    const elements = ids
-      .map((id) => document.getElementById(id))
-      .filter((el): el is HTMLElement => el !== null);
-
-    if (elements.length === 0) {
-      return;
-    }
-
+    let observer: IntersectionObserver | null = null;
+    let mutationObserver: MutationObserver | null = null;
     const visibility = new Map<string, number>();
 
-    const observer = new IntersectionObserver(
-      (entries) => {
-        for (const entry of entries) {
-          visibility.set(entry.target.id, entry.isIntersecting ? entry.intersectionRatio : 0);
-        }
+    const observeCurrentElements = () => {
+      const elements = ids
+        .map((id) => document.getElementById(id))
+        .filter((el): el is HTMLElement => el !== null);
 
-        let topId: string | null = null;
-        let topRatio = 0;
-        for (const id of ids) {
-          const ratio = visibility.get(id) ?? 0;
-          if (ratio > topRatio) {
-            topRatio = ratio;
-            topId = id;
+      if (elements.length === 0) {
+        return false;
+      }
+
+      observer?.disconnect();
+      visibility.clear();
+      observer = new IntersectionObserver(
+        (entries) => {
+          for (const entry of entries) {
+            visibility.set(entry.target.id, entry.isIntersecting ? entry.intersectionRatio : 0);
           }
+
+          let topId: string | null = null;
+          let topRatio = 0;
+          for (const id of ids) {
+            const ratio = visibility.get(id) ?? 0;
+            if (ratio > topRatio) {
+              topRatio = ratio;
+              topId = id;
+            }
+          }
+
+          if (topId) {
+            setActiveId(topId);
+          }
+        },
+        { rootMargin: '-120px 0px -55% 0px', threshold: [0, 0.25, 0.5, 0.75, 1] }
+      );
+
+      elements.forEach((el) => observer?.observe(el));
+      return true;
+    };
+
+    if (!observeCurrentElements() && typeof MutationObserver !== 'undefined') {
+      mutationObserver = new MutationObserver(() => {
+        if (observeCurrentElements()) {
+          mutationObserver?.disconnect();
+          mutationObserver = null;
         }
+      });
+      mutationObserver.observe(document.body, { childList: true, subtree: true });
+    }
 
-        if (topId) {
-          setActiveId(topId);
-        }
-      },
-      { rootMargin: '-120px 0px -55% 0px', threshold: [0, 0.25, 0.5, 0.75, 1] }
-    );
-
-    elements.forEach((el) => observer.observe(el));
-
-    return () => observer.disconnect();
+    return () => {
+      observer?.disconnect();
+      mutationObserver?.disconnect();
+    };
   }, [key]);
 
   return activeId;


### PR DESCRIPTION
## Why

Several analysis pages did not expose the right-side context navigation, making long dashboards harder to scan and navigate. This change extends the existing ContextPanel pattern across detail-heavy views and keeps labels concise enough to fit the panel.

| Commit | Change |
|--------|--------|
| `feat: add context panels across detail views` | Adds context section metadata and scroll anchors for Clients, Copilot Adoption, AI Adoption Phases, Languages, Client Versions, User Details, and Model Usage. Also updates active-section tracking so asynchronously rendered anchors, such as User Details, are observed when they appear. |