### PR TITLE
Fix plugin updater imports for Node

### DIFF
--- a/data-utils/anonymize-report.ts
+++ b/data-utils/anonymize-report.ts
@@ -5,7 +5,7 @@ import { readFile, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { randomInt } from 'node:crypto';
 import { pathToFileURL } from 'node:url';
-import { splitNdjsonLines } from '../src/utils/ndjsonParser';
+import { splitNdjsonLines } from '#utils/ndjsonParser';
 
 type JsonRecord = Record<string, unknown>;
 interface ParsedRecord {

--- a/data-utils/models-list.ts
+++ b/data-utils/models-list.ts
@@ -4,7 +4,7 @@
 import { mkdir, readdir, readFile, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
-import { splitNdjsonLines } from '../src/utils/ndjsonParser';
+import { splitNdjsonLines } from '#utils/ndjsonParser';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);

--- a/data-utils/update-plugin-versions.ts
+++ b/data-utils/update-plugin-versions.ts
@@ -5,7 +5,7 @@ import {
   derivePreviewMinor,
   isStableVsCodeVersion,
   parseTagMinor,
-} from '../src/domain/vscodeVersionRules';
+} from '#domain/vscodeVersionRules';
 
 export const STABLE_RELEASES_WINDOW = 20;
 

--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "user-level-metrics-viewer",
   "version": "0.1.0",
   "private": true,
+  "imports": {
+    "#domain/*": "./src/domain/*.ts",
+    "#utils/*": "./src/utils/*.ts"
+  },
   "scripts": {
     "dev": "npm run build:worker && next dev --turbopack",
     "build": "npm run build:worker -- --production && next build",


### PR DESCRIPTION
## Why

This change fixes the GitHub Pages build failure in `npm run update:plugins` after shared VS Code version parsing moved into `src/domain`. It keeps the project’s extensionless import style while giving Node’s native TypeScript type stripping an explicit package-import mapping it can resolve.

| Commit | Change |
|--------|--------|
| `fix: resolve plugin updater imports for Node` | Adds package import aliases for shared domain and utility modules, then updates Node-executed data utilities to use those aliases instead of relative `src` imports. |