### PR TITLE
Run deploy checks in parallel

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,11 +27,12 @@ jobs:
       - name: Install dependencies
         run: npm ci
         
-      - name: Lint code
-        run: npm run lint
+      - parallel:
+          - name: Lint code
+            run: npm run lint
 
-      - name: Run tests
-        run: npm run test:run
+          - name: Run tests
+            run: npm run test:run
 
       - name: Setup Pages
         uses: actions/configure-pages@v6


### PR DESCRIPTION
## Why

This change adopts GitHub Actions' new parallel step groups where the deploy pipeline already has independent checks. It shortens the build job's critical path without changing the deployment sequence.

| Commit | Change |
|--------|--------|
| `ci: run checks in parallel` | Runs lint and test checks concurrently after dependency installation in the deploy workflow. |