### PR TITLE
fix: remove usage-based billing deprecation banner

### DIFF
--- a/src/components/ModelDetailsView.tsx
+++ b/src/components/ModelDetailsView.tsx
@@ -32,17 +32,6 @@ export default function ModelDetailsView({ modelBreakdownData }: ModelDetailsVie
       contentClassName="space-y-6"
     >
       <div className="space-y-6">
-        <div className="rounded-md border border-blue-200 bg-blue-50 px-4 py-3 text-sm text-blue-900">
-          GitHub Copilot has moved to usage-based billing.{' '}
-          <a
-            href="https://github.blog/news-insights/company-news/github-copilot-is-moving-to-usage-based-billing/"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="font-medium underline decoration-blue-400 underline-offset-2 hover:text-blue-700"
-          >
-            Read the announcement.
-          </a>
-        </div>
         <div id={allModelsSection.id} className="scroll-mt-28">
           <ModelsUsageChart modelEntries={modelEntries} dates={modelBreakdownData.dates} totalInteractions={modelTotal} variant="all" />
         </div>


### PR DESCRIPTION
## Why

The Model Usage view displayed a "GitHub Copilot has moved to usage-based billing. Read the announcement." notice with a link to the GitHub blog post. This announcement is no longer relevant to surface to users, so it's being removed.

## What changed

- Removed the blue notice banner (including its link to the blog announcement) from `ModelDetailsView`.
- No other code referenced this banner text or link, so no further cleanup was needed.

## Verification

- `npm run build`, `npm run lint`, and `npm run test:run` all pass.
- Ran a code-review pass on the diff; no issues found (clean JSX removal, no orphaned imports/variables, no other references to the banner elsewhere in the codebase).