### PR TITLE
Add top client column to unique users

### DIFF
--- a/src/components/UniqueUsersView.tsx
+++ b/src/components/UniqueUsersView.tsx
@@ -5,6 +5,8 @@ import type { UserSummary } from '../types/metrics';
 import { useUsernameTrieSearch } from '../hooks/useUsernameTrieSearch';
 import { useSortableTable } from '../hooks/useSortableTable';
 import { formatAiAdoptionPhase, formatAiCreditCost } from '../utils/formatters';
+import { formatIDEName } from '../utils/ideNames';
+import { getIDEIcon } from './icons/IDEIcons';
 import { ViewPanel } from './ui';
 import DashboardStatsCard from './ui/DashboardStatsCard';
 import StatsGrid from './ui/StatsGrid';
@@ -15,8 +17,18 @@ interface UniqueUsersViewProps {
   onUserClick: (userLogin: string, userId: number) => void;
 }
 
-type SortField = 'user_login' | 'total_user_initiated_interactions' | 'total_code_generation_activities' | 'total_ai_credits_used' | 'days_active' | 'net_loc_contribution' | 'cloud_agent_days' | 'code_review_days';
+type SortField = 'user_login' | 'total_user_initiated_interactions' | 'total_code_generation_activities' | 'total_ai_credits_used' | 'days_active' | 'net_loc_contribution' | 'cloud_agent_days' | 'code_review_days' | 'top_client';
 const USERS_PER_PAGE = 500;
