### PR TITLE
Fix user details routing correctness

### DIFF
--- a/docs/project-overview.md
+++ b/docs/project-overview.md
@@ -41,7 +41,7 @@ Next.js App Router SPA, TypeScript, Tailwind CSS. All rendering is client-side.
 - `MetricsContext` (`src/components/MetricsContext.tsx`) — stores the `AggregatedMetrics` result, loading/error/warning state, and data actions
 - `NavigationContext` (`src/state/NavigationContext.tsx`) — manages current view, selected user/model, and navigation actions
 
-**All view components consume pre-aggregated data.** No component accesses raw `CopilotMetrics[]` directly. The `AggregatedMetrics` type (see `src/types/aggregatedMetrics.ts`) is the sole data contract between the worker and the UI.
+**All view components consume pre-aggregated data.** No component accesses raw `CopilotMetrics[]` directly. The `AggregatedMetrics` type is declared in `src/domain/metricsAggregator.ts` and is the primary data contract between the worker and the UI. The worker also retains a compact user-detail accumulator so it can serve user details on demand without moving raw records onto the main thread.
 
 ### 3.2. Code Organization
 
@@ -50,7 +50,8 @@ Next.js App Router SPA, TypeScript, Tailwind CSS. All rendering is client-side.
 | `src/app/` | Next.js App Router entry points and providers |
 | `src/components/` | View components, charts, layout, UI primitives |
 | `src/components/charts/` | Chart.js visualizations (via react-chartjs-2) |
-| `src/domain/` | Business logic: parser, aggregator, model config |
+| `src/domain/` | Business logic: aggregator, model config, calculators |
+| `src/infra/` | Streaming metrics file parser |
 | `src/domain/calculators/` | Individual metric calculators (stats, engagement, model usage, impact, etc.) |
 | `src/hooks/` | Reusable React hooks (file upload, sorting, search) |
 | `src/workers/` | Web Worker entry point, client API, message types |
@@ -78,9 +79,9 @@ flowchart LR
 ### 4.1. Upload and Parsing
 
 1. `useFileUpload` validates file extension and sends files to the worker via `parseAndAggregateInWorker()`
-2. The worker streams each file using `File.stream()` API, parses lines via `parseMetricsLine`, and applies string interning (`StringPool`) for memory efficiency
+2. The worker streams each file through `src/infra/metricsFileParser.ts` using the `File.stream()` API, parses lines via `parseMetricsLine`, and applies string interning (`StringPool`) for memory efficiency
 3. Records using deprecated LOC fields or missing required fields are skipped
-4. The worker runs `aggregateMetrics()` on the parsed data and returns the `AggregatedMetrics` result, enterprise name, record count, and any per-file parse errors (surfaced as a non-fatal warning in the UI when partial failures occur)
+4. The worker runs `aggregateMetrics()` on the parsed data, retains the compact user-detail accumulator for on-demand requests, and returns the `AggregatedMetrics` result, enterprise name, record count, and any per-file parse errors (surfaced as a non-fatal warning in the UI when partial failures occur). Raw records remain off the main thread.
 
 ### 4.2. Aggregation
 
@@ -111,7 +112,7 @@ flowchart TB
 	end
 
 	subgraph WebWorker[Web Worker]
-		MFP[metricsFileParser.ts]
+		MFP[infra/metricsFileParser.ts]
 		MA[metricsAggregator.ts]
 		CALC[calculators/]
 		MConf[modelConfig.ts]

--- a/src/components/MetricsContext.tsx
+++ b/src/components/MetricsContext.tsx
@@ -112,7 +112,3 @@ export function useMetrics(): MetricsContextValue {
   }
   return ctx;
 }
-
-export function useRawMetrics(): MetricsContextValue {
-  return useMetrics();
-}

