### PR TITLE
refactor: clarify metrics worker ownership

### DIFF
--- a/docs/project-overview.md
+++ b/docs/project-overview.md
@@ -70,18 +70,20 @@ Next.js App Router SPA, TypeScript, Tailwind CSS. All rendering is client-side.
 ```mermaid
 flowchart LR
   A[User uploads .ndjson file] --> B[useFileUpload hook]
-  B -->|postMessage: parseAndAggregate| W[Web Worker: parse + aggregate]
-  W -->|parseAndAggregateResult| C[MetricsContext stores AggregatedMetrics + warnings]
-  C --> D[ViewRouter renders current view]
-  D --> E[Chart components]
+  B --> C[MetricsWorkerProvider-owned client]
+  C -->|postMessage: parseAndAggregate| W[Web Worker: parse + aggregate]
+  W -->|parseAndAggregateResult| D[MetricsContext stores AggregatedMetrics + warnings]
+  D --> E[ViewRouter renders current view]
+  E --> F[Chart components]
 ```
 
 ### 4.1. Upload and Parsing
 
-1. `useFileUpload` validates file extension and sends files to the worker via `parseAndAggregateInWorker()`
+1. `useFileUpload` validates file extensions and requests parsing through the typed worker client exposed by `MetricsWorkerProvider`
 2. The worker streams each file through `src/infra/metricsFileParser.ts` using the `File.stream()` API, parses lines via `parseMetricsLine`, and applies string interning (`StringPool`) for memory efficiency
 3. Records using deprecated LOC fields or missing required fields are skipped
 4. The worker runs `aggregateMetrics()` on the parsed data, retains the compact user-detail accumulator for on-demand requests, and returns the `AggregatedMetrics` result, enterprise name, record count, and any per-file parse errors (surfaced as a non-fatal warning in the UI when partial failures occur). Raw records remain off the main thread.
+5. `MetricsWorkerProvider` is the application-level lifecycle owner. Its client creates the browser Worker lazily, correlates requests and progress responses, cancels pending work on reusable resets, and permanently disposes the Worker when the provider unmounts.
 
 ### 4.2. Aggregation
 
@@ -104,6 +106,7 @@ flowchart TB
 		L[layout.tsx] --> P[providers.tsx]
 		P --> H[page.tsx]
 		H --> VR[ViewRouter]
+		P --> MWP[MetricsWorkerProvider]
 	end
 
 	subgraph State
@@ -119,13 +122,17 @@ flowchart TB
 	end
 
 	subgraph WorkerBridge
+		MWC[MetricsWorkerContext.tsx]
 		WC[metricsWorkerClient.ts]
 		WT[metricsWorker.ts]
 	end
 
 	VR --> Views[View Components + Charts]
 
-	UFU[useFileUpload] --> WC
+	MWP --> MWC
+	MWC --> WC
+	UFU[useFileUpload] --> MWC
+	VR -->|user detail requests| MWC
 	WC -->|postMessage| WT
 	WT --> MFP
 	WT --> MA

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -3,14 +3,17 @@
 import React from 'react';
 import { MetricsProvider } from '../components/MetricsContext';
 import { NavigationProvider } from '../state/NavigationContext';
+import { MetricsWorkerProvider } from '../workers/MetricsWorkerContext';
 
 const Providers: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   return (
-    <NavigationProvider>
-      <MetricsProvider>
-        {children}
-      </MetricsProvider>
-    </NavigationProvider>
+    <MetricsWorkerProvider>
+      <NavigationProvider>
+        <MetricsProvider>
+          {children}
+        </MetricsProvider>
+      </NavigationProvider>
+    </MetricsWorkerProvider>
   );
 };
 

--- a/src/components/layout/ViewRouter.tsx
+++ b/src/components/layout/ViewRouter.tsx
@@ -6,7 +6,7 @@ import { useNavigation } from '../../state/NavigationContext';
 import { useMetrics } from '../MetricsContext';
 import { useFileUpload } from '../../hooks/useFileUpload';
 import { useResetAppState } from '../../hooks/useResetAppState';
