### PR TITLE
Remove obsolete premium references

### DIFF
--- a/src/components/charts/utils/tooltipFooters.test.ts
+++ b/src/components/charts/utils/tooltipFooters.test.ts
@@ -33,22 +33,22 @@ describe('tooltip footer helpers', () => {
 
   it('formats stacked total with share and zero-total fallback', () => {
     const footer = createStackedTotalWithShareFooter({
-      shareDatasetLabel: 'Premium',
-      shareLabel: 'Premium share',
+      shareDatasetLabel: 'Selected',
+      shareLabel: 'Selected share',
       shareSeparator: ' · ',
     });
 
-    expect(footer([tooltipItem('Premium', 0), tooltipItem('Base', 0)])).toBe('Total: 0 · Premium share: 0.0%');
-    expect(footer([tooltipItem('Base', 10)])).toBe('Total: 10 · Premium share: 0.0%');
+    expect(footer([tooltipItem('Selected', 0), tooltipItem('Other', 0)])).toBe('Total: 0 · Selected share: 0.0%');
+    expect(footer([tooltipItem('Other', 10)])).toBe('Total: 10 · Selected share: 0.0%');
   });
 
   it('computes non-zero share from the named dataset', () => {
     const footer = createStackedTotalWithShareFooter({
-      shareDatasetLabel: 'Premium',
-      shareLabel: 'Premium share',
+      shareDatasetLabel: 'Selected',
+      shareLabel: 'Selected share',
       shareSeparator: ' · ',
     });
 
-    expect(footer([tooltipItem('Premium', 25), tooltipItem('Base', 75)])).toBe('Total: 100 · Premium share: 25.0%');
+    expect(footer([tooltipItem('Selected', 25), tooltipItem('Other', 75)])).toBe('Total: 100 · Selected share: 25.0%');
   });
 });

--- a/src/components/ui/icons/MetricTileIcon.tsx
+++ b/src/components/ui/icons/MetricTileIcon.tsx
@@ -8,7 +8,6 @@ export type MetricTileIconName =
   | "top-language"
   | "top-ide"
   | "impact"
-  | "pru-usage"
   | "copilot-adoption"
   | "top-model"
   | "chat-users"
@@ -80,14 +79,6 @@ const ICON_PATHS: Record<MetricTileIconName, React.ReactElement> = {
         d="M20.488 9H15V3.512A9.025 9.025 0 0120.488 9z"
       />
     </>
-  ),
-  "pru-usage": (
-    <path
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      strokeWidth={2}
-      d="M3 3h18M9 7h12M9 11h12M9 15h12M3 7h.01M3 11h.01M3 15h.01M9 19h12M3 19h.01"
-    />
   ),
   "copilot-adoption": (
     <path


### PR DESCRIPTION
## Why

The Premium/Base request concepts are obsolete, so the remaining references should not imply they are still part of the product model. This keeps shared UI/test helpers neutral and avoids carrying an unused PRU icon name forward.

| Commit | Change |
|--------|--------|
| `chore: remove obsolete premium references` | Removes the unused `pru-usage` metric icon entry and replaces Premium/Base tooltip test fixture labels with neutral Selected/Other labels. |