--- a/src/components/layout/ViewRouter.tsx
+++ b/src/components/layout/ViewRouter.tsx
@@ -1,13 +1,17 @@
 'use client';
 
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { VIEW_MODES } from '../../types/navigation';
-import type { UserDetailedMetrics } from '../../types/aggregatedMetrics';
 import { useNavigation } from '../../state/NavigationContext';
 import { useMetrics } from '../MetricsContext';
 import { useFileUpload } from '../../hooks/useFileUpload';
 import { useResetAppState } from '../../hooks/useResetAppState';
 import { terminateWorker, computeUserDetailsInWorker } from '../../workers/metricsWorkerClient';
+import {
+  resolveUserDetailsRouteState,
+  type UserDetailsLoadState,
+} from './userDetailsRouteState';
+import { runUserDetailsRequest } from './userDetailsRequest';
 import { FileUploadArea } from '../features/file-upload';
 import { OverviewDashboard } from '../features/overview';
 import UniqueUsersView from '../UniqueUsersView';
@@ -36,32 +40,93 @@ const ViewRouter: React.FC = () => {
   const { handleFileUpload, handleSampleLoad, uploadProgress } = useFileUpload();
   const resetAppState = useResetAppState();
 
-  const [userDetails, setUserDetails] = useState<UserDetailedMetrics | null>(null);
-  const [userDetailsLoading, setUserDetailsLoading] = useState(false);
-  const [loadedUserId, setLoadedUserId] = useState<number | null>(null);
+  const [userDetailsLoadState, setUserDetailsLoadState] = useState<UserDetailsLoadState>({
+    status: 'idle',
+  });
+  const [userDetailsRetryKey, setUserDetailsRetryKey] = useState(0);
+  const userDetailsRequestVersion = useRef(0);
+  const userDetailsRouteState = resolveUserDetailsRouteState({
+    currentView,
+    selectedUser,
+    userSummaries: aggregatedMetrics?.userSummaries ?? null,
+    dataset: aggregatedMetrics,
+    loadState: userDetailsLoadState,
+  });
 
   useEffect(() => {
-    setUserDetails(null);
-    setUserDetailsLoading(false);
-    setLoadedUserId(null);
-  }, [aggregatedMetrics]);
+    userDetailsRequestVersion.current += 1;
+    setUserDetailsLoadState({ status: 'idle' });
+  }, [aggregatedMetrics, selectedUser]);
 
   useEffect(() => {
-    if (currentView === VIEW_MODES.USER_DETAILS && selectedUser && loadedUserId !== selectedUser.id) {
-      setUserDetailsLoading(true);
-      setUserDetails(null);
-      computeUserDetailsInWorker(selectedUser.id)
-        .then(details => {
-          setUserDetails(details);
-          setLoadedUserId(selectedUser.id);
-          setUserDetailsLoading(false);
-        })
-        .catch(() => {
-          setUserDetailsLoading(false);
-          navigateTo(VIEW_MODES.USERS);
-        });
+    if (userDetailsRouteState.status === 'redirect') {
+      navigateTo(VIEW_MODES.USERS);
     }
-  }, [currentView, selectedUser, loadedUserId, navigateTo]);
+  }, [userDetailsRouteState.status, navigateTo]);
+
+  let userDetailsRequestUserId: number | null = null;
+  let userDetailsRequestLogin: string | null = null;
+  if (
+    userDetailsRouteState.status === 'error'
+    || userDetailsRouteState.status === 'ready'
+    || (
+      userDetailsRouteState.status === 'loading'
+      && userDetailsRouteState.userSummary !== null
+    )
+  ) {
+    userDetailsRequestUserId = userDetailsRouteState.selectedUser.id;
+    userDetailsRequestLogin = userDetailsRouteState.selectedUser.login;
+  }
+  const userDetailsRequestDataset = userDetailsRequestUserId === null
+    ? null
+    : aggregatedMetrics;
+
+  useEffect(() => {
+    if (!userDetailsRequestDataset || userDetailsRequestUserId === null) {
+      return;
+    }
+
+    const requestVersion = userDetailsRequestVersion.current + 1;
+    userDetailsRequestVersion.current = requestVersion;
+    setUserDetailsLoadState({
+      status: 'loading',
+      dataset: userDetailsRequestDataset,
+      userId: userDetailsRequestUserId,
+    });
+
+    void runUserDetailsRequest({
+      userId: userDetailsRequestUserId,
+      load: computeUserDetailsInWorker,
+      isCurrent: () => userDetailsRequestVersion.current === requestVersion,
+      onSuccess: (details) => {
+        setUserDetailsLoadState({
+          status: 'ready',
+          dataset: userDetailsRequestDataset,
+          userId: userDetailsRequestUserId,
+          details,
+        });
+      },
+      onError: (message) => {
+        setUserDetailsLoadState({
+          status: 'error',
+          dataset: userDetailsRequestDataset,
+          userId: userDetailsRequestUserId,
+          message,
+        });
+      },
+    });
+
+    return () => {
+      if (userDetailsRequestVersion.current === requestVersion) {
+        userDetailsRequestVersion.current += 1;
+      }
+    };
+  }, [
+    userDetailsRequestDataset,
+    userDetailsRequestLogin,
+    userDetailsRequestUserId,
+    userDetailsRetryKey,
+  ]);
 
   useEffect(() => {
     return () => { terminateWorker(); };
@@ -69,6 +134,10 @@ const ViewRouter: React.FC = () => {
 
   const handleUserClick = (userLogin: string, userId: number) => {
     selectUser({ login: userLogin, id: userId });
+  };
+
+  const retryUserDetails = () => {
+    setUserDetailsRetryKey((retryKey) => retryKey + 1);
   };
 
   if (error && hasData) {
@@ -262,35 +331,61 @@ const ViewRouter: React.FC = () => {
       );
 
     case VIEW_MODES.USER_DETAILS:
-      if (!selectedUser) {
-        navigateTo(VIEW_MODES.USERS);
+      if (
+        userDetailsRouteState.status === 'inactive'
+        || userDetailsRouteState.status === 'redirect'
+      ) {
         return null;
       }
-      {
-        if (userDetailsLoading || !userDetails) {
-          return (
-            <div className="flex items-center justify-center h-64">
-              <div className="text-center">
-                <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-500 mx-auto mb-4"></div>
-                <p className="text-gray-500 dark:text-gray-400">Loading user details...</p>
-              </div>
-            </div>
-          );
-        }
-        const userSummary = userSummaries.find(u => u.user_id === selectedUser.id);
-        if (!userSummary) {
-          navigateTo(VIEW_MODES.USERS);
-          return null;
-        }
+
+      if (userDetailsRouteState.status === 'loading') {
         return (
-          <UserDetailsView
-            userDetails={userDetails}
-            userSummary={userSummary}
-            userLogin={selectedUser.login}
-            userId={selectedUser.id}
-          />
+          <div className="flex items-center justify-center h-64">
+            <div className="text-center">
+              <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-500 mx-auto mb-4"></div>
+              <p className="text-gray-500 dark:text-gray-400">Loading user details...</p>
+            </div>
+          </div>
         );
       }
+
+      if (userDetailsRouteState.status === 'error') {
+        return (
+          <div className="flex items-center justify-center h-64">
+            <div className="text-center max-w-md">
+              <p className="text-red-600 dark:text-red-400 font-medium mb-2">
+                Failed to load user details
+              </p>
+              <p className="text-sm text-gray-500 dark:text-gray-400">
+                {userDetailsRouteState.message}
+              </p>
+              <div className="mt-4 flex items-center justify-center gap-3">
+                <button
+                  onClick={retryUserDetails}
+                  className="px-4 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-md transition-colors"
+                >
+                  Retry
+                </button>
+                <button
+                  onClick={() => navigateTo(VIEW_MODES.USERS)}
+                  className="px-4 py-2 text-sm font-medium text-blue-600 hover:text-blue-800 border border-blue-300 hover:border-blue-400 rounded-md transition-colors"
+                >
+                  Back to Users
+                </button>
+              </div>
+            </div>
+          </div>
+        );
+      }
+
+      return (
+        <UserDetailsView
+          userDetails={userDetailsRouteState.details}
+          userSummary={userDetailsRouteState.userSummary}
+          userLogin={userDetailsRouteState.selectedUser.login}
+          userId={userDetailsRouteState.selectedUser.id}
+        />
+      );
 
     case VIEW_MODES.MODEL_DETAILS:
       return (

--- a/src/components/layout/__tests__/ViewRouter.test.tsx
+++ b/src/components/layout/__tests__/ViewRouter.test.tsx
@@ -1,0 +1,73 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { makeMetric } from '../../../__tests__/factories/metrics';
+import {
+  aggregateMetrics,
+  type AggregatedMetrics,
+} from '../../../domain/metricsAggregator';
+import { VIEW_MODES } from '../../../types/navigation';
+import ViewRouter from '../ViewRouter';
+
+const mocks = vi.hoisted(() => ({
+  navigateTo: vi.fn(),
+  selectedUser: null as { id: number; login: string } | null,
+  aggregatedMetrics: null as AggregatedMetrics | null,
+}));
+
+vi.mock('../../MetricsContext', () => ({
+  useMetrics: () => ({
+    hasData: true,
+    enterpriseName: 'test-enterprise',
+    aggregatedMetrics: mocks.aggregatedMetrics,
+    isLoading: false,
+    error: null,
+  }),
+}));
+
+vi.mock('../../../state/NavigationContext', () => ({
+  useNavigation: () => ({
+    currentView: VIEW_MODES.USER_DETAILS,
+    selectedUser: mocks.selectedUser,
+    navigateTo: mocks.navigateTo,
+    selectUser: vi.fn(),
+  }),
+}));
+
+vi.mock('../../../hooks/useFileUpload', () => ({
+  useFileUpload: () => ({
+    handleFileUpload: vi.fn(),
+    handleSampleLoad: vi.fn(),
+    uploadProgress: null,
+  }),
+}));
+
+vi.mock('../../../hooks/useResetAppState', () => ({
+  useResetAppState: () => vi.fn(),
+}));
+
+vi.mock('../../../workers/metricsWorkerClient', () => ({
+  computeUserDetailsInWorker: vi.fn(),
+  terminateWorker: vi.fn(),
+}));
+
+describe('ViewRouter user-detail redirects', () => {
+  beforeEach(() => {
+    mocks.navigateTo.mockClear();
+    mocks.selectedUser = null;
+    mocks.aggregatedMetrics = aggregateMetrics([makeMetric()]).aggregated;
+  });
+
+  it('does not navigate during render when no user is selected', () => {
+    renderToStaticMarkup(<ViewRouter />);
+
+    expect(mocks.navigateTo).not.toHaveBeenCalled();
+  });
+
+  it('does not navigate during render when the selected user summary is missing', () => {
+    mocks.selectedUser = { id: 999, login: 'missing-user' };
+
+    renderToStaticMarkup(<ViewRouter />);
+
+    expect(mocks.navigateTo).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/layout/__tests__/userDetailsRequest.test.ts
+++ b/src/components/layout/__tests__/userDetailsRequest.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { UserDetailedMetrics } from '../../../types/aggregatedMetrics';
+import { runUserDetailsRequest } from '../userDetailsRequest';
+
+const details: UserDetailedMetrics = {
+  totalModelRequests: 0,
+  total_ai_credits_used: 0,
+  featureAggregates: [],
+  ideAggregates: [],
+  languageFeatureAggregates: [],
+  modelFeatureAggregates: [],
+  pluginVersions: [],
+  cliVersions: [],
+  dailyCombinedImpact: [],
+  dailyModelUsage: [],
+  dailyAgentImpact: [],
+  dailyAskModeImpact: [],
+  dailyCompletionImpact: [],
+  dailyCliImpact: [],
+  days: [],
+  reportStartDay: '2024-01-01',
+  reportEndDay: '2024-01-31',
+};
+
+describe('runUserDetailsRequest', () => {
+  it('preserves the worker error message', async () => {
+    const onError = vi.fn();
+
+    await runUserDetailsRequest({
+      userId: 42,
+      load: vi.fn().mockRejectedValue(new Error('Worker accumulator unavailable')),
+      isCurrent: () => true,
+      onSuccess: vi.fn(),
+      onError,
+    });
+
+    expect(onError).toHaveBeenCalledWith('Worker accumulator unavailable');
+  });
+
+  it('ignores late results from an obsolete request', async () => {
+    let resolveRequest: (value: UserDetailedMetrics | null) => void = () => undefined;
+    const load = vi.fn(() => new Promise<UserDetailedMetrics | null>((resolve) => {
+      resolveRequest = resolve;
+    }));
+    let isCurrent = true;
+    const onSuccess = vi.fn();
+    const onError = vi.fn();
+
+    const request = runUserDetailsRequest({
+      userId: 42,
+      load,
+      isCurrent: () => isCurrent,
+      onSuccess,
+      onError,
+    });
+    isCurrent = false;
+    resolveRequest(details);
+    await request;
+
+    expect(onSuccess).not.toHaveBeenCalled();
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it('makes a fresh request when retried for the same user', async () => {
+    const load = vi.fn()
+      .mockRejectedValueOnce(new Error('First request failed'))
+      .mockResolvedValueOnce(details);
+    const onSuccess = vi.fn();
+    const onError = vi.fn();
+    const options = {
+      userId: 42,
+      load,
+      isCurrent: () => true,
+      onSuccess,
+      onError,
+    };
+
+    await runUserDetailsRequest(options);
+    await runUserDetailsRequest(options);
+
+    expect(load).toHaveBeenCalledTimes(2);
+    expect(onError).toHaveBeenCalledWith('First request failed');
+    expect(onSuccess).toHaveBeenCalledWith(details);
+  });
+});

--- a/src/components/layout/__tests__/userDetailsRouteState.test.ts
+++ b/src/components/layout/__tests__/userDetailsRouteState.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from 'vitest';
+import type { UserDetailedMetrics } from '../../../types/aggregatedMetrics';
+import type { UserSummary } from '../../../types/metrics';
+import { VIEW_MODES } from '../../../types/navigation';
+import {
+  resolveUserDetailsRouteState,
+  type UserDetailsLoadState,
+} from '../userDetailsRouteState';
+
+const dataset = {};
+const selectedUser = { id: 42, login: 'octocat' };
+const userSummary: UserSummary = {
+  user_id: selectedUser.id,
+  user_login: selectedUser.login,
+  total_user_initiated_interactions: 0,
+  total_code_generation_activities: 0,
+  total_code_acceptance_activities: 0,
+  total_loc_added: 0,
+  total_loc_deleted: 0,
+  total_loc_suggested_to_add: 0,
+  total_loc_suggested_to_delete: 0,
+  total_ai_credits_used: 0,
+  net_loc_contribution: 0,
+  days_active: 0,
+  cloud_agent_days: 0,
+  code_review_days: 0,
+  top_client: null,
+  used_agent: false,
+  used_chat: false,
+  used_cli: false,
+  used_copilot_coding_agent: false,
+  used_copilot_code_review_active: false,
+  used_copilot_code_review_passive: false,
+};
+const details: UserDetailedMetrics = {
+  totalModelRequests: 0,
+  total_ai_credits_used: 0,
+  featureAggregates: [],
+  ideAggregates: [],
+  languageFeatureAggregates: [],
+  modelFeatureAggregates: [],
+  pluginVersions: [],
+  cliVersions: [],
+  dailyCombinedImpact: [],
+  dailyModelUsage: [],
+  dailyAgentImpact: [],
+  dailyAskModeImpact: [],
+  dailyCompletionImpact: [],
+  dailyCliImpact: [],
+  days: [],
+  reportStartDay: '2024-01-01',
+  reportEndDay: '2024-01-31',
+};
+
+function resolve(loadState: UserDetailsLoadState) {
+  return resolveUserDetailsRouteState({
+    currentView: VIEW_MODES.USER_DETAILS,
+    selectedUser,
+    userSummaries: [userSummary],
+    dataset,
+    loadState,
+  });
+}
+
+describe('resolveUserDetailsRouteState', () => {
+  it('returns inactive outside the user-details view', () => {
+    const state = resolveUserDetailsRouteState({
+      currentView: VIEW_MODES.USERS,
+      selectedUser,
+      userSummaries: [userSummary],
+      dataset,
+      loadState: { status: 'idle' },
+    });
+
+    expect(state).toEqual({ status: 'inactive' });
+  });
+
+  it('redirects when no user is selected', () => {
+    const state = resolveUserDetailsRouteState({
+      currentView: VIEW_MODES.USER_DETAILS,
+      selectedUser: null,
+      userSummaries: [userSummary],
+      dataset,
+      loadState: { status: 'idle' },
+    });
+
+    expect(state).toEqual({ status: 'redirect', reason: 'missing-selection' });
+  });
+
+  it('redirects when the selected user has no aggregate summary', () => {
+    const state = resolveUserDetailsRouteState({
+      currentView: VIEW_MODES.USER_DETAILS,
+      selectedUser,
+      userSummaries: [],
+      dataset,
+      loadState: { status: 'idle' },
+    });
+
+    expect(state).toEqual({ status: 'redirect', reason: 'missing-summary' });
+  });
+
+  it('returns loading while the matching request is pending', () => {
+    expect(resolve({
+      status: 'loading',
+      dataset,
+      userId: selectedUser.id,
+    })).toMatchObject({ status: 'loading', userSummary });
+  });
+
+  it('returns the matching request error', () => {
+    expect(resolve({
+      status: 'error',
+      dataset,
+      userId: selectedUser.id,
+      message: 'Worker unavailable',
+    })).toMatchObject({ status: 'error', message: 'Worker unavailable', userSummary });
+  });
+
+  it('returns ready with matching user details', () => {
+    expect(resolve({
+      status: 'ready',
+      dataset,
+      userId: selectedUser.id,
+      details,
+    })).toMatchObject({ status: 'ready', details, userSummary });
+  });
+
+  it('treats results from an obsolete dataset as loading', () => {
+    expect(resolve({
+      status: 'ready',
+      dataset: {},
+      userId: selectedUser.id,
+      details,
+    })).toMatchObject({ status: 'loading', userSummary });
+  });
+});

--- a/src/components/layout/userDetailsRequest.ts
+++ b/src/components/layout/userDetailsRequest.ts
@@ -1,0 +1,37 @@
+import type { UserDetailedMetrics } from '../../types/aggregatedMetrics';
+
+interface RunUserDetailsRequestOptions {
+  userId: number;
+  load: (userId: number) => Promise<UserDetailedMetrics | null>;
+  isCurrent: () => boolean;
+  onSuccess: (details: UserDetailedMetrics) => void;
+  onError: (message: string) => void;
+}
+
+export async function runUserDetailsRequest({
+  userId,
+  load,
+  isCurrent,
+  onSuccess,
+  onError,
+}: RunUserDetailsRequestOptions): Promise<void> {
+  try {
+    const details = await load(userId);
+    if (!isCurrent()) {
+      return;
+    }
+
+    if (!details) {
+      onError('No user details were returned for this user.');
+      return;
+    }
+
+    onSuccess(details);
+  } catch (error) {
+    if (!isCurrent()) {
+      return;
+    }
+
+    onError(error instanceof Error ? error.message : 'Failed to load user details.');
+  }
+}

--- a/src/components/layout/userDetailsRouteState.ts
+++ b/src/components/layout/userDetailsRouteState.ts
@@ -1,0 +1,83 @@
+import type { UserDetailedMetrics } from '../../types/aggregatedMetrics';
+import type { UserSummary } from '../../types/metrics';
+import type { SelectedUser, ViewMode } from '../../types/navigation';
+import { VIEW_MODES } from '../../types/navigation';
+
+export type UserDetailsLoadState =
+  | { status: 'idle' }
+  | { status: 'loading'; dataset: object; userId: number }
+  | { status: 'error'; dataset: object; userId: number; message: string }
+  | { status: 'ready'; dataset: object; userId: number; details: UserDetailedMetrics };
+
+export type UserDetailsRouteState =
+  | { status: 'inactive' }
+  | { status: 'redirect'; reason: 'missing-selection' | 'missing-summary' }
+  | { status: 'loading'; selectedUser: SelectedUser; userSummary: UserSummary | null }
+  | { status: 'error'; selectedUser: SelectedUser; userSummary: UserSummary; message: string }
+  | {
+      status: 'ready';
+      selectedUser: SelectedUser;
+      userSummary: UserSummary;
+      details: UserDetailedMetrics;
+    };
+
+interface ResolveUserDetailsRouteStateOptions {
+  currentView: ViewMode;
+  selectedUser: SelectedUser | null;
+  userSummaries: UserSummary[] | null;
+  dataset: object | null;
+  loadState: UserDetailsLoadState;
+}
+
+export function resolveUserDetailsRouteState({
+  currentView,
+  selectedUser,
+  userSummaries,
+  dataset,
+  loadState,
+}: ResolveUserDetailsRouteStateOptions): UserDetailsRouteState {
+  if (currentView !== VIEW_MODES.USER_DETAILS) {
+    return { status: 'inactive' };
+  }
+
+  if (!selectedUser) {
+    return { status: 'redirect', reason: 'missing-selection' };
+  }
+
+  if (!userSummaries || !dataset) {
+    return { status: 'loading', selectedUser, userSummary: null };
+  }
+
+  const userSummary = userSummaries.find((summary) => summary.user_id === selectedUser.id);
+  if (!userSummary) {
+    return { status: 'redirect', reason: 'missing-summary' };
+  }
+
+  if (
+    loadState.status === 'idle'
+    || loadState.dataset !== dataset
+    || loadState.userId !== selectedUser.id
+  ) {
+    return { status: 'loading', selectedUser, userSummary };
+  }
+
+  if (loadState.status === 'error') {
+    return {
+      status: 'error',
+      selectedUser,
+      userSummary,
+      message: loadState.message,
+    };
+  }
+
+  if (loadState.status === 'ready') {
+    return {
+      status: 'ready',
+      selectedUser,
+      userSummary,
+      details: loadState.details,
+    };
+  }
+
+  return { status: 'loading', selectedUser, userSummary };
+}


### PR DESCRIPTION
## Why

User-detail navigation currently performs redirects during render and discards worker failures, which can cause React side effects, unrecoverable loading failures, and stale async results. This change makes the flow deterministic and recoverable while preserving worker-only ownership of raw metrics.

| Commit | Change |
|--------|--------|
| `fix: make user details routing recoverable` | Resolve explicit route states, redirect in effects, preserve errors, add retry, and guard obsolete user/dataset requests. |
| `refactor: remove obsolete raw metrics hook` | Remove the misleading unused `useRawMetrics` alias. |
| `docs: correct metrics processing architecture` | Document the streaming parser, aggregate contract, and retained compact user-detail accumulator accurately. |