-import { terminateWorker, computeUserDetailsInWorker } from '../../workers/metricsWorkerClient';
+import { useMetricsWorker } from '../../workers/MetricsWorkerContext';
 import {
   resolveUserDetailsRouteState,
   type UserDetailsLoadState,
@@ -39,6 +39,7 @@ const ViewRouter: React.FC = () => {
   } = useNavigation();
   const { handleFileUpload, handleSampleLoad, uploadProgress } = useFileUpload();
   const resetAppState = useResetAppState();
+  const metricsWorker = useMetricsWorker();
 
   const [userDetailsLoadState, setUserDetailsLoadState] = useState<UserDetailsLoadState>({
     status: 'idle',
@@ -96,7 +97,7 @@ const ViewRouter: React.FC = () => {
 
     void runUserDetailsRequest({
       userId: userDetailsRequestUserId,
-      load: computeUserDetailsInWorker,
+      load: metricsWorker.computeUserDetails,
       isCurrent: () => userDetailsRequestVersion.current === requestVersion,
       onSuccess: (details) => {
         setUserDetailsLoadState({
@@ -126,11 +127,8 @@ const ViewRouter: React.FC = () => {
     userDetailsRequestLogin,
     userDetailsRequestUserId,
     userDetailsRetryKey,
+    metricsWorker,
   ]);
-
-  useEffect(() => {
-    return () => { terminateWorker(); };
-  }, []);
 
   const handleUserClick = (userLogin: string, userId: number) => {
     selectUser({ login: userLogin, id: userId });

--- a/src/components/layout/__tests__/ViewRouter.test.tsx
+++ b/src/components/layout/__tests__/ViewRouter.test.tsx
@@ -45,9 +45,12 @@ vi.mock('../../../hooks/useResetAppState', () => ({
   useResetAppState: () => vi.fn(),
 }));
 
-vi.mock('../../../workers/metricsWorkerClient', () => ({
-  computeUserDetailsInWorker: vi.fn(),
-  terminateWorker: vi.fn(),
+vi.mock('../../../workers/MetricsWorkerContext', () => ({
+  useMetricsWorker: () => ({
+    computeUserDetails: vi.fn(),
+    parseAndAggregate: vi.fn(),
+    reset: vi.fn(),
+  }),
 }));
 
 describe('ViewRouter user-detail redirects', () => {

--- a/src/hooks/useFileUpload.ts
+++ b/src/hooks/useFileUpload.ts
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { MultiFileProgress } from '../infra/metricsFileParser';
-import { parseAndAggregateInWorker, terminateWorker } from '../workers/metricsWorkerClient';
+import { useMetricsWorker } from '../workers/MetricsWorkerContext';
 import { useMetrics } from '../components/MetricsContext';
 import { getBasePath } from '../utils/basePath';
 
@@ -19,6 +19,7 @@ interface UseFileUploadReturn {
 export function useFileUpload(): UseFileUploadReturn {
   const [uploadProgress, setUploadProgress] = useState<MultiFileProgress | null>(null);
   const requestIdRef = useRef(0);
+  const metricsWorker = useMetricsWorker();
   const {
     isLoading,
     error,
@@ -33,7 +34,7 @@ export function useFileUpload(): UseFileUploadReturn {
   } = useMetrics();
 
   const processFiles = useCallback(async (files: File[], requestId: number) => {
-    const response = await parseAndAggregateInWorker(files, (progress) => {
+    const response = await metricsWorker.parseAndAggregate(files, (progress) => {
       if (requestIdRef.current === requestId) {
         setUploadProgress(progress);
       }
@@ -61,12 +62,11 @@ export function useFileUpload(): UseFileUploadReturn {
     setFilename(files.length === 1 ? files[0].name : `${files.length} files`);
     setRecordCount(recordCount);
     setAggregatedMetrics(result);
-  }, [setAggregatedMetrics, setEnterpriseName, setFilename, setRecordCount, setUploadProgress, setError, setWarning]);
+  }, [metricsWorker, setAggregatedMetrics, setEnterpriseName, setFilename, setRecordCount, setUploadProgress, setError, setWarning]);
 
   useEffect(() => {
     return () => {
       requestIdRef.current++;
-      terminateWorker();
     };
   }, []);
 
@@ -80,7 +80,7 @@ export function useFileUpload(): UseFileUploadReturn {
       const lowerName = file.name.toLowerCase();
       if (!lowerName.endsWith('.ndjson') && !lowerName.endsWith('.json')) {
         requestIdRef.current++;
-        terminateWorker();
+        metricsWorker.reset();
         setIsLoading(false);
         setUploadProgress(null);
         setWarning(null);
@@ -90,7 +90,7 @@ export function useFileUpload(): UseFileUploadReturn {
     }
 
     const requestId = ++requestIdRef.current;
-    terminateWorker();
+    metricsWorker.reset();
     resetMetrics();
     setIsLoading(true);
     setUploadProgress(null);
@@ -107,11 +107,11 @@ export function useFileUpload(): UseFileUploadReturn {
         setUploadProgress(null);
       }
     }
-  }, [processFiles, resetMetrics, setIsLoading, setError, setWarning, setUploadProgress]);
+  }, [metricsWorker, processFiles, resetMetrics, setIsLoading, setError, setWarning, setUploadProgress]);
 
   const handleSampleLoad = useCallback(async () => {
     const requestId = ++requestIdRef.current;
-    terminateWorker();
+    metricsWorker.reset();
     resetMetrics();
     setIsLoading(true);
     setUploadProgress(null);
@@ -138,7 +138,7 @@ export function useFileUpload(): UseFileUploadReturn {
         setUploadProgress(null);
       }
     }
-  }, [processFiles, resetMetrics, setIsLoading, setError, setWarning, setUploadProgress]);
+  }, [metricsWorker, processFiles, resetMetrics, setIsLoading, setError, setWarning, setUploadProgress]);
 
   return {
     handleFileUpload,

--- a/src/hooks/useResetAppState.ts
+++ b/src/hooks/useResetAppState.ts
@@ -3,15 +3,16 @@
 import { useCallback } from 'react';
 import { useMetrics } from '../components/MetricsContext';
 import { useNavigation } from '../state/NavigationContext';
-import { terminateWorker } from '../workers/metricsWorkerClient';
+import { useMetricsWorker } from '../workers/MetricsWorkerContext';
 
 export function useResetAppState() {
   const { resetMetrics } = useMetrics();
   const { resetNavigation } = useNavigation();
+  const metricsWorker = useMetricsWorker();
 
   return useCallback(() => {
-    terminateWorker();
+    metricsWorker.reset();
     resetMetrics();
     resetNavigation();
-  }, [resetMetrics, resetNavigation]);
+  }, [metricsWorker, resetMetrics, resetNavigation]);
 }

--- a/src/workers/MetricsWorkerContext.tsx
+++ b/src/workers/MetricsWorkerContext.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useRef,
+  type ReactNode,
+} from 'react';
+import type { MultiFileProgress } from '../infra/metricsFileParser';
+import type { UserDetailedMetrics } from '../types/aggregatedMetrics';
+import {
+  MetricsWorkerClient,
+  type ParseAndAggregateResult,
+} from './metricsWorkerClient';
+
+interface MetricsWorkerOperations {
+  parseAndAggregate: (
+    files: File[],
+    onProgress?: (progress: MultiFileProgress) => void
+  ) => Promise<ParseAndAggregateResult>;
+  computeUserDetails: (userId: number) => Promise<UserDetailedMetrics | null>;
+  reset: () => void;
+}
+
+const MetricsWorkerContext = createContext<MetricsWorkerOperations | null>(null);
+
+export function MetricsWorkerProvider({ children }: { children: ReactNode }) {
+  const clientRef = useRef<MetricsWorkerClient | null>(null);
+  const operationsRef = useRef<MetricsWorkerOperations | null>(null);
+  const lifecycleVersionRef = useRef(0);
+
+  if (clientRef.current === null) {
+    clientRef.current = new MetricsWorkerClient();
+  }
+
+  if (operationsRef.current === null) {
+    const getClient = () => {
+      if (clientRef.current === null) {
+        throw new Error('MetricsWorkerProvider has been disposed');
+      }
+      return clientRef.current;
+    };
+
+    operationsRef.current = {
+      parseAndAggregate: (files, onProgress) =>
+        getClient().parseAndAggregate(files, onProgress),
+      computeUserDetails: (userId) => getClient().computeUserDetails(userId),
+      reset: () => getClient().reset(),
+    };
+  }
+
+  useEffect(() => {
+    lifecycleVersionRef.current += 1;
+
+    return () => {
+      const cleanupVersion = ++lifecycleVersionRef.current;
+
+      // Strict Mode replays setup before this microtask; a real unmount does not.
+      queueMicrotask(() => {
+        if (lifecycleVersionRef.current !== cleanupVersion) return;
+
+        clientRef.current?.dispose();
+        clientRef.current = null;
+      });
+    };
+  }, []);
+
+  return (
+    <MetricsWorkerContext.Provider value={operationsRef.current}>
+      {children}
+    </MetricsWorkerContext.Provider>
+  );
+}
+
+export function useMetricsWorker(): MetricsWorkerOperations {
+  const context = useContext(MetricsWorkerContext);
+  if (!context) {
+    throw new Error('useMetricsWorker must be used within a MetricsWorkerProvider');
+  }
+  return context;
+}

--- a/src/workers/__tests__/metricsWorkerClient.test.ts
+++ b/src/workers/__tests__/metricsWorkerClient.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, it, vi } from 'vitest';
+import { makeMetric } from '../../__tests__/factories/metrics';
+import { aggregateMetrics } from '../../domain/metricsAggregator';
+import type { WorkerRequest, WorkerResponse } from '../types';
+import { MetricsWorkerClient } from '../metricsWorkerClient';
+
+class MockWorker {
+  onmessage: ((event: MessageEvent<WorkerResponse>) => void) | null = null;
+  onerror: ((event: ErrorEvent) => void) | null = null;
+  readonly messages: WorkerRequest[] = [];
+  terminate = vi.fn();
+
+  postMessage(message: WorkerRequest): void {
+    this.messages.push(message);
+  }
+
+  respond(message: WorkerResponse): void {
+    this.onmessage?.({ data: message } as MessageEvent<WorkerResponse>);
+  }
+
+  fail(message: string): void {
+    this.onerror?.({ message } as ErrorEvent);
+  }
+}
+
+function createHarness() {
+  const workers: MockWorker[] = [];
+  const createWorker = vi.fn(() => {
+    const worker = new MockWorker();
+    workers.push(worker);
+    return worker;
+  });
+  const client = new MetricsWorkerClient(createWorker);
+
+  return { client, createWorker, workers };
+}
+
+function parseResult(id: string): Extract<WorkerResponse, { type: 'parseAndAggregateResult' }> {
+  return {
+    type: 'parseAndAggregateResult',
+    id,
+    result: aggregateMetrics([makeMetric()]).aggregated,
+    enterpriseName: 'acme',
+    recordCount: 1,
+    errors: [],
+  };
+}
+
+describe('MetricsWorkerClient', () => {
+  it('creates one worker lazily and reuses it across concurrent requests', async () => {
+    const { client, createWorker, workers } = createHarness();
+
+    expect(createWorker).not.toHaveBeenCalled();
+
+    const parsePromise = client.parseAndAggregate([new File([''], 'metrics.ndjson')]);
+    const detailsPromise = client.computeUserDetails(42);
+
+    expect(createWorker).toHaveBeenCalledTimes(1);
+    expect(workers[0].messages).toEqual([
+      {
+        type: 'parseAndAggregate',
+        id: 'req-1',
+        files: [expect.objectContaining({ name: 'metrics.ndjson' })],
+      },
+      { type: 'computeUserDetails', id: 'req-2', userId: 42 },
+    ]);
+
+    workers[0].respond(parseResult('req-1'));
+    workers[0].respond({ type: 'userDetailsResult', id: 'req-2', result: null });
+    await Promise.all([parsePromise, detailsPromise]);
+  });
+
+  it('correlates concurrent requests and routes parse and user-detail results', async () => {
+    const { client, workers } = createHarness();
+    const parsePromise = client.parseAndAggregate([new File([''], 'metrics.ndjson')]);
+    const detailsPromise = client.computeUserDetails(42);
+
+    workers[0].respond({ type: 'userDetailsResult', id: 'req-2', result: null });
+    workers[0].respond(parseResult('req-1'));
+
+    await expect(detailsPromise).resolves.toBeNull();
+    await expect(parsePromise).resolves.toEqual({
+      result: expect.objectContaining({ stats: expect.any(Object) }),
+      enterpriseName: 'acme',
+      recordCount: 1,
+      errors: [],
+    });
+  });
+
+  it('routes parse progress without settling the request', async () => {
+    const { client, workers } = createHarness();
+    const onProgress = vi.fn();
+    let settled = false;
+    const request = client
+      .parseAndAggregate([new File([''], 'metrics.ndjson')], onProgress)
+      .finally(() => {
+        settled = true;
+      });
+    const progress = {
+      currentFile: 1,
+      totalFiles: 1,
+      fileName: 'metrics.ndjson',
+      recordsProcessed: 12,
+    };
+
+    workers[0].respond({ type: 'parseProgress', id: 'req-1', progress });
+    await Promise.resolve();
+
+    expect(onProgress).toHaveBeenCalledWith(progress);
+    expect(settled).toBe(false);
+
+    workers[0].respond(parseResult('req-1'));
+    await request;
+  });
+
+  it('rejects a request when the response kind does not match', async () => {
+    const { client, workers } = createHarness();
+    const request = client.computeUserDetails(42);
+
+    workers[0].respond(parseResult('req-1'));
+
+    await expect(request).rejects.toThrow(
+      "Unexpected response type 'parseAndAggregateResult' for 'computeUserDetails' request"
+    );
+  });
+
+  it('rejects every pending request and releases resources on worker error', async () => {
+    const { client, workers } = createHarness();
+    const parsePromise = client.parseAndAggregate([new File([''], 'metrics.ndjson')]);
+    const detailsPromise = client.computeUserDetails(42);
+
+    workers[0].fail('worker crashed');
+
+    await expect(parsePromise).rejects.toThrow('Worker error: worker crashed');
+    await expect(detailsPromise).rejects.toThrow('Worker error: worker crashed');
+    expect(workers[0].terminate).toHaveBeenCalledTimes(1);
+    expect(workers[0].onmessage).toBeNull();
+    expect(workers[0].onerror).toBeNull();
+  });
+
+  it('rejects pending work exactly once on reset and recreates the worker', async () => {
+    const { client, createWorker, workers } = createHarness();
+    const onRejected = vi.fn();
+    void client
+      .parseAndAggregate([new File([''], 'metrics.ndjson')])
+      .catch(onRejected);
+
+    client.reset();
+    client.reset();
+    await Promise.resolve();
+
+    expect(onRejected).toHaveBeenCalledTimes(1);
+    expect(onRejected.mock.calls[0][0]).toEqual(new Error('Metrics worker reset'));
+    expect(workers[0].terminate).toHaveBeenCalledTimes(1);
+
+    const detailsPromise = client.computeUserDetails(42);
+    expect(createWorker).toHaveBeenCalledTimes(2);
+    expect(workers[1].messages[0]).toEqual({
+      type: 'computeUserDetails',
+      id: 'req-2',
+      userId: 42,
+    });
+
+    workers[1].respond({ type: 'userDetailsResult', id: 'req-2', result: null });
+    await detailsPromise;
+  });
+
+  it('permanently disposes the client and rejects pending work exactly once', async () => {
+    const { client, createWorker } = createHarness();
+    const onRejected = vi.fn();
+    void client.computeUserDetails(42).catch(onRejected);
+
+    client.dispose();
+    client.dispose();
+    await Promise.resolve();
+
+    expect(onRejected).toHaveBeenCalledTimes(1);
+    expect(onRejected.mock.calls[0][0]).toEqual(new Error('Metrics worker disposed'));
+    await expect(client.computeUserDetails(7)).rejects.toThrow(
+      'Metrics worker client has been disposed'
+    );
+    expect(createWorker).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores responses for stale or unknown request IDs', async () => {
+    const { client, workers } = createHarness();
+    let settled = false;
+    const request = client.computeUserDetails(42).finally(() => {
+      settled = true;
+    });
+
+    workers[0].respond({ type: 'userDetailsResult', id: 'unknown', result: null });
+    await Promise.resolve();
+
+    expect(settled).toBe(false);
+
+    workers[0].respond({ type: 'userDetailsResult', id: 'req-1', result: null });
+    await request;
+  });
+});

--- a/src/workers/metricsWorkerClient.ts
+++ b/src/workers/metricsWorkerClient.ts
@@ -1,11 +1,18 @@
 import type { AggregatedMetrics } from '../domain/metricsAggregator';
 import type { UserDetailedMetrics } from '../types/aggregatedMetrics';
 import type { MultiFileProgress, MultiFileResult } from '../infra/metricsFileParser';
-import type { WorkerResponse } from './types';
+import type { WorkerRequest, WorkerResponse } from './types';
 import { getBasePath } from '../utils/basePath';
 
+export interface ParseAndAggregateResult {
+  result: AggregatedMetrics;
+  enterpriseName: string | null;
+  recordCount: number;
+  errors: MultiFileResult['errors'];
+}
+
 interface PendingParseAndAggregateRequest {
-  resolve: (value: { result: AggregatedMetrics; enterpriseName: string | null; recordCount: number; errors: MultiFileResult['errors'] }) => void;
+  resolve: (value: ParseAndAggregateResult) => void;
   reject: (error: Error) => void;
   onProgress?: (progress: MultiFileProgress) => void;
 }
@@ -19,117 +26,173 @@ type PendingRequest =
   | ({ kind: 'parseAndAggregate' } & PendingParseAndAggregateRequest)
   | ({ kind: 'computeUserDetails' } & PendingUserDetailsRequest);
 
-let worker: Worker | null = null;
-const pendingRequests = new Map<string, PendingRequest>();
-let requestCounter = 0;
+interface MetricsWorkerPort {
+  onmessage: ((event: MessageEvent<WorkerResponse>) => void) | null;
+  onerror: ((event: ErrorEvent) => void) | null;
+  postMessage(message: WorkerRequest): void;
+  terminate(): void;
+}
 
-function getWorker(): Worker {
-  if (worker) return worker;
+type MetricsWorkerFactory = () => MetricsWorkerPort;
 
-  worker = new Worker(`${getBasePath()}/workers/metricsWorker.js`);
+function createBrowserWorker(): MetricsWorkerPort {
+  if (typeof Worker === 'undefined') {
+    throw new Error('Metrics worker is only available in the browser');
+  }
 
-  worker.onmessage = (event: MessageEvent<WorkerResponse>) => {
-    const msg = event.data;
-    const pending = pendingRequests.get(msg.id);
+  return new Worker(`${getBasePath()}/workers/metricsWorker.js`);
+}
+
+export class MetricsWorkerClient {
+  private worker: MetricsWorkerPort | null = null;
+  private readonly pendingRequests = new Map<string, PendingRequest>();
+  private requestCounter = 0;
+  private disposed = false;
+
+  constructor(private readonly createWorker: MetricsWorkerFactory = createBrowserWorker) {}
+
+  parseAndAggregate(
+    files: File[],
+    onProgress?: (progress: MultiFileProgress) => void
+  ): Promise<ParseAndAggregateResult> {
+    const id = this.nextId();
+    return new Promise((resolve, reject) => {
+      this.pendingRequests.set(id, { kind: 'parseAndAggregate', resolve, reject, onProgress });
+      this.postRequest({ type: 'parseAndAggregate', id, files });
+    });
+  }
+
+  computeUserDetails(userId: number): Promise<UserDetailedMetrics | null> {
+    const id = this.nextId();
+    return new Promise((resolve, reject) => {
+      this.pendingRequests.set(id, { kind: 'computeUserDetails', resolve, reject });
+      this.postRequest({ type: 'computeUserDetails', id, userId });
+    });
+  }
+
+  reset(): void {
+    this.releaseWorker(new Error('Metrics worker reset'));
+  }
+
+  dispose(): void {
+    if (this.disposed) return;
+
+    this.disposed = true;
+    this.releaseWorker(new Error('Metrics worker disposed'));
+  }
+
+  private nextId(): string {
+    return `req-${++this.requestCounter}`;
+  }
+
+  private postRequest(request: WorkerRequest): void {
+    try {
+      this.getWorker().postMessage(request);
+    } catch (error) {
+      const pending = this.pendingRequests.get(request.id);
+      this.pendingRequests.delete(request.id);
+      pending?.reject(error instanceof Error ? error : new Error(String(error)));
+    }
+  }
+
+  private getWorker(): MetricsWorkerPort {
+    if (this.disposed) {
+      throw new Error('Metrics worker client has been disposed');
+    }
+    if (this.worker) return this.worker;
+
+    const worker = this.createWorker();
+    worker.onmessage = (event) => {
+      this.handleMessage(event.data);
+    };
+    worker.onerror = (event) => {
+      this.handleWorkerError(worker, event.message);
+    };
+    this.worker = worker;
+    return worker;
+  }
+
+  private handleMessage(message: WorkerResponse): void {
+    const pending = this.pendingRequests.get(message.id);
     if (!pending) return;
 
-    switch (msg.type) {
+    switch (message.type) {
       case 'parseProgress':
         if (pending.kind === 'parseAndAggregate') {
-          pending.onProgress?.(msg.progress);
+          pending.onProgress?.(message.progress);
+        } else {
+          this.rejectUnexpectedResponse(message.id, message.type, pending);
         }
         break;
       case 'parseAndAggregateResult':
-        pendingRequests.delete(msg.id);
+        this.pendingRequests.delete(message.id);
         if (pending.kind === 'parseAndAggregate') {
           pending.resolve({
-            result: msg.result,
-            enterpriseName: msg.enterpriseName,
-            recordCount: msg.recordCount,
-            errors: msg.errors,
+            result: message.result,
+            enterpriseName: message.enterpriseName,
+            recordCount: message.recordCount,
+            errors: message.errors,
           });
         } else {
-          pending.reject(new Error(`Unexpected response type '${msg.type}' for '${pending.kind}' request`));
+          pending.reject(this.unexpectedResponseError(message.type, pending.kind));
         }
         break;
       case 'userDetailsResult':
-        pendingRequests.delete(msg.id);
+        this.pendingRequests.delete(message.id);
         if (pending.kind === 'computeUserDetails') {
-          pending.resolve(msg.result);
+          pending.resolve(message.result);
         } else {
-          pending.reject(new Error(`Unexpected response type '${msg.type}' for '${pending.kind}' request`));
+          pending.reject(this.unexpectedResponseError(message.type, pending.kind));
         }
         break;
       case 'error':
-        pendingRequests.delete(msg.id);
-        pending.reject(new Error(msg.error));
+        this.pendingRequests.delete(message.id);
+        pending.reject(new Error(message.error));
         break;
       default: {
-        const unexpectedMsg = msg as { id: string; type: string };
-        pendingRequests.delete(unexpectedMsg.id);
-        pending.reject(new Error(`Unknown response type '${unexpectedMsg.type}' for '${pending.kind}' request`));
+        const unexpected = message as { id: string; type: string };
+        this.pendingRequests.delete(unexpected.id);
+        pending.reject(new Error(
+          `Unknown response type '${unexpected.type}' for '${pending.kind}' request`
+        ));
         break;
       }
     }
-  };
+  }
 
-  worker.onerror = (err) => {
-    const failedWorker = worker;
-    worker = null;
-    for (const [id, pending] of pendingRequests) {
-      pending.reject(new Error(`Worker error: ${err.message}`));
-      pendingRequests.delete(id);
+  private rejectUnexpectedResponse(
+    id: string,
+    responseType: WorkerResponse['type'],
+    pending: PendingRequest
+  ): void {
+    this.pendingRequests.delete(id);
+    pending.reject(this.unexpectedResponseError(responseType, pending.kind));
+  }
+
+  private unexpectedResponseError(responseType: WorkerResponse['type'], requestKind: PendingRequest['kind']): Error {
+    return new Error(`Unexpected response type '${responseType}' for '${requestKind}' request`);
+  }
+
+  private handleWorkerError(failedWorker: MetricsWorkerPort, message: string): void {
+    if (this.worker !== failedWorker) return;
+
+    this.releaseWorker(new Error(`Worker error: ${message}`));
+  }
+
+  private releaseWorker(error: Error): void {
+    const worker = this.worker;
+    this.worker = null;
+
+    if (worker) {
+      worker.onmessage = null;
+      worker.onerror = null;
+      worker.terminate();
     }
-    failedWorker?.terminate();
-  };
 
-  return worker;
-}
-
-function nextId(): string {
-  return `req-${++requestCounter}`;
-}
-
-export function parseAndAggregateInWorker(
-  files: File[],
-  onProgress?: (progress: MultiFileProgress) => void
-): Promise<{ result: AggregatedMetrics; enterpriseName: string | null; recordCount: number; errors: MultiFileResult['errors'] }> {
-  const id = nextId();
-  return new Promise((resolve, reject) => {
-    pendingRequests.set(id, { kind: 'parseAndAggregate', resolve, reject, onProgress });
-    try {
-      getWorker().postMessage({ type: 'parseAndAggregate', id, files });
-    } catch (err) {
-      pendingRequests.delete(id);
-      reject(err instanceof Error ? err : new Error(String(err)));
-    }
-  });
-}
-
-export function terminateWorker(): void {
-  if (worker) {
-    worker.onmessage = null;
-    worker.onerror = null;
-    worker.terminate();
-    worker = null;
-    for (const [id, pending] of pendingRequests) {
-      pending.reject(new Error('Worker terminated'));
-      pendingRequests.delete(id);
+    const pending = Array.from(this.pendingRequests.values());
+    this.pendingRequests.clear();
+    for (const request of pending) {
+      request.reject(error);
     }
   }
-}
-
-export function computeUserDetailsInWorker(
-  userId: number
-): Promise<UserDetailedMetrics | null> {
-  const id = nextId();
-  return new Promise((resolve, reject) => {
-    pendingRequests.set(id, { kind: 'computeUserDetails', resolve, reject });
-    try {
-      getWorker().postMessage({ type: 'computeUserDetails', id, userId });
-    } catch (err) {
-      pendingRequests.delete(id);
-      reject(err instanceof Error ? err : new Error(String(err)));
-    }
-  });
 }


### PR DESCRIPTION
## Why

Worker creation, request routing, and termination were spread across consumers, making cancellation and disposal semantics difficult to reason about. This centralizes lifecycle ownership while preserving worker-only parsing and existing UI behavior.

| Commit | Change |
|--------|--------|
| `refactor: encapsulate metrics worker client` | Replace module-global state with a typed client covering lazy creation, correlated routing, reset, disposal, and worker errors, backed by focused mocked-Worker tests. |
| `refactor: centralize metrics worker ownership` | Add the application-level provider owner and route upload, reset, and user-detail consumers through its typed operations. |
| `docs: clarify metrics worker ownership` | Document the provider-owned lifecycle and updated worker data flow. |