### PR TITLE
feat: add AI Credits view with usage distribution

### DIFF
--- a/src/components/AiCreditsView.tsx
+++ b/src/components/AiCreditsView.tsx
@@ -1,0 +1,307 @@
+'use client';
+
+import React, { useMemo } from 'react';
+import AiCreditsChart from './charts/AiCreditsChart';
+import { ViewPanel } from './ui';
+import MetricsTable, { TableColumn } from './ui/MetricsTable';
+import { formatAiAdoptionPhase, formatAiCreditCost, formatModelDisplayName, formatNumber, formatPercentage } from '../utils/formatters';
+import { formatIDEName, getIDEIcon } from './icons/IDEIcons';
+import { getModelIcon } from './icons/ModelIcons';
+import type { DailyAiCreditsData, AiAdoptionPhaseTopEntry, UsageDistributionBucket } from '../domain/calculators/metricCalculators';
+import type { MetricsStats, UserSummary } from '../types/metrics';
+
+interface AiCreditsViewProps {
+  stats: MetricsStats;
+  dailyAiCreditsData: DailyAiCreditsData[];
+  userSummaries: UserSummary[];
+  usageDistributionData: UsageDistributionBucket[];
+  onUserClick: (userLogin: string, userId: number) => void;
+}
+
+function formatAverage(value: number): string {
+  return formatNumber(value, 1);
+}
+
+function renderTopModelEntries(entries: AiAdoptionPhaseTopEntry[]) {
+  if (entries.length === 0) {
+    return <span className="text-sm text-gray-400">No data</span>;
+  }
+
+  return (
+    <div className="space-y-1">
+      {entries.map((entry) => {
+        const ModelIcon = getModelIcon(entry.name);
+        return (
+          <div key={entry.name} className="flex items-center justify-between gap-3 text-sm">
+            <div className="flex min-w-0 items-center gap-2">
+              <div className="flex-shrink-0">
+                <ModelIcon />
+              </div>
+              <span className="truncate text-gray-900" title={entry.name}>
+                {formatModelDisplayName(entry.name)}
+              </span>
+            </div>
+            <span className="whitespace-nowrap text-xs text-gray-500" title={`${entry.uniqueUsers.toLocaleString()} users`}>
+              {entry.total.toLocaleString()}
+            </span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function renderTopClientEntries(entries: AiAdoptionPhaseTopEntry[]) {
+  if (entries.length === 0) {
+    return <span className="text-sm text-gray-400">No data</span>;
+  }
+
+  return (
+    <div className="space-y-1">
+      {entries.map((entry) => {
+        const ClientIcon = getIDEIcon(entry.name);
+        return (
+          <div key={entry.name} className="flex items-center justify-between gap-3 text-sm">
+            <div className="flex min-w-0 items-center gap-2">
+              <div className="flex-shrink-0">
+                <ClientIcon />
+              </div>
+              <span className="truncate text-gray-900" title={entry.name}>
+                {formatIDEName(entry.name)}
+              </span>
+            </div>
+            <span className="whitespace-nowrap text-xs text-gray-500" title={`${entry.uniqueUsers.toLocaleString()} users`}>
+              {entry.total.toLocaleString()}
+            </span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+interface TopAiCreditsUser extends UserSummary {
+  creditsShare: number;
+}
+
+const TOP_USER_COUNT = 5;
+
+export default function AiCreditsView({ stats, dailyAiCreditsData, userSummaries, usageDistributionData, onUserClick }: AiCreditsViewProps) {
+  const hasAiCreditsData = dailyAiCreditsData.some(entry => entry.aiCreditsUsed > 0);
+
+  const topUsers = useMemo<TopAiCreditsUser[]>(() => {
+    const totalCredits = userSummaries.reduce((sum, user) => sum + user.total_ai_credits_used, 0);
+    return userSummaries
+      .filter(user => user.total_ai_credits_used > 0)
+      .sort((a, b) => b.total_ai_credits_used - a.total_ai_credits_used)
+      .slice(0, TOP_USER_COUNT)
+      .map(user => ({
+        ...user,
+        creditsShare: totalCredits > 0 ? (user.total_ai_credits_used / totalCredits) * 100 : 0,
+      }));
+  }, [userSummaries]);
+
+  const headerBaseClass = 'px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider';
+  const headerRightClass = 'px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider';
+  const valueCellClass = 'px-6 py-4 whitespace-nowrap text-sm text-gray-900 text-right';
+
+  const columns: TableColumn<TopAiCreditsUser>[] = [
+    {
+      id: 'user_login',
+      header: 'USERNAME',
+      headerClassName: headerBaseClass,
+      className: 'px-6 py-4 whitespace-nowrap',
+      renderCell: (user) => (
+        <button
+          type="button"
+          onClick={() => onUserClick(user.user_login, user.user_id)}
+          className="flex items-center text-left group"
+        >
+          <div className="h-9 w-9 rounded-full bg-blue-100 flex items-center justify-center flex-shrink-0">
+            <span className="text-sm font-medium text-blue-700">
+              {user.user_login.charAt(0).toUpperCase()}
+            </span>
+          </div>
+          <div className="ml-3 text-sm font-medium text-blue-600 group-hover:text-blue-800 group-hover:underline">{user.user_login}</div>
+        </button>
+      ),
+    },
+    {
+      id: 'days_active',
+      header: 'DAYS ACTIVE',
+      headerClassName: headerRightClass,
+      className: valueCellClass,
+      renderCell: (user) => formatNumber(user.days_active),
+    },
+    {
+      id: 'total_ai_credits_used',
+      header: 'AI CREDITS',
+      headerClassName: headerRightClass,
+      className: valueCellClass,
+      renderCell: (user) => formatAiCreditCost(user.total_ai_credits_used),
+    },
+    {
+      id: 'creditsShare',
+      header: 'SHARE',
+      headerClassName: headerRightClass,
+      className: valueCellClass,
+      renderCell: (user) => formatPercentage(user.creditsShare),
+    },
+    {
+      id: 'net_loc_contribution',
+      header: 'LOC IMPACT',
+      headerClassName: headerRightClass,
+      className: valueCellClass,
+      renderCell: (user) => (
+        <span className="whitespace-nowrap tabular-nums">
+          <span className="text-green-600">+{user.total_loc_added.toLocaleString()}</span>
+          <span className="text-gray-400">/</span>
+          <span className="text-red-600">-{user.total_loc_deleted.toLocaleString()}</span>
+        </span>
+      ),
+    },
+    {
+      id: 'ai_adoption_phase',
+      header: 'AI ADOPTION',
+      headerClassName: `${headerRightClass} whitespace-nowrap`,
+      className: 'px-6 py-4 whitespace-nowrap text-right',
+      renderCell: (user) => (
+        <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-purple-100 text-purple-800">
+          {formatAiAdoptionPhase(user.ai_adoption_phase)}
+        </span>
+      ),
+    },
+  ];
+
+  const distributionColumns: TableColumn<UsageDistributionBucket>[] = [
+    {
+      id: 'bucket',
+      header: 'Segment',
+      headerClassName: 'px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider min-w-[200px]',
+      className: 'px-6 py-4 align-top',
+      renderCell: (bucket) => (
+        <div>
+          <div className="text-sm font-semibold text-gray-900">{bucket.label}</div>
+          <div className="text-xs text-gray-500">{bucket.description}</div>
+        </div>
+      ),
+    },
+    {
+      id: 'userCount',
+      header: 'Users',
+      headerClassName: headerRightClass,
+      className: `${valueCellClass} font-medium align-top`,
+      renderCell: (bucket) => bucket.userCount.toLocaleString(),
+    },
+    {
+      id: 'totalAiCreditsUsed',
+      header: 'Total AI Credits',
+      headerClassName: headerRightClass,
+      className: `${valueCellClass} font-medium align-top`,
+      renderCell: (bucket) => formatAiCreditCost(bucket.totalAiCreditsUsed),
+    },
+    {
+      id: 'avgAiCreditsUsed',
+      header: 'Avg AI Credits',
+      headerClassName: headerRightClass,
+      className: `${valueCellClass} align-top`,
+      renderCell: (bucket) => formatAiCreditCost(bucket.avgAiCreditsUsed),
+    },
+    {
+      id: 'avgDaysActive',
+      header: 'Avg Active Days',
+      headerClassName: headerRightClass,
+      className: `${valueCellClass} align-top`,
+      renderCell: (bucket) => formatAverage(bucket.avgDaysActive),
+    },
+    {
+      id: 'totalLocImpact',
+      header: 'Total LOC Impact',
+      headerClassName: headerRightClass,
+      className: `${valueCellClass} align-top`,
+      renderCell: (bucket) => (
+        <span className="whitespace-nowrap tabular-nums">
+          <span className="text-green-600">+{bucket.totalLocAdded.toLocaleString()}</span>
+          <span className="text-gray-400">/</span>
+          <span className="text-red-600">-{bucket.totalLocDeleted.toLocaleString()}</span>
+        </span>
+      ),
+    },
+    {
+      id: 'topModels',
+      header: 'Top Models - interactions',
+      headerClassName: 'px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider min-w-[180px]',
+      className: 'px-6 py-4 align-top',
+      renderCell: (bucket) => renderTopModelEntries(bucket.topModels),
+    },
+    {
+      id: 'topClients',
+      header: 'Top Clients - activity',
+      headerClassName: 'px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider min-w-[180px]',
+      className: 'px-6 py-4 align-top',
+      renderCell: (bucket) => renderTopClientEntries(bucket.topClients),
+    },
+  ];
+
+  const hasDistributionData = usageDistributionData.some((bucket) => bucket.userCount > 0);
+
+  return (
+    <ViewPanel
+      headerProps={{
+        title: 'AI Credits',
+        description: 'AI credit consumption across the reporting period.',
+      }}
+      contentClassName="space-y-8"
+    >
+      {hasAiCreditsData ? (
+        <div id="ai-credits-daily-consumption" className="scroll-mt-28">
+          <AiCreditsChart
+            data={dailyAiCreditsData}
+            reportStartDay={stats.reportStartDay}
+            reportEndDay={stats.reportEndDay}
+          />
+        </div>
+      ) : (
+        <div id="ai-credits-daily-consumption" className="scroll-mt-28 rounded-md border border-gray-200 bg-gray-50 px-4 py-6 text-sm text-gray-600">
+          No AI credit consumption was recorded during the reporting period.
+        </div>
+      )}
+
+      {topUsers.length > 0 && (
+        <div id="ai-credits-top-users" className="space-y-3 scroll-mt-28">
+          <div>
+            <h3 className="text-base font-semibold text-gray-900">Top 5 Users by AI Credits Consumption</h3>
+            <p className="text-sm text-gray-600">Users with the highest AI credit usage and their share of total credits consumed.</p>
+          </div>
+          <MetricsTable
+            data={topUsers}
+            columns={columns}
+            getRowKey={(user) => user.user_id}
+            tableContainerClassName="overflow-x-auto border border-gray-200 rounded-lg"
+            tableClassName="min-w-full divide-y divide-gray-200"
+            theadClassName="bg-gray-50"
+            tbodyClassName="bg-white divide-y divide-gray-200"
+          />
+        </div>
+      )}
+
+      {hasDistributionData && (
+        <div id="ai-credits-usage-distribution" className="space-y-3 scroll-mt-28">
+          <div>
+            <h3 className="text-base font-semibold text-gray-900">Usage Distribution</h3>
+            <p className="text-sm text-gray-600">Users segmented by AI credit consumption. Averages are calculated per user within each segment.</p>
+          </div>
+          <MetricsTable<UsageDistributionBucket>
+            data={usageDistributionData}
+            columns={distributionColumns}
+            getRowKey={(bucket) => bucket.id}
+            tableContainerClassName="overflow-x-auto border border-gray-200 rounded-lg"
+            tableClassName="min-w-full divide-y divide-gray-200"
+            theadClassName="bg-gray-50"
+            rowClassName={(_, index) => `${index % 2 === 0 ? 'bg-white' : 'bg-gray-50'}`}
+          />
+        </div>
+      )}
+    </ViewPanel>
+  );
+}

--- a/src/components/AiCreditsView.tsx
+++ b/src/components/AiCreditsView.tsx
@@ -267,12 +267,12 @@ export default function AiCreditsView({ stats, dailyAiCreditsData, userSummaries
         </div>
       )}
 
-      {topUsers.length > 0 && (
-        <div id="ai-credits-top-users" className="space-y-3 scroll-mt-28">
-          <div>
-            <h3 className="text-base font-semibold text-gray-900">Top 5 Users by AI Credits Consumption</h3>
-            <p className="text-sm text-gray-600">Users with the highest AI credit usage and their share of total credits consumed.</p>
-          </div>
+      <div id="ai-credits-top-users" className="space-y-3 scroll-mt-28">
+        <div>
+          <h3 className="text-base font-semibold text-gray-900">Top 5 Users by AI Credits Consumption</h3>
+          <p className="text-sm text-gray-600">Users with the highest AI credit usage and their share of total credits consumed.</p>
+        </div>
+        {topUsers.length > 0 ? (
           <MetricsTable
             data={topUsers}
             columns={columns}
@@ -282,15 +282,19 @@ export default function AiCreditsView({ stats, dailyAiCreditsData, userSummaries
             theadClassName="bg-gray-50"
             tbodyClassName="bg-white divide-y divide-gray-200"
           />
-        </div>
-      )}
-
-      {hasDistributionData && (
-        <div id="ai-credits-usage-distribution" className="space-y-3 scroll-mt-28">
-          <div>
-            <h3 className="text-base font-semibold text-gray-900">Usage Distribution</h3>
-            <p className="text-sm text-gray-600">Users segmented by AI credit consumption. Averages are calculated per user within each segment.</p>
+        ) : (
+          <div className="rounded-md border border-gray-200 bg-gray-50 px-4 py-6 text-sm text-gray-600">
+            No AI credit consumption was recorded during the reporting period.
           </div>
+        )}
+      </div>
+
+      <div id="ai-credits-usage-distribution" className="space-y-3 scroll-mt-28">
+        <div>
+          <h3 className="text-base font-semibold text-gray-900">Usage Distribution</h3>
+          <p className="text-sm text-gray-600">Users segmented by AI credit consumption. Averages are calculated per user within each segment.</p>
+        </div>
+        {hasDistributionData ? (
           <MetricsTable<UsageDistributionBucket>
             data={usageDistributionData}
             columns={distributionColumns}
@@ -300,8 +304,12 @@ export default function AiCreditsView({ stats, dailyAiCreditsData, userSummaries
             theadClassName="bg-gray-50"
             rowClassName={(_, index) => `${index % 2 === 0 ? 'bg-white' : 'bg-gray-50'}`}
           />
-        </div>
-      )}
+        ) : (
+          <div className="rounded-md border border-gray-200 bg-gray-50 px-4 py-6 text-sm text-gray-600">
+            No AI credit consumption was recorded during the reporting period.
+          </div>
+        )}
+      </div>
     </ViewPanel>
   );
 }

--- a/src/components/features/overview/OverviewDashboard.tsx
+++ b/src/components/features/overview/OverviewDashboard.tsx
@@ -2,11 +2,10 @@
 
 import React from 'react';
 import { MetricsStats } from '../../../types/metrics';
-import { DailyEngagementData, DailyChatUsersData, DailyChatRequestsData, DailyAiCreditsData } from '../../../domain/calculators/metricCalculators';
+import { DailyEngagementData, DailyChatUsersData, DailyChatRequestsData } from '../../../domain/calculators/metricCalculators';
 import EngagementChart from '../../charts/EngagementChart';
 import ChatUsersChart from '../../charts/ChatUsersChart';
 import ChatRequestsChart from '../../charts/ChatRequestsChart';
-import AiCreditsChart from '../../charts/AiCreditsChart';
 import { OVERVIEW_SECTIONS } from './overviewSections';
 
 const [engagementSection, chatUsersSection, chatRequestsSection] = OVERVIEW_SECTIONS;
@@ -17,7 +16,6 @@ interface OverviewDashboardProps {
   engagementData: DailyEngagementData[];
   chatUsersData: DailyChatUsersData[];
   chatRequestsData: DailyChatRequestsData[];
-  dailyAiCreditsData: DailyAiCreditsData[];
 }
 
 const OverviewDashboard: React.FC<OverviewDashboardProps> = ({
@@ -26,7 +24,6 @@ const OverviewDashboard: React.FC<OverviewDashboardProps> = ({
   engagementData,
   chatUsersData,
   chatRequestsData,
-  dailyAiCreditsData,
 }) => {
   const formatDate = (dateString: string) => {
     return new Date(dateString).toLocaleDateString('en-US', {
@@ -35,7 +32,6 @@ const OverviewDashboard: React.FC<OverviewDashboardProps> = ({
       day: 'numeric'
     });
   };
-  const hasAiCreditsData = dailyAiCreditsData.some(entry => entry.aiCreditsUsed > 0);
 
   return (
     <div className="space-y-8">
@@ -58,16 +54,6 @@ const OverviewDashboard: React.FC<OverviewDashboardProps> = ({
       <div id={chatRequestsSection.id} className="w-full scroll-mt-28">
         <ChatRequestsChart data={chatRequestsData} />
       </div>
-
-      {hasAiCreditsData && (
-        <div className="w-full">
-          <AiCreditsChart
-            data={dailyAiCreditsData}
-            reportStartDay={stats.reportStartDay}
-            reportEndDay={stats.reportEndDay}
-          />
-        </div>
-      )}
     </div>
   );
 };

--- a/src/components/layout/ViewRouter.tsx
+++ b/src/components/layout/ViewRouter.tsx
@@ -20,6 +20,7 @@ import AiAdoptionPhaseView from '../AiAdoptionPhaseView';
 import CLIAdoptionView from '../CLIAdoptionView';
 import ModelDetailsView from '../ModelDetailsView';
 import ExecutiveSummaryView from '../ExecutiveSummaryView';
+import AiCreditsView from '../AiCreditsView';
 import ClientVersionsView from '../ClientVersionsView';
 import AboutView from '../AboutView';
 
@@ -142,6 +143,7 @@ const ViewRouter: React.FC = () => {
     dailyCodeReviewAdoptionData = [],
     aiAdoptionPhaseData = [],
     dailyAiCreditsData = [],
+    usageDistributionData = [],
   } = aggregatedMetrics;
 
   switch (currentView) {
@@ -154,6 +156,17 @@ const ViewRouter: React.FC = () => {
           agentImpactData={agentImpactData}
           codeCompletionImpactData={codeCompletionImpactData}
           featureAdoptionData={featureAdoptionData}
+        />
+      );
+
+    case VIEW_MODES.AI_CREDITS:
+      return (
+        <AiCreditsView
+          stats={stats}
+          dailyAiCreditsData={dailyAiCreditsData}
+          userSummaries={userSummaries}
+          usageDistributionData={usageDistributionData}
+          onUserClick={handleUserClick}
         />
       );
 
@@ -295,7 +308,6 @@ const ViewRouter: React.FC = () => {
           engagementData={engagementData}
           chatUsersData={chatUsersData}
           chatRequestsData={chatRequestsData}
-          dailyAiCreditsData={dailyAiCreditsData}
         />
       );
   }

--- a/src/components/layout/contextSections.ts
+++ b/src/components/layout/contextSections.ts
@@ -73,8 +73,15 @@ export const MODEL_DETAILS_SECTIONS: ContextSection[] = [
   { id: 'model-auto-adoption', label: 'Auto Adoption' },
 ];
 
+export const AI_CREDITS_SECTIONS: ContextSection[] = [
+  { id: 'ai-credits-daily-consumption', label: 'Daily Consumption' },
+  { id: 'ai-credits-top-users', label: 'Top Users' },
+  { id: 'ai-credits-usage-distribution', label: 'Usage Distribution' },
+];
+
 export const CONTEXT_SECTIONS: Partial<Record<ViewMode, ContextSection[]>> = {
   [VIEW_MODES.OVERVIEW]: OVERVIEW_SECTIONS,
+  [VIEW_MODES.AI_CREDITS]: AI_CREDITS_SECTIONS,
   [VIEW_MODES.CLIENT_ANALYSIS]: CLIENT_ANALYSIS_SECTIONS,
   [VIEW_MODES.COPILOT_IMPACT]: COPILOT_IMPACT_SECTIONS,
   [VIEW_MODES.COPILOT_ADOPTION]: COPILOT_ADOPTION_SECTIONS,

--- a/src/components/layout/navigationItems.tsx
+++ b/src/components/layout/navigationItems.tsx
@@ -104,6 +104,15 @@ export const NAV_ITEMS: NavItem[] = [
     ),
   },
   {
+    label: 'AI Credits',
+    view: VIEW_MODES.AI_CREDITS,
+    icon: (
+      <svg className="w-5 h-5" aria-hidden="true" focusable="false" fill="none" stroke="currentColor" strokeWidth={1.5} viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" d="M12 6v12m-3-2.818l.879.659c1.171.879 3.07.879 4.242 0 1.172-.879 1.172-2.303 0-3.182C13.536 12.219 12.768 12 12 12c-.725 0-1.45-.22-2.003-.659-1.106-.879-1.106-2.303 0-3.182s2.9-.879 4.006 0l.415.33M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+      </svg>
+    ),
+  },
+  {
     label: 'Executive Summary',
     view: VIEW_MODES.EXECUTIVE_SUMMARY,
     icon: (

--- a/src/domain/calculators/__tests__/usageDistributionCalculator.test.ts
+++ b/src/domain/calculators/__tests__/usageDistributionCalculator.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest';
+import {
+  createAiAdoptionPhaseAccumulator,
+  accumulateAiAdoptionPhase,
+} from '../aiAdoptionPhaseCalculator';
+import { computeUsageDistributionData } from '../usageDistributionCalculator';
+import { makeMetric } from '../../../__tests__/factories/metrics';
+
+function buildAccumulator(metrics: Parameters<typeof accumulateAiAdoptionPhase>[1][]) {
+  const accumulator = createAiAdoptionPhaseAccumulator();
+  for (const metric of metrics) {
+    accumulateAiAdoptionPhase(accumulator, metric);
+  }
+  return accumulator;
+}
+
+describe('usageDistributionCalculator', () => {
+  it('always returns the four ordered buckets', () => {
+    const buckets = computeUsageDistributionData(createAiAdoptionPhaseAccumulator());
+    expect(buckets.map((bucket) => bucket.id)).toEqual(['power', 'heavy', 'typical', 'light']);
+    expect(buckets.every((bucket) => bucket.userCount === 0)).toBe(true);
+  });
+
+  it('partitions 20 users into 5% / 15% / 55% / 25% segments by consumption', () => {
+    const metrics = Array.from({ length: 20 }, (_, index) =>
+      makeMetric({ user_id: index + 1, ai_credits_used: (20 - index) * 10 })
+    );
+
+    const buckets = computeUsageDistributionData(buildAccumulator(metrics));
+    const counts = buckets.map((bucket) => bucket.userCount);
+
+    expect(counts).toEqual([1, 3, 11, 5]);
+    expect(counts.reduce((sum, count) => sum + count, 0)).toBe(20);
+
+    // Power users are the highest consumers.
+    expect(buckets[0].avgAiCreditsUsed).toBe(200);
+    expect(buckets[0].totalAiCreditsUsed).toBe(200);
+    // Light users are the lowest consumers (last 5 of the ranked list: credits 50..10).
+    expect(buckets[3].avgAiCreditsUsed).toBe(30);
+    expect(buckets[3].totalAiCreditsUsed).toBe(150);
+  });
+
+  it('aggregates per-user averages, totals, and top dimensions within a segment', () => {
+    const metrics = [
+      makeMetric({
+        user_id: 1,
+        day: '2024-01-15',
+        ai_credits_used: 100,
+        loc_added_sum: 50,
+        loc_deleted_sum: 10,
+        totals_by_model_feature: [
+          { model: 'gpt-4o', feature: 'chat', user_initiated_interaction_count: 8, code_generation_activity_count: 0, code_acceptance_activity_count: 0, loc_added_sum: 0, loc_deleted_sum: 0, loc_suggested_to_add_sum: 0, loc_suggested_to_delete_sum: 0 },
+        ],
+        totals_by_ide: [
+          { ide: 'vscode', user_initiated_interaction_count: 5, code_generation_activity_count: 0, code_acceptance_activity_count: 0, loc_added_sum: 0, loc_deleted_sum: 0, loc_suggested_to_add_sum: 0, loc_suggested_to_delete_sum: 0 },
+        ],
+      }),
+      makeMetric({
+        user_id: 1,
+        day: '2024-01-16',
+        ai_credits_used: 100,
+        loc_added_sum: 50,
+        loc_deleted_sum: 10,
+      }),
+    ];
+
+    const buckets = computeUsageDistributionData(buildAccumulator(metrics));
+    // With a single user, the typical bucket (round(1 * 0.75) = 1) holds them.
+    const populated = buckets.find((bucket) => bucket.userCount > 0)!;
+
+    expect(populated.userCount).toBe(1);
+    expect(populated.totalAiCreditsUsed).toBe(200);
+    expect(populated.avgAiCreditsUsed).toBe(200);
+    expect(populated.avgDaysActive).toBe(2);
+    expect(populated.totalLocAdded).toBe(100);
+    expect(populated.totalLocDeleted).toBe(20);
+    expect(populated.topModels[0]).toMatchObject({ total: 8, uniqueUsers: 1 });
+    expect(populated.topClients[0]).toMatchObject({ name: 'vscode', total: 5, uniqueUsers: 1 });
+  });
+});

--- a/src/domain/calculators/aiAdoptionPhaseCalculator.ts
+++ b/src/domain/calculators/aiAdoptionPhaseCalculator.ts
@@ -22,7 +22,7 @@ export interface AiAdoptionPhaseData {
   topLanguages: AiAdoptionPhaseTopEntry[];
 }
 
-interface UserPhaseAccumulatorEntry {
+export interface UserPhaseAccumulatorEntry {
   phase?: AIAdoptionPhase;
   latestPhaseDay?: string;
   totalUserInitiatedInteractions: number;
@@ -147,8 +147,10 @@ export function accumulateAiAdoptionPhase(
   }
 }
 
-function addUserDimensionsToPhase(
-  phaseDimensions: PhaseAccumulatorEntry['models'],
+export type DimensionUsageTotals = Map<string, { total: number; uniqueUsers: number }>;
+
+export function addUserDimensionsToPhase(
+  phaseDimensions: DimensionUsageTotals,
   userDimensions: Map<string, number>
 ): void {
   for (const [name, total] of userDimensions) {
@@ -184,7 +186,7 @@ function getOrCreatePhaseEntry(
   return phases.get(phase.phase_number)!;
 }
 
-function computeTopEntries(dimensions: Map<string, { total: number; uniqueUsers: number }>): AiAdoptionPhaseTopEntry[] {
+export function computeTopEntries(dimensions: DimensionUsageTotals): AiAdoptionPhaseTopEntry[] {
   return Array.from(dimensions.entries())
     .map(([name, entry]) => ({
       name,

--- a/src/domain/calculators/index.ts
+++ b/src/domain/calculators/index.ts
@@ -158,10 +158,18 @@ export {
   type AiAdoptionPhaseAccumulator,
   type AiAdoptionPhaseData,
   type AiAdoptionPhaseTopEntry,
+  type DimensionUsageTotals,
+  type UserPhaseAccumulatorEntry,
   createAiAdoptionPhaseAccumulator,
   accumulateAiAdoptionPhase,
   computeAiAdoptionPhaseData,
 } from './aiAdoptionPhaseCalculator';
+
+export {
+  type UsageDistributionBucket,
+  type UsageDistributionBucketId,
+  computeUsageDistributionData,
+} from './usageDistributionCalculator';
 
 export {
   type DailyAiCreditsData,

--- a/src/domain/calculators/metricCalculators.ts
+++ b/src/domain/calculators/metricCalculators.ts
@@ -49,6 +49,11 @@ export type {
 } from './aiAdoptionPhaseCalculator';
 
 export type {
+  UsageDistributionBucket,
+  UsageDistributionBucketId,
+} from './usageDistributionCalculator';
+
+export type {
   DailyAiCreditsData,
 } from './aiCreditsCalculator';
 

--- a/src/domain/calculators/usageDistributionCalculator.ts
+++ b/src/domain/calculators/usageDistributionCalculator.ts
@@ -1,0 +1,95 @@
+import type {
+  AiAdoptionPhaseAccumulator,
+  AiAdoptionPhaseTopEntry,
+  DimensionUsageTotals,
+  UserPhaseAccumulatorEntry,
+} from './aiAdoptionPhaseCalculator';
+import { addUserDimensionsToPhase, computeTopEntries } from './aiAdoptionPhaseCalculator';
+
+export type UsageDistributionBucketId = 'power' | 'heavy' | 'typical' | 'light';
+
+export interface UsageDistributionBucket {
+  id: UsageDistributionBucketId;
+  label: string;
+  description: string;
+  userCount: number;
+  totalAiCreditsUsed: number;
+  avgAiCreditsUsed: number;
+  avgDaysActive: number;
+  totalLocAdded: number;
+  totalLocDeleted: number;
+  topModels: AiAdoptionPhaseTopEntry[];
+  topClients: AiAdoptionPhaseTopEntry[];
+}
+
+interface BucketDefinition {
+  id: UsageDistributionBucketId;
+  label: string;
+  description: string;
+  /** Cumulative upper boundary as a fraction of the ranked population. */
+  cumulativeFraction: number;
+}
+
+const BUCKET_DEFINITIONS: BucketDefinition[] = [
+  { id: 'power', label: 'Power Users', description: 'Top 5% by AI credit consumption', cumulativeFraction: 0.05 },
+  { id: 'heavy', label: 'Heavy Users', description: 'Next 15% by AI credit consumption', cumulativeFraction: 0.2 },
+  { id: 'typical', label: 'Typical Users', description: 'Middle 55% by AI credit consumption', cumulativeFraction: 0.75 },
+  { id: 'light', label: 'Light Users', description: 'Remaining 25% by AI credit consumption', cumulativeFraction: 1 },
+];
+
+function aggregateBucket(
+  definition: BucketDefinition,
+  users: UserPhaseAccumulatorEntry[]
+): UsageDistributionBucket {
+  const models: DimensionUsageTotals = new Map();
+  const clients: DimensionUsageTotals = new Map();
+
+  let totalAiCreditsUsed = 0;
+  let totalDaysActive = 0;
+  let totalLocAdded = 0;
+  let totalLocDeleted = 0;
+
+  for (const user of users) {
+    totalAiCreditsUsed += user.totalAiCreditsUsed;
+    totalDaysActive += user.activeDays.size;
+    totalLocAdded += user.totalLocAdded;
+    totalLocDeleted += user.totalLocDeleted;
+    addUserDimensionsToPhase(models, user.models);
+    addUserDimensionsToPhase(clients, user.clients);
+  }
+
+  const userCount = users.length;
+
+  return {
+    id: definition.id,
+    label: definition.label,
+    description: definition.description,
+    userCount,
+    totalAiCreditsUsed,
+    avgAiCreditsUsed: userCount > 0 ? totalAiCreditsUsed / userCount : 0,
+    avgDaysActive: userCount > 0 ? totalDaysActive / userCount : 0,
+    totalLocAdded,
+    totalLocDeleted,
+    topModels: computeTopEntries(models),
+    topClients: computeTopEntries(clients),
+  };
+}
+
+export function computeUsageDistributionData(
+  accumulator: AiAdoptionPhaseAccumulator
+): UsageDistributionBucket[] {
+  const rankedUsers = Array.from(accumulator.users.values()).sort(
+    (a, b) => b.totalAiCreditsUsed - a.totalAiCreditsUsed || b.activeDays.size - a.activeDays.size
+  );
+
+  const totalUsers = rankedUsers.length;
+
+  let cursor = 0;
+  return BUCKET_DEFINITIONS.map((definition) => {
+    const upperBound = Math.round(totalUsers * definition.cumulativeFraction);
+    const end = Math.max(cursor, Math.min(upperBound, totalUsers));
+    const bucketUsers = rankedUsers.slice(cursor, end);
+    cursor = end;
+    return aggregateBucket(definition, bucketUsers);
+  });
+}

--- a/src/domain/metricsAggregator.ts
+++ b/src/domain/metricsAggregator.ts
@@ -112,6 +112,9 @@ import {
   accumulateAiAdoptionPhase,
   computeAiAdoptionPhaseData,
 
+  UsageDistributionBucket,
+  computeUsageDistributionData,
+
   DailyAiCreditsData,
   createAiCreditsAccumulator,
   accumulateAiCredits,
@@ -151,6 +154,7 @@ export interface AggregatedMetrics {
   dailyCloudAgentAdoptionData: DailyCloudAgentAdoptionData[];
   dailyCodeReviewAdoptionData: DailyCodeReviewAdoptionData[];
   aiAdoptionPhaseData: AiAdoptionPhaseData[];
+  usageDistributionData: UsageDistributionBucket[];
   dailyAiCreditsData: DailyAiCreditsData[];
 }
 
@@ -436,6 +440,7 @@ export function aggregateMetrics(
     dailyCloudAgentAdoptionData: computeDailyCloudAgentAdoptionData(advancedAdoptionAccumulator),
     dailyCodeReviewAdoptionData: computeDailyCodeReviewAdoptionData(advancedAdoptionAccumulator),
     aiAdoptionPhaseData: computeAiAdoptionPhaseData(aiAdoptionPhaseAccumulator),
+    usageDistributionData: computeUsageDistributionData(aiAdoptionPhaseAccumulator),
     dailyAiCreditsData: computeDailyAiCreditsData(aiCreditsAccumulator),
     },
     userDetailAccumulator,

--- a/src/types/navigation.ts
+++ b/src/types/navigation.ts
@@ -1,5 +1,6 @@
 export const VIEW_MODES = {
   OVERVIEW: 'overview',
+  AI_CREDITS: 'aiCredits',
   EXECUTIVE_SUMMARY: 'executiveSummary',
   ABOUT: 'about',
   CLIENT_VERSIONS: 'clientVersions',


### PR DESCRIPTION
## Why

AI credit consumption was buried as a single chart on the Overview dashboard, with no way to see who is driving spend or how usage is distributed across the user base. This adds a dedicated **AI Credits** view that surfaces consumption patterns at a glance.

## What

- **New navigation view** "AI Credits", placed directly above Executive Summary. The Daily AI Credits Consumption chart moves here from the Overview dashboard.
- **Top 5 Users table** by AI credit consumption: username (clickable, opens User Details), days active, AI Credits (shown as dollar cost), share of total credits, LOC impact, and AI adoption phase.
- **Usage Distribution table** segmenting users into four consumption buckets, Power Users (top 5%), Heavy (next 15%), Typical (mid 55%), and Light (remaining). Each bucket shows user count, total and average AI credits, average active days, total LOC impact, and top models/clients with icons.
- **Context bar** registered for the view ("On this page").

## Approach notes

The Usage Distribution calculator reuses the existing `aiAdoptionPhaseAccumulator` per-user data rather than running a second accumulation pass, so the new bucketing adds no extra parse work in the worker. Bucket boundaries use strictly increasing cumulative fractions so the partition has no gaps or overlaps and the final bucket always captures the remainder. Model icons in the distribution table follow the same `getModelIcon` pattern just introduced in the phase comparison table.

All parsing/aggregation stays in the Web Worker via `metricsAggregator`; the new data is exposed on `AggregatedMetrics`.

## Verification

`npm run build`, `npm run lint`, and the full test suite (506 tests, including 3 new unit tests for the distribution calculator) all pass.