### PR TITLE
Add daily model type distribution

### DIFF
--- a/src/components/ModelDetailsView.tsx
+++ b/src/components/ModelDetailsView.tsx
@@ -2,6 +2,7 @@
 
 import React, { useMemo } from 'react';
 import ModelsUsageChart from './charts/ModelsUsageChart';
+import ModelCategoryDistributionChart from './charts/ModelCategoryDistributionChart';
 import AutoModeAdoptionTrendChart from './charts/AutoModeAdoptionTrendChart';
 import type { ModelBreakdownData } from '../types/metrics';
 import { ViewPanel } from './ui';
@@ -21,7 +22,7 @@ export default function ModelDetailsView({ modelBreakdownData }: ModelDetailsVie
     () => autoModels.reduce((sum, entry) => sum + entry.total, 0),
     [autoModels]
   );
-  const [allModelsSection, autoModelsSection, autoAdoptionSection] = MODEL_DETAILS_SECTIONS;
+  const [allModelsSection, modelTypesSection, autoModelsSection, autoAdoptionSection] = MODEL_DETAILS_SECTIONS;
 
   return (
     <ViewPanel
@@ -34,6 +35,13 @@ export default function ModelDetailsView({ modelBreakdownData }: ModelDetailsVie
       <div className="space-y-6">
         <div id={allModelsSection.id} className="scroll-mt-28">
           <ModelsUsageChart modelEntries={modelEntries} dates={modelBreakdownData.dates} totalInteractions={modelTotal} variant="all" />
+        </div>
+        <div id={modelTypesSection.id} className="scroll-mt-28">
+          <ModelCategoryDistributionChart
+            entries={modelBreakdownData.modelCategories}
+            dates={modelBreakdownData.dates}
+            totalInteractions={modelTotal}
+          />
         </div>
         <div id={autoModelsSection.id} className="scroll-mt-28">
           <ModelsUsageChart modelEntries={autoModels} dates={modelBreakdownData.dates} totalInteractions={autoTotal} variant="auto" />

--- a/src/components/charts/ModelCategoryDistributionChart.tsx
+++ b/src/components/charts/ModelCategoryDistributionChart.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+import { useMemo } from 'react';
+import type { TooltipItem } from 'chart.js';
+import { Bar } from 'react-chartjs-2';
+import type { ModelCategoryUsageEntry } from '../../types/metrics';
+import { formatShortDate } from '../../utils/formatters';
+import ChartContainer from '../ui/ChartContainer';
+import { createStackedBarChartOptions } from './utils/chartOptions';
+import { modelCategoryColors } from './utils/chartColors';
+import { registerChartJS } from './utils/chartSetup';
+import { createBarDataset } from './utils/chartStyles';
+import { createStackedTotalFooter } from './utils/tooltipFooters';
+
+registerChartJS();
+
+interface ModelCategoryDistributionChartProps {
+  entries: ModelCategoryUsageEntry[];
+  dates: string[];
+  totalInteractions: number;
+}
+
+export default function ModelCategoryDistributionChart({
+  entries,
+  dates,
+  totalInteractions,
+}: ModelCategoryDistributionChartProps) {
+  const { labels, datasets } = useMemo(() => ({
+    labels: dates.map(formatShortDate),
+    datasets: entries.map(entry => createBarDataset(
+      modelCategoryColors[entry.category].solid,
+      entry.category,
+      dates.map(date => entry.dailyData[date] ?? 0),
+      { stack: 'model-categories' }
+    )),
+  }), [dates, entries]);
+
+  const categorizedInteractions = entries
+    .filter(entry => entry.category !== 'Uncategorized')
+    .reduce((sum, entry) => sum + entry.total, 0);
+  const categorizedPercentage = totalInteractions > 0
+    ? Math.round((categorizedInteractions / totalInteractions) * 100)
+    : 0;
+
+  const options = createStackedBarChartOptions({
+    xAxisLabel: 'Date',
+    yAxisLabel: 'Interactions',
+    tooltipLabelCallback: (context: TooltipItem<'line' | 'bar'>) =>
+      `${context.dataset.label}: ${(context.parsed.y ?? 0).toLocaleString()} interactions`,
+    tooltipFooterCallback: createStackedTotalFooter(),
+  });
+
+  return (
+    <ChartContainer
+      title="Model Type Distribution"
+      description="Daily user-initiated interactions grouped by GitHub Copilot model category."
+      isEmpty={dates.length === 0 || datasets.length === 0}
+      emptyState="No categorized model usage data available"
+      summaryStats={[
+        {
+          value: entries.filter(entry => entry.category !== 'Uncategorized').length,
+          label: 'Categories Used',
+          colorClass: 'text-indigo-600',
+        },
+        {
+          value: `${categorizedPercentage}%`,
+          label: 'Usage Categorized',
+          colorClass: 'text-purple-600',
+        },
+      ]}
+      chartHeight="h-96"
+      footer={
+        <p className="text-xs text-gray-600 mb-4">
+          Categories follow GitHub&apos;s published Copilot model pricing catalog. Legacy and
+          unmapped models appear as Uncategorized.
+        </p>
+      }
+    >
+      <Bar data={{ labels, datasets }} options={options} />
+    </ChartContainer>
+  );
+}

--- a/src/components/charts/index.ts
+++ b/src/components/charts/index.ts
@@ -16,6 +16,7 @@ export { default as FeatureAdoptionChart } from './FeatureAdoptionChart';
 export { default as CLIOverlapChart } from './CLIOverlapChart';
 export { default as ClientActivityChart } from './ClientActivityChart';
 export { default as ModeImpactChart } from './ModeImpactChart';
+export { default as ModelCategoryDistributionChart } from './ModelCategoryDistributionChart';
 export { default as ModelsUsageChart } from './ModelsUsageChart';
 export { default as UserActivityByLanguageAndFeatureChart } from './UserActivityByLanguageAndFeatureChart';
 export { default as UserActivityByModelAndFeatureChart } from './UserActivityByModelAndFeatureChart';

--- a/src/components/charts/utils/chartColors.ts
+++ b/src/components/charts/utils/chartColors.ts
@@ -105,6 +105,13 @@ export const chatModeColors = {
   cli: chartColors.rose,
 } as const;
 
+export const modelCategoryColors = {
+  Lightweight: chartColors.green,
+  Versatile: chartColors.blue,
+  Powerful: chartColors.purple,
+  Uncategorized: chartColors.gray,
+} as const;
+
 /**
  * IDE/client brand colors for consistent representation across distribution and activity charts.
  * Keys are lowercase identifiers matching the values returned by the API (e.g. 'vscode', 'jetbrains').

--- a/src/components/layout/contextSections.ts
+++ b/src/components/layout/contextSections.ts
@@ -69,6 +69,7 @@ export const USER_DETAILS_SECTIONS: ContextSection[] = [
 
 export const MODEL_DETAILS_SECTIONS: ContextSection[] = [
   { id: 'model-usage-all', label: 'All Models' },
+  { id: 'model-type-distribution', label: 'Model Types' },
   { id: 'model-usage-auto', label: 'Auto Models' },
   { id: 'model-auto-adoption', label: 'Auto Adoption' },
 ];

--- a/src/domain/__tests__/modelConfig.test.ts
+++ b/src/domain/__tests__/modelConfig.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   classifyModelRequest,
+  getModelCategory,
   isActiveAutoModeFeature,
   isKnownModelName,
   isUnknownModelName,
@@ -22,10 +23,16 @@ describe('modelConfig', () => {
   });
 
   describe('known model catalog', () => {
-    it('should keep model entries name-only', () => {
-      const model = KNOWN_MODELS.find(entry => entry.name === 'gpt-5');
+    it('should attach published categories to current models', () => {
+      const model = KNOWN_MODELS.find(entry => entry.name === 'gpt-5.6-sol');
 
-      expect(model).toEqual({ name: 'gpt-5' });
+      expect(model).toEqual({ name: 'gpt-5.6-sol', category: 'Powerful' });
+      expect(getModelCategory('GPT-5.6 Luna')).toBe('Lightweight');
+      expect(getModelCategory('Claude Sonnet 5')).toBe('Versatile');
+      expect(getModelCategory('Claude 4.6 Sonnet')).toBe('Versatile');
+      expect(getModelCategory('Claude 4.5 Haiku')).toBe('Versatile');
+      expect(getModelCategory('Gemini 3.0 Flash')).toBe('Lightweight');
+      expect(getModelCategory('legacy-model')).toBeUndefined();
     });
 
     it('should include the unknown sentinel', () => {

--- a/src/domain/calculators/__tests__/modelBreakdownCalculator.test.ts
+++ b/src/domain/calculators/__tests__/modelBreakdownCalculator.test.ts
@@ -20,6 +20,7 @@ describe('modelBreakdownCalculator', () => {
       expect(acc.cliTotal).toBe(0);
       expect(acc.unknownTotal).toBe(0);
       expect(acc.modelTotal).toBe(0);
+      expect(acc.modelCategories.size).toBe(0);
       expect(acc.allModels.size).toBe(0);
     });
   });
@@ -169,6 +170,22 @@ describe('modelBreakdownCalculator', () => {
         { model: 'gpt-4o', total: 20, dailyData: { '2024-01-15': 20 } },
         { model: 'gpt-5', total: 10, dailyData: { '2024-01-15': 10 } },
         { model: 'unknown', total: 5, dailyData: { '2024-01-15': 5 } },
+      ]);
+      expect(data.modelCategories).toEqual([
+        { category: 'Uncategorized', total: 35, dailyData: { '2024-01-15': 35 } },
+      ]);
+    });
+
+    it('should aggregate daily interactions by published model category', () => {
+      const acc = createModelBreakdownAccumulator();
+      accumulateModelBreakdown(acc, '2024-01-15', 1, makeModelFeature('gpt-5-mini', 'chat_panel', 8));
+      accumulateModelBreakdown(acc, '2024-01-15', 2, makeModelFeature('claude-sonnet-4.6', 'chat_panel', 12));
+      accumulateModelBreakdown(acc, '2024-01-16', 1, makeModelFeature('claude-opus-4.8', 'chat_panel', 5));
+
+      expect(computeModelBreakdownData(acc).modelCategories).toEqual([
+        { category: 'Lightweight', total: 8, dailyData: { '2024-01-15': 8 } },
+        { category: 'Versatile', total: 12, dailyData: { '2024-01-15': 12 } },
+        { category: 'Powerful', total: 5, dailyData: { '2024-01-16': 5 } },
       ]);
     });
   });

--- a/src/domain/calculators/modelBreakdownCalculator.ts
+++ b/src/domain/calculators/modelBreakdownCalculator.ts
@@ -1,7 +1,13 @@
-import type { AutoModeAdoptionTrendEntry, ModelBreakdownData, ModelDailyUsageEntry } from '../../types/metrics';
+import type {
+  AutoModeAdoptionTrendEntry,
+  ModelBreakdownData,
+  ModelCategoryUsageEntry,
+  ModelDailyUsageEntry,
+  ModelUsageCategory,
+} from '../../types/metrics';
 import { isCliFeature } from '../featureCategories';
 import { isActiveAutoModeFeature } from '../autoMode';
-import { classifyModelRequest } from '../modelConfig';
+import { classifyModelRequest, getModelCategory } from '../modelConfig';
 import { compareDatesAsc } from './statsCalculators';
 import { computeAdoptionTrendFromUserSets } from './adoptionTrendHelpers';
 
@@ -12,6 +18,7 @@ interface ModelAccEntry {
 
 export interface ModelBreakdownAccumulator {
   allModels: Map<string, ModelAccEntry>;
+  modelCategories: Map<ModelUsageCategory, ModelAccEntry>;
   autoModels: Map<string, ModelAccEntry>;
   cliModels: Map<string, ModelAccEntry>;
   autoModeUsersByDate: Map<string, Set<number>>;
@@ -24,6 +31,7 @@ export interface ModelBreakdownAccumulator {
 export function createModelBreakdownAccumulator(): ModelBreakdownAccumulator {
   return {
     allModels: new Map(),
+    modelCategories: new Map(),
     autoModels: new Map(),
     cliModels: new Map(),
     autoModeUsersByDate: new Map(),
@@ -89,6 +97,12 @@ export function accumulateModelBreakdown(
   accumulator.allDates.add(date);
   accumulator.modelTotal += interactionCount;
   accumulateModelEntry(accumulator.allModels, normalizedModel || 'unknown', date, interactionCount);
+  accumulateModelEntry(
+    accumulator.modelCategories,
+    getModelCategory(normalizedModel) ?? 'Uncategorized',
+    date,
+    interactionCount
+  );
 
   if (isUnknown) {
     accumulator.unknownTotal += interactionCount;
@@ -113,6 +127,28 @@ function buildModelEntries(
     .sort((a, b) => b.total - a.total);
 }
 
+function buildModelCategoryEntries(
+  categoriesMap: Map<ModelUsageCategory, ModelAccEntry>
+): ModelCategoryUsageEntry[] {
+  const categoryOrder: ModelUsageCategory[] = [
+    'Lightweight',
+    'Versatile',
+    'Powerful',
+    'Uncategorized',
+  ];
+
+  return categoryOrder.flatMap(category => {
+    const entry = categoriesMap.get(category);
+    if (!entry) return [];
+
+    return [{
+      category,
+      total: entry.total,
+      dailyData: Object.fromEntries(entry.dailyData),
+    }];
+  });
+}
+
 function computeAutoModeAdoptionTrend(
   dates: string[],
   usersByDate: Map<string, Set<number>>
@@ -133,6 +169,7 @@ export function computeModelBreakdownData(
 
   return {
     allModels: buildModelEntries(accumulator.allModels),
+    modelCategories: buildModelCategoryEntries(accumulator.modelCategories),
     autoModels: buildModelEntries(accumulator.autoModels),
     cliModels: buildModelEntries(accumulator.cliModels),
     autoModeAdoptionTrend: computeAutoModeAdoptionTrend(dates, accumulator.autoModeUsersByDate),

--- a/src/domain/modelConfig.ts
+++ b/src/domain/modelConfig.ts
@@ -5,8 +5,13 @@ import { normalizeModelName } from './autoMode';
 
 export { isActiveAutoModeFeature, normalizeModelName } from './autoMode';
 
+export type ModelCategory = 'Lightweight' | 'Powerful' | 'Versatile';
+
 export class Model {
-  constructor(public readonly name: string) {}
+  constructor(
+    public readonly name: string,
+    public readonly category?: ModelCategory
+  ) {}
 }
 
 /**
@@ -20,23 +25,26 @@ export const KNOWN_MODELS: Model[] = [
   new Model('gpt-4o'),
   new Model('gpt-4o-mini'),
   new Model('gpt-4o-latest'),
-  new Model('gpt-5-mini'),
+  new Model('gpt-5-mini', 'Lightweight'),
   new Model('grok-code-fast'),
-  new Model('raptor-mini'),
+  new Model('raptor-mini', 'Versatile'),
   new Model('gpt-5'),
   new Model('gpt-5.0'),
   new Model('gpt-5.1'),
   new Model('gpt-5.2'),
-  new Model('gpt-5.4'),
-  new Model('gpt-5.5'),
-  new Model('gpt-5.3-codex'),
+  new Model('gpt-5.4', 'Versatile'),
+  new Model('gpt-5.5', 'Powerful'),
+  new Model('gpt-5.3-codex', 'Powerful'),
   new Model('gpt-5-codex'),
   new Model('gpt-5.2-codex'),
   new Model('gpt-5.1-codex'),
   new Model('gpt-5.1-codex-max'),
   new Model('gpt-5.1-codex-mini'),
-  new Model('gpt-5.4-mini'),
-  new Model('gpt-5.4-nano'),
+  new Model('gpt-5.4-mini', 'Lightweight'),
+  new Model('gpt-5.4-nano', 'Lightweight'),
+  new Model('gpt-5.6-luna', 'Lightweight'),
+  new Model('gpt-5.6-sol', 'Powerful'),
+  new Model('gpt-5.6-terra', 'Versatile'),
   new Model('grok-code-fast-1'),
   new Model('o3'),
   new Model('o3-mini'),
@@ -44,29 +52,35 @@ export const KNOWN_MODELS: Model[] = [
   new Model('claude-3.5-sonnet'),
   new Model('claude-3.7-sonnet'),
   new Model('claude-3.7-sonnet-thought'),
-  new Model('claude-4.0-sonnet'),
-  new Model('claude-4.5-sonnet'),
-  new Model('claude-4.6-sonnet'),
+  new Model('claude-4.0-sonnet', 'Versatile'),
+  new Model('claude-4.5-sonnet', 'Versatile'),
+  new Model('claude-4.6-sonnet', 'Versatile'),
   new Model('claude-opus-4'),
   new Model('claude-opus-4.1'),
-  new Model('claude-opus-4.5'),
-  new Model('claude-opus-4.6'),
-  new Model('claude-opus-4.7'),
-  new Model('claude-opus-4.8'),
+  new Model('claude-opus-4.5', 'Powerful'),
+  new Model('claude-opus-4.6', 'Powerful'),
+  new Model('claude-opus-4.7', 'Powerful'),
+  new Model('claude-opus-4.8', 'Powerful'),
+  new Model('claude-opus-4.8-fast-mode', 'Powerful'),
+  new Model('claude-opus-4.8-fast-mode-preview', 'Powerful'),
+  new Model('claude-fable-5', 'Powerful'),
   new Model('claude-opus-4.6-fast-mode'),
   new Model('claude-opus-4.6-fast-mode-preview'),
-  new Model('claude-4.5-haiku'),
-  new Model('claude-haiku-4.5'),
-  new Model('claude-sonnet-4'),
-  new Model('claude-sonnet-4.5'),
-  new Model('claude-sonnet-4.6'),
+  new Model('claude-4.5-haiku', 'Versatile'),
+  new Model('claude-haiku-4.5', 'Versatile'),
+  new Model('claude-sonnet-4', 'Versatile'),
+  new Model('claude-sonnet-4.5', 'Versatile'),
+  new Model('claude-sonnet-4.6', 'Versatile'),
+  new Model('claude-sonnet-5', 'Versatile'),
   new Model('gemini-2.0-flash'),
-  new Model('gemini-2.5-pro'),
+  new Model('gemini-2.5-pro', 'Powerful'),
   new Model('gemini-3.0-pro'),
-  new Model('gemini-3.1-pro'),
-  new Model('gemini-3.0-flash'),
-  new Model('gemini-3-flash'),
-  new Model('gemini-3.5-flash'),
+  new Model('gemini-3.1-pro', 'Powerful'),
+  new Model('gemini-3.0-flash', 'Lightweight'),
+  new Model('gemini-3-flash', 'Lightweight'),
+  new Model('gemini-3.5-flash', 'Lightweight'),
+  new Model('mai-code-1-flash', 'Lightweight'),
+  new Model('kimi-k2.7-code', 'Versatile'),
   new Model('auto'),
   new Model('unknown'),
 ];
@@ -75,6 +89,12 @@ const UNKNOWN_MODEL_NAME = 'unknown';
 
 const KNOWN_MODEL_NAMES = new Set(
   KNOWN_MODELS.map(model => normalizeModelName(model.name))
+);
+
+const MODEL_CATEGORIES = new Map(
+  KNOWN_MODELS.flatMap(model => model.category
+    ? [[normalizeModelName(model.name), model.category] as const]
+    : [])
 );
 
 export interface ModelRequestClassification {
@@ -91,6 +111,10 @@ export function isUnknownModelName(modelName: string): boolean {
 export function isKnownModelName(modelName: string): boolean {
   const normalized = normalizeModelName(modelName);
   return normalized !== '' && normalized !== UNKNOWN_MODEL_NAME && KNOWN_MODEL_NAMES.has(normalized);
+}
+
+export function getModelCategory(modelName: string): ModelCategory | undefined {
+  return MODEL_CATEGORIES.get(normalizeModelName(modelName));
 }
 
 export function classifyModelRequest(modelName: string): ModelRequestClassification {

--- a/src/types/metrics.ts
+++ b/src/types/metrics.ts
@@ -197,6 +197,14 @@ export interface ModelDailyUsageEntry {
   dailyData: Record<string, number>;
 }
 
+export type ModelUsageCategory = 'Lightweight' | 'Powerful' | 'Versatile' | 'Uncategorized';
+
+export interface ModelCategoryUsageEntry {
+  category: ModelUsageCategory;
+  total: number;
+  dailyData: Record<string, number>;
+}
+
 export interface AutoModeAdoptionTrendEntry {
   date: string;
   newUsers: number;
@@ -207,6 +215,7 @@ export interface AutoModeAdoptionTrendEntry {
 
 export interface ModelBreakdownData {
   allModels: ModelDailyUsageEntry[];
+  modelCategories: ModelCategoryUsageEntry[];
   autoModels?: ModelDailyUsageEntry[];
   cliModels?: ModelDailyUsageEntry[];
   autoModeAdoptionTrend?: AutoModeAdoptionTrendEntry[];


### PR DESCRIPTION
## Why

Copilot model usage currently shows individual models without the Lightweight, Powerful, and Versatile classifications published in GitHub's pricing catalog. This makes it difficult to understand how daily usage is distributed across model types.

| Commit | Change |
|--------|--------|
| `feat: add model type distribution` | Adds model category metadata and normalized aliases, aggregates daily category usage in the Web Worker, and displays it as a stacked chart on the Model Usage view. Legacy, unknown, and unmapped models remain visible as Uncategorized. |