+
+function ClientIcon({ client }: { client: string }) {
+  const Icon = getIDEIcon(client);
+
+  return (
+    <span aria-hidden="true" className="inline-flex h-5 w-5 flex-shrink-0 items-center justify-center">
+      <Icon />
+    </span>
+  );
+}
 
 export default function UniqueUsersView({ users, onUserClick }: UniqueUsersViewProps) {
   const { searchQuery, setSearchQuery, filteredUsers } = useUsernameTrieSearch(users);
@@ -137,6 +149,19 @@ export default function UniqueUsersView({ users, onUserClick }: UniqueUsersViewP
       accessor: 'code_review_days',
       headerClassName: `${headerRightClass} w-1/8`,
       className: valueCellClass,
+    },
+    {
+      id: 'top_client',
+      header: 'CLIENT',
+      sortable: true,
+      headerClassName: `${headerRightClass} w-1/8`,
+      className: valueCellClass,
+      renderCell: (user) => user.top_client ? (
+        <span className="inline-flex items-center justify-end gap-2">
+          <ClientIcon client={user.top_client} />
+          {formatIDEName(user.top_client)}
+        </span>
+      ) : '-',
     },
     {
       id: 'ai_adoption_phase',

--- a/src/components/icons/IDEIcons.tsx
+++ b/src/components/icons/IDEIcons.tsx
@@ -155,6 +155,24 @@ const RustRoverIcon = () => (
   </svg>
 );
 
+const RubyMineIcon = () => (
+  <svg className="w-5 h-5" viewBox="0 0 24 24" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg">
+    <path d="M0 0v24h24V0H0z" fill="#000" />
+    <text
+      x="12"
+      y="13.4"
+      textAnchor="middle"
+      fontFamily="Arial, Helvetica, sans-serif"
+      fontSize="8.5"
+      fontWeight="700"
+      fill="#fff"
+    >
+      RM
+    </text>
+    <path d="M2.28 19.5h9V21h-9z" fill="#fff" />
+  </svg>
+);
+
 const DefaultIDEIcon = () => (
   <svg className="w-5 h-5" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
     <path d="M3 3h18a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2z" stroke="#6B7280" strokeWidth="2" fill="none"/>
@@ -175,6 +193,7 @@ const ideIconMap: Record<string, React.ComponentType> = {
   android_studio: AndroidStudioIcon,
   goland: GoLandIcon,
   phpstorm: PhpStormIcon,
+  rubymine: RubyMineIcon,
   clion: CLionIcon,
   rustrover: RustRoverIcon,
   rstudio: RStudioIcon,

--- a/src/domain/__tests__/metricsAggregator.test.ts
+++ b/src/domain/__tests__/metricsAggregator.test.ts
@@ -111,6 +111,86 @@ describe('metricsAggregator', () => {
       expect(userSummary.days_active).toBe(2);
     });
 
+    it('should select the top user client by interaction count', () => {
+      const ideTotal = (ide: string, interactions: number) => ({
+        ide,
+        user_initiated_interaction_count: interactions,
+        code_generation_activity_count: 0,
+        code_acceptance_activity_count: 0,
+        loc_added_sum: 0,
+        loc_deleted_sum: 0,
+        loc_suggested_to_add_sum: 0,
+        loc_suggested_to_delete_sum: 0,
+      });
+      const day1 = createBasicMetric({
+        user_id: 123,
+        day: '2024-01-15',
+        totals_by_ide: [ideTotal('vscode', 3), ideTotal('intellij', 8)],
+      });
+      const day2 = createBasicMetric({
+        user_id: 123,
+        day: '2024-01-16',
+        totals_by_ide: [ideTotal('vscode', 7), ideTotal('intellij', 1)],
+      });
+      const inactiveClientDay = createBasicMetric({
+        user_id: 456,
+        day: '2024-01-15',
+        totals_by_ide: [ideTotal('vscode', 0)],
+      });
+
+      const { aggregated } = aggregateMetrics([day1, day2, inactiveClientDay]);
+
+      expect(aggregated.userSummaries.find(user => user.user_id === 123)?.top_client).toBe('vscode');
+      expect(aggregated.userSummaries.find(user => user.user_id === 456)?.top_client).toBeNull();
+    });
+
+    it('should include CLI activity when selecting the top user client', () => {
+      const ideTotal = (ide: string, interactions: number) => ({
+        ide,
+        user_initiated_interaction_count: interactions,
+        code_generation_activity_count: 0,
+        code_acceptance_activity_count: 0,
+        loc_added_sum: 0,
+        loc_deleted_sum: 0,
+        loc_suggested_to_add_sum: 0,
+        loc_suggested_to_delete_sum: 0,
+      });
+      const cliOnly = createBasicMetric({
+        user_id: 123,
+        used_cli: true,
+        totals_by_cli: {
+          session_count: 3,
+          request_count: 12,
+          prompt_count: 9,
+          token_usage: {
+            output_tokens_sum: 0,
+            prompt_tokens_sum: 0,
+            avg_tokens_per_request: 0,
+          },
+        },
+      });
+      const cliTop = createBasicMetric({
+        user_id: 456,
+        used_cli: true,
+        totals_by_ide: [ideTotal('vscode', 4)],
+        totals_by_cli: {
+          session_count: 3,
+          request_count: 12,
+          prompt_count: 9,
+          token_usage: {
+            output_tokens_sum: 0,
+            prompt_tokens_sum: 0,
+            avg_tokens_per_request: 0,
+          },
+        },
+      });
+
+      const { aggregated } = aggregateMetrics([cliOnly, cliTop]);
+
+      expect(aggregated.userSummaries.find(user => user.user_id === 123)?.top_client).toBe('copilot_cli');
+      expect(aggregated.userSummaries.find(user => user.user_id === 456)?.top_client).toBe('copilot_cli');
+    });
+
     it('should aggregate AI credits per user across days', () => {
       const day1 = createBasicMetric({
         user_id: 123,

--- a/src/domain/metricsAggregator.ts
+++ b/src/domain/metricsAggregator.ts
@@ -163,6 +163,7 @@ interface UserSummaryAccumulator {
   userActiveDays: Map<number, Set<string>>;
   userCloudAgentDays: Map<number, Set<string>>;
   userCodeReviewDays: Map<number, Set<string>>;
+  userClientInteractions: Map<number, Map<string, number>>;
   userAiAdoptionPhaseDays: Map<number, string>;
 }
 
@@ -172,12 +173,26 @@ function createUserSummaryAccumulator(): UserSummaryAccumulator {
     userActiveDays: new Map(),
     userCloudAgentDays: new Map(),
     userCodeReviewDays: new Map(),
+    userClientInteractions: new Map(),
     userAiAdoptionPhaseDays: new Map(),
   };
 }
 
 function hasAutoModeActivity(metric: CopilotMetrics): boolean {
   return metric.totals_by_model_feature.some(isActiveAutoModeFeature);
+}
+
+function addClientInteractions(
+  clientInteractions: Map<string, number>,
+  client: string | undefined,
+  interactions: number
+): void {
+  const normalizedClient = client?.trim();
+  if (!normalizedClient || interactions <= 0) return;
+  clientInteractions.set(
+    normalizedClient,
+    (clientInteractions.get(normalizedClient) ?? 0) + interactions
+  );
 }
 
 function accumulateUserSummary(
@@ -204,6 +219,7 @@ function accumulateUserSummary(
       days_active: 0,
       cloud_agent_days: 0,
       code_review_days: 0,
+      top_client: null,
       used_agent: false,
       used_chat: false,
       used_cli: false,
@@ -215,6 +231,7 @@ function accumulateUserSummary(
     accumulator.userActiveDays.set(userId, new Set());
     accumulator.userCloudAgentDays.set(userId, new Set());
     accumulator.userCodeReviewDays.set(userId, new Set());
+    accumulator.userClientInteractions.set(userId, new Map());
   }
 
   const userSummary = accumulator.userMap.get(userId)!;
@@ -239,6 +256,21 @@ function accumulateUserSummary(
   if ((metric.used_copilot_code_review_active ?? false) || (metric.used_copilot_code_review_passive ?? false)) {
     accumulator.userCodeReviewDays.get(userId)!.add(date);
   }
+  const userClientInteractions = accumulator.userClientInteractions.get(userId)!;
+  for (const ideTotal of metric.totals_by_ide) {
+    addClientInteractions(
+      userClientInteractions,
+      ideTotal.ide,
+      ideTotal.user_initiated_interaction_count || 0
+    );
+  }
+  if (metric.totals_by_cli || metric.used_cli) {
+    addClientInteractions(
+      userClientInteractions,
+      'copilot_cli',
+      metric.totals_by_cli?.prompt_count ?? (metric.used_cli ? 1 : 0)
+    );
+  }
   if (metric.ai_adoption_phase) {
     const latestPhaseDay = accumulator.userAiAdoptionPhaseDays.get(userId);
     if (!latestPhaseDay || metric.day >= latestPhaseDay) {
@@ -249,6 +281,23 @@ function accumulateUserSummary(
   accumulator.userActiveDays.get(userId)!.add(date);
 }
 
+function getTopClient(clientInteractions: Map<string, number> | undefined): string | null {
+  let topClient: string | null = null;
+  let topInteractions = 0;
+
+  for (const [client, interactions] of clientInteractions ?? []) {
+    if (
+      interactions > topInteractions ||
+      (interactions === topInteractions && topClient !== null && client.localeCompare(topClient) < 0)
+    ) {
+      topClient = client;
+      topInteractions = interactions;
+    }
+  }
+
+  return topClient;
+}
+
 function computeUserSummaries(accumulator: UserSummaryAccumulator): UserSummary[] {
   return Array.from(accumulator.userMap.values())
     .map(user => ({
@@ -256,6 +305,7 @@ function computeUserSummaries(accumulator: UserSummaryAccumulator): UserSummary[
       days_active: accumulator.userActiveDays.get(user.user_id)?.size || 0,
       cloud_agent_days: accumulator.userCloudAgentDays.get(user.user_id)?.size || 0,
       code_review_days: accumulator.userCodeReviewDays.get(user.user_id)?.size || 0,
+      top_client: getTopClient(accumulator.userClientInteractions.get(user.user_id)),
       net_loc_contribution: user.total_loc_added - user.total_loc_deleted,
     }))
     .sort((a, b) => b.total_user_initiated_interactions - a.total_user_initiated_interactions);

--- a/src/types/metrics.ts
+++ b/src/types/metrics.ts
@@ -132,6 +132,7 @@ export interface UserSummary {
   days_active: number;
   cloud_agent_days: number;
   code_review_days: number;
+  top_client: string | null;
   used_agent: boolean;
   used_chat: boolean;
   used_cli: boolean;

--- a/src/utils/__tests__/sorting.test.ts
+++ b/src/utils/__tests__/sorting.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { sortBySelector, takeTopBySelector, rankBySelector } from '../sorting';
+import { sortByField, sortBySelector, takeTopBySelector, rankBySelector } from '../sorting';
 
 interface Item {
   name: string;
@@ -50,6 +50,27 @@ describe('sortBySelector', () => {
     const cIndex = result.findIndex(i => i.name === 'c');
     const dIndex = result.findIndex(i => i.name === 'd');
     expect(cIndex).toBeLessThan(dIndex);
+  });
+});
+
+describe('sortByField', () => {
+  it('sorts nullable strings with null values last', () => {
+    const users: Array<{ login: string; top_client: string | null }> = [
+      { login: 'first', top_client: 'vscode' },
+      { login: 'missing', top_client: null },
+      { login: 'second', top_client: 'intellij' },
+    ];
+
+    expect(sortByField(users, 'top_client', 'asc').map(user => user.login)).toEqual([
+      'second',
+      'first',
+      'missing',
+    ]);
+    expect(sortByField(users, 'top_client', 'desc').map(user => user.login)).toEqual([
+      'first',
+      'second',
+      'missing',
+    ]);
   });
 });
 

--- a/src/utils/ideNames.ts
+++ b/src/utils/ideNames.ts
@@ -11,6 +11,7 @@ const FORMAT_MAP: Record<string, string> = {
   android_studio: 'Android Studio',
   goland: 'GoLand',
   phpstorm: 'PhpStorm',
+  rubymine: 'RubyMine',
   clion: 'CLion',
   rustrover: 'RustRover',
   rstudio: 'RStudio',

--- a/src/utils/sorting.ts
+++ b/src/utils/sorting.ts
@@ -1,5 +1,25 @@
 import type { SortDirection } from '../types/sort';
 
+function compareValues(
+  aVal: string | number | boolean | null | undefined,
+  bVal: string | number | boolean | null | undefined,
+  sortDirection: SortDirection,
+): number {
+  const aMissing = aVal == null;
+  const bMissing = bVal == null;
+
+  if (aMissing || bMissing) {
+    if (aMissing && bMissing) return 0;
+    return aMissing ? 1 : -1;
+  }
+
+  const normalizedA = typeof aVal === 'string' ? aVal.toLowerCase() : aVal;
+  const normalizedB = typeof bVal === 'string' ? bVal.toLowerCase() : bVal;
+  const comparison = normalizedA < normalizedB ? -1 : normalizedA > normalizedB ? 1 : 0;
+
+  return sortDirection === 'asc' ? comparison : -comparison;
+}
+
 /**
  * Generic comparator for sorting arrays of objects by a field.
  * Handles string (case-insensitive) and numeric comparisons.
@@ -12,19 +32,9 @@ export function sortByField<T, K extends keyof T>(
   if (sortField == null) return [...items];
 
   return [...items].sort((a, b) => {
-    let aVal = a[sortField];
-    let bVal = b[sortField];
-
-    if (typeof aVal === 'string' && typeof bVal === 'string') {
-      aVal = aVal.toLowerCase() as T[K];
-      bVal = bVal.toLowerCase() as T[K];
-    }
-
-    if (sortDirection === 'asc') {
-      return aVal < bVal ? -1 : aVal > bVal ? 1 : 0;
-    } else {
-      return aVal > bVal ? -1 : aVal < bVal ? 1 : 0;
-    }
+    const aVal = a[sortField] as string | number | boolean | null | undefined;
+    const bVal = b[sortField] as string | number | boolean | null | undefined;
+    return compareValues(aVal, bVal, sortDirection);
   });
 }
 


### PR DESCRIPTION
## Why

Users need to see which client each person uses most in the Unique Users table, including CLI-heavy users that previously appeared without a client. This makes the table better reflect actual user activity across IDE and CLI surfaces.

| Commit | Change |
|--------|--------|
| `feat: add user top client column` | Adds a sortable Client column after Code Review, computes each user's top client from IDE and CLI interaction counts, renders existing IDE icons, adds RubyMine display/icon support, and keeps null clients sorted consistently. |