### PR TITLE
Add initial feature read-model boundaries

### DIFF
--- a/docs/project-overview.md
+++ b/docs/project-overview.md
@@ -41,7 +41,7 @@ Next.js App Router SPA, TypeScript, Tailwind CSS. All rendering is client-side.
 - `MetricsContext` (`src/components/MetricsContext.tsx`) — stores the `AggregatedMetrics` result, loading/error/warning state, and data actions
 - `NavigationContext` (`src/state/NavigationContext.tsx`) — manages current view, selected user/model, and navigation actions
 
-**All view components consume pre-aggregated data.** No component accesses raw `CopilotMetrics[]` directly. The `AggregatedMetrics` type is declared in `src/domain/metricsAggregator.ts` and is the primary data contract between the worker and the UI. The worker also retains a compact user-detail accumulator so it can serve user details on demand without moving raw records onto the main thread.
+**All view components consume pre-aggregated data.** No component accesses raw `CopilotMetrics[]` directly. The flat `AggregatedMetrics` worker/UI contract is declared in `src/types/aggregatedMetrics.ts`. Feature read-model selectors in `src/read-models/` insulate migrated UI paths from that flat payload; overview, executive summary, users, and user details consume only their typed projections. The worker also retains a compact user-detail accumulator so it can serve user details on demand without moving raw records onto the main thread.
 
 ### 3.2. Code Organization
 
@@ -56,6 +56,7 @@ Next.js App Router SPA, TypeScript, Tailwind CSS. All rendering is client-side.
 | `src/hooks/` | Reusable React hooks (file upload, sorting, search) |
 | `src/workers/` | Web Worker entry point, client API, message types |
 | `src/state/` | Navigation context |
+| `src/read-models/` | Pure feature projections over the aggregate contract |
 | `src/types/` | TypeScript type definitions |
 | `src/utils/` | Formatting and utility helpers |
 
@@ -73,7 +74,8 @@ flowchart LR
   B --> C[MetricsWorkerProvider-owned client]
   C -->|postMessage: parseAndAggregate| W[Web Worker: parse + aggregate]
   W -->|parseAndAggregateResult| D[MetricsContext stores AggregatedMetrics + warnings]
-  D --> E[ViewRouter renders current view]
+  D --> RM[Feature read-model selectors]
+  RM --> E[ViewRouter renders current view]
   E --> F[Chart components]
 ```
 
@@ -87,11 +89,11 @@ flowchart LR
 
 ### 4.2. Aggregation
 
-`metricsAggregator.ts` orchestrates all calculators in `src/domain/calculators/` to produce the `AggregatedMetrics` object. This includes user summaries, daily time series, language/IDE/model breakdowns, model usage analysis, feature adoption, and LOC impact by mode. See the calculator files for specifics.
+`metricsAggregator.ts` orchestrates all calculators in `src/domain/calculators/` to produce the flat `AggregatedMetrics` object declared in `src/types/aggregatedMetrics.ts`. This includes user summaries, daily time series, language/IDE/model breakdowns, model usage analysis, feature adoption, and LOC impact by mode. The worker payload remains flat; `src/read-models/` provides feature boundaries on the consuming side. See the calculator files for specifics.
 
 ### 4.3. Views
 
-`ViewRouter` (`src/components/layout/ViewRouter.tsx`) maps the current `ViewMode` to the appropriate component. Views include: overview dashboard, users list, user details, languages, IDEs, Copilot impact, model usage analysis, adoption, AI adoption phases, and model details.
+`ViewRouter` (`src/components/layout/ViewRouter.tsx`) maps the current `ViewMode` to the appropriate component. Migrated views receive typed read models rather than the full aggregate contract. Views include: overview dashboard, users list, user details, languages, IDEs, Copilot impact, model usage analysis, adoption, AI adoption phases, and model details.
 
 Charts use **Chart.js** via **react-chartjs-2**, wrapped in a `ChartContainer` component for consistent styling.
 
@@ -128,6 +130,7 @@ flowchart TB
 	end
 
 	VR --> Views[View Components + Charts]
+	VR --> RM[read-models/]
 
 	MWP --> MWC
 	MWC --> WC

--- a/src/__tests__/factories/aggregatedMetrics.ts
+++ b/src/__tests__/factories/aggregatedMetrics.ts
@@ -1,0 +1,39 @@
+import { aggregateMetrics } from '../../domain/metricsAggregator';
+import type { AggregatedMetrics } from '../../types/aggregatedMetrics';
+import type { UserSummary } from '../../types/metrics';
+
+export function makeAggregatedMetrics(
+  overrides: Partial<AggregatedMetrics> = {}
+): AggregatedMetrics {
+  return {
+    ...aggregateMetrics([]).aggregated,
+    ...overrides,
+  };
+}
+
+export function makeUserSummary(overrides: Partial<UserSummary> = {}): UserSummary {
+  return {
+    user_login: 'octocat',
+    user_id: 42,
+    total_user_initiated_interactions: 0,
+    total_code_generation_activities: 0,
+    total_code_acceptance_activities: 0,
+    total_loc_added: 0,
+    total_loc_deleted: 0,
+    total_loc_suggested_to_add: 0,
+    total_loc_suggested_to_delete: 0,
+    total_ai_credits_used: 0,
+    net_loc_contribution: 0,
+    days_active: 0,
+    cloud_agent_days: 0,
+    code_review_days: 0,
+    top_client: null,
+    used_agent: false,
+    used_chat: false,
+    used_cli: false,
+    used_copilot_coding_agent: false,
+    used_copilot_code_review_active: false,
+    used_copilot_code_review_passive: false,
+    ...overrides,
+  };
+}

--- a/src/components/ExecutiveSummaryView.tsx
+++ b/src/components/ExecutiveSummaryView.tsx
@@ -4,20 +4,11 @@ import React from 'react';
 import { ViewPanel } from './ui';
 import ModeImpactChart from './charts/ModeImpactChart';
 import FeatureAdoptionChart from './charts/FeatureAdoptionChart';
-import type {
-  ModeImpactData,
-  AgentImpactData,
-  CodeCompletionImpactData,
-  FeatureAdoptionData,
-} from '../domain/calculators/metricCalculators';
-import type { MetricsStats } from '../types/metrics';
+import type { ExecutiveSummaryReadModel } from '../read-models/overview';
+
 interface ExecutiveSummaryViewProps {
-  stats: MetricsStats;
+  model: ExecutiveSummaryReadModel;
   enterpriseName: string | null;
-  joinedImpactData: ModeImpactData[];
-  agentImpactData: AgentImpactData[];
-  codeCompletionImpactData: CodeCompletionImpactData[];
-  featureAdoptionData: FeatureAdoptionData;
 }
 
 function formatLongDate(dateString: string) {
@@ -44,14 +35,18 @@ function sumNetChange(data: Array<{ netChange: number }>): number {
 }
 
 export default function ExecutiveSummaryView({
-  stats,
+  model,
   enterpriseName,
-  joinedImpactData,
-  agentImpactData,
-  codeCompletionImpactData,
-  featureAdoptionData,
 }: ExecutiveSummaryViewProps) {
-  const reportRange = `${formatLongDate(stats.reportStartDay)} – ${formatLongDate(stats.reportEndDay)}`;
+  const {
+    reportStartDay,
+    reportEndDay,
+    joinedImpactData,
+    agentImpactData,
+    codeCompletionImpactData,
+    featureAdoptionData,
+  } = model;
+  const reportRange = `${formatLongDate(reportStartDay)} – ${formatLongDate(reportEndDay)}`;
   const generatedOn = new Date().toLocaleDateString('en-US', {
     year: 'numeric',
     month: 'long',

--- a/src/components/MetricsContext.tsx
+++ b/src/components/MetricsContext.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { createContext, useContext, useState, useCallback, useMemo } from 'react';
-import type { AggregatedMetrics } from '../domain/metricsAggregator';
+import type { AggregatedMetrics } from '../types/aggregatedMetrics';
 
 interface MetricsState {
   hasData: boolean;

--- a/src/components/UniqueUsersView.tsx
+++ b/src/components/UniqueUsersView.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useMemo, useState } from 'react';
+import type { UsersReadModel } from '../read-models/users';
 import type { UserSummary } from '../types/metrics';
 import { useUsernameTrieSearch } from '../hooks/useUsernameTrieSearch';
 import { useSortableTable } from '../hooks/useSortableTable';
@@ -13,7 +14,7 @@ import StatsGrid from './ui/StatsGrid';
 import MetricsTable, { TableColumn } from './ui/MetricsTable';
 
 interface UniqueUsersViewProps {
-  users: UserSummary[];
+  model: UsersReadModel;
   onUserClick: (userLogin: string, userId: number) => void;
 }
 
@@ -30,7 +31,8 @@ function ClientIcon({ client }: { client: string }) {
   );
 }
 
-export default function UniqueUsersView({ users, onUserClick }: UniqueUsersViewProps) {
+export default function UniqueUsersView({ model, onUserClick }: UniqueUsersViewProps) {
+  const { users } = model;
   const { searchQuery, setSearchQuery, filteredUsers } = useUsernameTrieSearch(users);
   const { sortField, sortDirection, sortedItems: sortedUsers, handleSort } = useSortableTable<UserSummary, SortField>(
     filteredUsers,

--- a/src/components/UserDetailsView.tsx
+++ b/src/components/UserDetailsView.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import React, { useState, useMemo, useCallback } from 'react';
-import type { UserSummary, UserDayData } from '../types/metrics';
-import type { UserDetailedMetrics } from '../types/aggregatedMetrics';
+import type { UserDayData } from '../types/metrics';
+import type { UserDetailsViewModel } from '../read-models/userDetails';
 import { translateFeature } from '../domain/featureTranslations';
 import { formatIDEName } from './icons/IDEIcons';
 import { formatAiAdoptionPhase, formatAiCreditCost, formatShortDate, generateDateRange } from '../utils/formatters';
@@ -33,10 +33,7 @@ import { USER_DETAILS_SECTIONS } from './layout/contextSections';
 registerChartJS();
 
 interface UserDetailsViewProps {
-  userDetails: UserDetailedMetrics;
-  userSummary: UserSummary;
-  userLogin: string;
-  userId: number;
+  model: UserDetailsViewModel;
 }
 
 type UserDayWithCliTotals = UserDayData & {
@@ -71,7 +68,8 @@ function buildDailyCliSeries<T>(
   );
 }
 
-export default function UserDetailsView({ userDetails, userSummary, userLogin, userId }: UserDetailsViewProps) {
+export default function UserDetailsView({ model }: UserDetailsViewProps) {
+  const { userDetails, userSummary, userLogin, userId } = model;
   const { navigateTo } = useNavigation();
   const filledCombinedImpact = useMemo(() => fillDateRange(userDetails.dailyCombinedImpact, userDetails.reportStartDay, userDetails.reportEndDay), [userDetails.dailyCombinedImpact, userDetails.reportStartDay, userDetails.reportEndDay]);
   const filledAgentImpact = useMemo(() => fillDateRange(userDetails.dailyAgentImpact, userDetails.reportStartDay, userDetails.reportEndDay), [userDetails.dailyAgentImpact, userDetails.reportStartDay, userDetails.reportEndDay]);

--- a/src/components/features/overview/OverviewDashboard.tsx
+++ b/src/components/features/overview/OverviewDashboard.tsx
@@ -1,8 +1,7 @@
 'use client';
 
 import React from 'react';
-import { MetricsStats } from '../../../types/metrics';
-import { DailyEngagementData, DailyChatUsersData, DailyChatRequestsData } from '../../../domain/calculators/metricCalculators';
+import type { OverviewReadModel } from '../../../read-models/overview';
 import EngagementChart from '../../charts/EngagementChart';
 import ChatUsersChart from '../../charts/ChatUsersChart';
 import ChatRequestsChart from '../../charts/ChatRequestsChart';
@@ -11,20 +10,21 @@ import { OVERVIEW_SECTIONS } from './overviewSections';
 const [engagementSection, chatUsersSection, chatRequestsSection] = OVERVIEW_SECTIONS;
 
 interface OverviewDashboardProps {
-  stats: MetricsStats;
+  model: OverviewReadModel;
   enterpriseName: string | null;
-  engagementData: DailyEngagementData[];
-  chatUsersData: DailyChatUsersData[];
-  chatRequestsData: DailyChatRequestsData[];
 }
 
 const OverviewDashboard: React.FC<OverviewDashboardProps> = ({
-  stats,
+  model,
   enterpriseName,
-  engagementData,
-  chatUsersData,
-  chatRequestsData,
 }) => {
+  const {
+    reportStartDay,
+    reportEndDay,
+    engagementData,
+    chatUsersData,
+    chatRequestsData,
+  } = model;
   const formatDate = (dateString: string) => {
     return new Date(dateString).toLocaleDateString('en-US', {
       year: 'numeric',
@@ -39,7 +39,7 @@ const OverviewDashboard: React.FC<OverviewDashboardProps> = ({
         <h2 className="text-xl text-gray-900">
           <span className="font-semibold">Metrics Overview</span>
           <br />
-          <span className="text-sm font-normal text-gray-600">Data covers the period from <strong>{formatDate(stats.reportStartDay)}</strong> to <strong>{formatDate(stats.reportEndDay)}</strong>{enterpriseName && <> for Enterprise <strong>{enterpriseName}</strong></>}</span>
+          <span className="text-sm font-normal text-gray-600">Data covers the period from <strong>{formatDate(reportStartDay)}</strong> to <strong>{formatDate(reportEndDay)}</strong>{enterpriseName && <> for Enterprise <strong>{enterpriseName}</strong></>}</span>
         </h2>
       </div>
 

--- a/src/components/layout/ViewRouter.tsx
+++ b/src/components/layout/ViewRouter.tsx
@@ -8,6 +8,12 @@ import { useFileUpload } from '../../hooks/useFileUpload';
 import { useResetAppState } from '../../hooks/useResetAppState';
 import { useMetricsWorker } from '../../workers/MetricsWorkerContext';
 import {
+  selectExecutiveSummaryReadModel,
+  selectOverviewReadModel,
+} from '../../read-models/overview';
+import { selectUsersReadModel } from '../../read-models/users';
+import { selectUserDetailsRouteReadModel } from '../../read-models/userDetails';
+import {
   resolveUserDetailsRouteState,
   type UserDetailsLoadState,
 } from './userDetailsRouteState';
@@ -46,11 +52,13 @@ const ViewRouter: React.FC = () => {
   });
   const [userDetailsRetryKey, setUserDetailsRetryKey] = useState(0);
   const userDetailsRequestVersion = useRef(0);
+  const userDetailsReadModel = selectUserDetailsRouteReadModel(
+    aggregatedMetrics,
+    selectedUser
+  );
   const userDetailsRouteState = resolveUserDetailsRouteState({
     currentView,
-    selectedUser,
-    userSummaries: aggregatedMetrics?.userSummaries ?? null,
-    dataset: aggregatedMetrics,
+    routeModel: userDetailsReadModel,
     loadState: userDetailsLoadState,
   });
 
@@ -65,22 +73,13 @@ const ViewRouter: React.FC = () => {
     }
   }, [userDetailsRouteState.status, navigateTo]);
 
-  let userDetailsRequestUserId: number | null = null;
-  let userDetailsRequestLogin: string | null = null;
-  if (
-    userDetailsRouteState.status === 'error'
-    || userDetailsRouteState.status === 'ready'
-    || (
-      userDetailsRouteState.status === 'loading'
-      && userDetailsRouteState.userSummary !== null
-    )
-  ) {
-    userDetailsRequestUserId = userDetailsRouteState.selectedUser.id;
-    userDetailsRequestLogin = userDetailsRouteState.selectedUser.login;
-  }
-  const userDetailsRequestDataset = userDetailsRequestUserId === null
-    ? null
-    : aggregatedMetrics;
+  const userDetailsRequest = currentView === VIEW_MODES.USER_DETAILS
+    && userDetailsReadModel.status === 'resolved'
+    ? userDetailsReadModel
+    : null;
+  const userDetailsRequestUserId = userDetailsRequest?.selectedUser.id ?? null;
+  const userDetailsRequestLogin = userDetailsRequest?.selectedUser.login ?? null;
+  const userDetailsRequestDataset = userDetailsRequest?.datasetKey ?? null;
 
   useEffect(() => {
     if (!userDetailsRequestDataset || userDetailsRequestUserId === null) {
@@ -181,9 +180,6 @@ const ViewRouter: React.FC = () => {
   const { 
     stats, 
     userSummaries, 
-    engagementData, 
-    chatUsersData, 
-    chatRequestsData, 
     languageStats,
     featureAdoptionData,
     agentModeHeatmapData,
@@ -212,17 +208,16 @@ const ViewRouter: React.FC = () => {
     dailyAiCreditsData = [],
     usageDistributionData = [],
   } = aggregatedMetrics;
+  const overviewReadModel = selectOverviewReadModel(aggregatedMetrics);
+  const executiveSummaryReadModel = selectExecutiveSummaryReadModel(aggregatedMetrics);
+  const usersReadModel = selectUsersReadModel(aggregatedMetrics);
 
   switch (currentView) {
     case VIEW_MODES.EXECUTIVE_SUMMARY:
       return (
         <ExecutiveSummaryView
-          stats={stats}
+          model={executiveSummaryReadModel}
           enterpriseName={enterpriseName}
-          joinedImpactData={joinedImpactData}
-          agentImpactData={agentImpactData}
-          codeCompletionImpactData={codeCompletionImpactData}
-          featureAdoptionData={featureAdoptionData}
         />
       );
 
@@ -323,7 +318,7 @@ const ViewRouter: React.FC = () => {
     case VIEW_MODES.USERS:
       return (
         <UniqueUsersView 
-          users={userSummaries} 
+          model={usersReadModel}
           onUserClick={handleUserClick}
         />
       );
@@ -378,10 +373,7 @@ const ViewRouter: React.FC = () => {
 
       return (
         <UserDetailsView
-          userDetails={userDetailsRouteState.details}
-          userSummary={userDetailsRouteState.userSummary}
-          userLogin={userDetailsRouteState.selectedUser.login}
-          userId={userDetailsRouteState.selectedUser.id}
+          model={userDetailsRouteState.model}
         />
       );
 
@@ -396,11 +388,8 @@ const ViewRouter: React.FC = () => {
     default:
       return (
         <OverviewDashboard
-          stats={stats}
+          model={overviewReadModel}
           enterpriseName={enterpriseName}
-          engagementData={engagementData}
-          chatUsersData={chatUsersData}
-          chatRequestsData={chatRequestsData}
         />
       );
   }

--- a/src/components/layout/__tests__/ViewRouter.test.tsx
+++ b/src/components/layout/__tests__/ViewRouter.test.tsx
@@ -3,8 +3,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { makeMetric } from '../../../__tests__/factories/metrics';
 import {
   aggregateMetrics,
-  type AggregatedMetrics,
 } from '../../../domain/metricsAggregator';
+import type { AggregatedMetrics } from '../../../types/aggregatedMetrics';
 import { VIEW_MODES } from '../../../types/navigation';
 import ViewRouter from '../ViewRouter';
 

--- a/src/components/layout/__tests__/userDetailsRouteState.test.ts
+++ b/src/components/layout/__tests__/userDetailsRouteState.test.ts
@@ -55,9 +55,12 @@ const details: UserDetailedMetrics = {
 function resolve(loadState: UserDetailsLoadState) {
   return resolveUserDetailsRouteState({
     currentView: VIEW_MODES.USER_DETAILS,
-    selectedUser,
-    userSummaries: [userSummary],
-    dataset,
+    routeModel: {
+      status: 'resolved',
+      selectedUser,
+      userSummary,
+      datasetKey: dataset,
+    },
     loadState,
   });
 }
@@ -66,9 +69,12 @@ describe('resolveUserDetailsRouteState', () => {
   it('returns inactive outside the user-details view', () => {
     const state = resolveUserDetailsRouteState({
       currentView: VIEW_MODES.USERS,
-      selectedUser,
-      userSummaries: [userSummary],
-      dataset,
+      routeModel: {
+        status: 'resolved',
+        selectedUser,
+        userSummary,
+        datasetKey: dataset,
+      },
       loadState: { status: 'idle' },
     });
 
@@ -78,9 +84,7 @@ describe('resolveUserDetailsRouteState', () => {
   it('redirects when no user is selected', () => {
     const state = resolveUserDetailsRouteState({
       currentView: VIEW_MODES.USER_DETAILS,
-      selectedUser: null,
-      userSummaries: [userSummary],
-      dataset,
+      routeModel: { status: 'missing-selection' },
       loadState: { status: 'idle' },
     });
 
@@ -90,9 +94,7 @@ describe('resolveUserDetailsRouteState', () => {
   it('redirects when the selected user has no aggregate summary', () => {
     const state = resolveUserDetailsRouteState({
       currentView: VIEW_MODES.USER_DETAILS,
-      selectedUser,
-      userSummaries: [],
-      dataset,
+      routeModel: { status: 'missing-summary', selectedUser },
       loadState: { status: 'idle' },
     });
 
@@ -122,7 +124,15 @@ describe('resolveUserDetailsRouteState', () => {
       dataset,
       userId: selectedUser.id,
       details,
-    })).toMatchObject({ status: 'ready', details, userSummary });
+    })).toMatchObject({
+      status: 'ready',
+      model: {
+        userDetails: details,
+        userSummary,
+        userLogin: selectedUser.login,
+        userId: selectedUser.id,
+      },
+    });
   });
 
   it('treats results from an obsolete dataset as loading', () => {

--- a/src/components/layout/userDetailsRouteState.ts
+++ b/src/components/layout/userDetailsRouteState.ts
@@ -1,4 +1,9 @@
 import type { UserDetailedMetrics } from '../../types/aggregatedMetrics';
+import {
+  selectUserDetailsViewModel,
+  type UserDetailsRouteReadModel,
+  type UserDetailsViewModel,
+} from '../../read-models/userDetails';
 import type { UserSummary } from '../../types/metrics';
 import type { SelectedUser, ViewMode } from '../../types/navigation';
 import { VIEW_MODES } from '../../types/navigation';
@@ -14,58 +19,52 @@ export type UserDetailsRouteState =
   | { status: 'redirect'; reason: 'missing-selection' | 'missing-summary' }
   | { status: 'loading'; selectedUser: SelectedUser; userSummary: UserSummary | null }
   | { status: 'error'; selectedUser: SelectedUser; userSummary: UserSummary; message: string }
-  | {
-      status: 'ready';
-      selectedUser: SelectedUser;
-      userSummary: UserSummary;
-      details: UserDetailedMetrics;
-    };
+  | { status: 'ready'; model: UserDetailsViewModel };
 
 interface ResolveUserDetailsRouteStateOptions {
   currentView: ViewMode;
-  selectedUser: SelectedUser | null;
-  userSummaries: UserSummary[] | null;
-  dataset: object | null;
+  routeModel: UserDetailsRouteReadModel;
   loadState: UserDetailsLoadState;
 }
 
 export function resolveUserDetailsRouteState({
   currentView,
-  selectedUser,
-  userSummaries,
-  dataset,
+  routeModel,
   loadState,
 }: ResolveUserDetailsRouteStateOptions): UserDetailsRouteState {
   if (currentView !== VIEW_MODES.USER_DETAILS) {
     return { status: 'inactive' };
   }
 
-  if (!selectedUser) {
+  if (routeModel.status === 'missing-selection') {
     return { status: 'redirect', reason: 'missing-selection' };
   }
 
-  if (!userSummaries || !dataset) {
-    return { status: 'loading', selectedUser, userSummary: null };
+  if (routeModel.status === 'pending') {
+    return { status: 'loading', selectedUser: routeModel.selectedUser, userSummary: null };
   }
 
-  const userSummary = userSummaries.find((summary) => summary.user_id === selectedUser.id);
-  if (!userSummary) {
+  if (routeModel.status === 'missing-summary') {
     return { status: 'redirect', reason: 'missing-summary' };
   }
 
   if (
     loadState.status === 'idle'
-    || loadState.dataset !== dataset
-    || loadState.userId !== selectedUser.id
+    || loadState.dataset !== routeModel.datasetKey
+    || loadState.userId !== routeModel.selectedUser.id
   ) {
-    return { status: 'loading', selectedUser, userSummary };
+    return {
+      status: 'loading',
+      selectedUser: routeModel.selectedUser,
+      userSummary: routeModel.userSummary,
+    };
   }
 
   if (loadState.status === 'error') {
     return {
       status: 'error',
-      selectedUser,
-      userSummary,
+      selectedUser: routeModel.selectedUser,
+      userSummary: routeModel.userSummary,
       message: loadState.message,
     };
   }
@@ -73,11 +72,13 @@ export function resolveUserDetailsRouteState({
   if (loadState.status === 'ready') {
     return {
       status: 'ready',
-      selectedUser,
-      userSummary,
-      details: loadState.details,
+      model: selectUserDetailsViewModel(routeModel, loadState.details),
     };
   }
 
-  return { status: 'loading', selectedUser, userSummary };
+  return {
+    status: 'loading',
+    selectedUser: routeModel.selectedUser,
+    userSummary: routeModel.userSummary,
+  };
 }

--- a/src/domain/metricsAggregator.ts
+++ b/src/domain/metricsAggregator.ts
@@ -1,13 +1,8 @@
 import {
   CopilotMetrics,
-  MetricsStats,
   UserSummary,
-  IDEStatsData,
-  PluginVersionAnalysisData,
-  LanguageFeatureImpactData,
-  DailyLanguageChartData,
-  ModelBreakdownData,
 } from '../types/metrics';
+import type { AggregatedMetrics } from '../types/aggregatedMetrics';
 import { resolveCopilotCloudAgentUsage } from './copilotCloudAgentUsage';
 import {
   createStatsAccumulator,
@@ -17,34 +12,26 @@ import {
   accumulateModelEngagement,
   computeStats,
 
-  DailyEngagementData,
-  DailyAdoptionTrend,
   createEngagementAccumulator,
   accumulateEngagement,
   computeEngagementData,
   computeAdoptionTrend,
 
-  DailyChatUsersData,
-  DailyChatRequestsData,
   createChatAccumulator,
   accumulateChatFeature,
   computeChatUsersData,
   computeChatRequestsData,
 
-  LanguageStats,
   createLanguageAccumulator,
   accumulateLanguageStats,
   computeLanguageStats,
 
-  DailyModelUsageData,
-  AgentModeHeatmapData,
   createModelUsageAccumulator,
   accumulateModelFeature,
   accumulateAgentHeatmapFromFeature,
   computeDailyModelUsageData,
   computeAgentModeHeatmapData,
 
-  FeatureAdoptionData,
   createFeatureAdoptionAccumulator,
   accumulateFeatureAdoption,
   accumulateCliAdoption,
@@ -52,10 +39,7 @@ import {
   accumulateCodeReviewAdoption,
   computeFeatureAdoptionData,
 
-  AgentImpactData,
-  CodeCompletionImpactData,
-  ModeImpactData,
-  FeatureImpactInput,
+  type FeatureImpactInput,
   createImpactAccumulator,
   ensureImpactDates,
   createFeatureImpactInput,
@@ -87,13 +71,10 @@ import {
   accumulateModelBreakdown,
   computeModelBreakdownData,
 
-  UserDetailAccumulator,
+  type UserDetailAccumulator,
   createUserDetailAccumulator,
   accumulateUserDetail,
 
-  DailyCliSessionData,
-  DailyCliTokenData,
-  DailyCliAdoptionTrend,
   createCliUsageAccumulator,
   accumulateCliUsage,
   ensureCliDates,
@@ -101,65 +82,24 @@ import {
   computeDailyCliTokenData,
   computeCliAdoptionTrend,
 
-  DailyCloudAgentAdoptionData,
-  DailyCodeReviewAdoptionData,
   createAdvancedAdoptionAccumulator,
   accumulateCloudAgentAdoption,
   accumulateCodeReviewAdoptionSignal,
   computeDailyCloudAgentAdoptionData,
   computeDailyCodeReviewAdoptionData,
 
-  AiAdoptionPhaseData,
   createAiAdoptionPhaseAccumulator,
   accumulateAiAdoptionPhase,
   computeAiAdoptionPhaseData,
 
-  UsageDistributionBucket,
   computeUsageDistributionData,
 
-  DailyAiCreditsData,
   createAiCreditsAccumulator,
   accumulateAiCredits,
   computeDailyAiCreditsData,
 } from './calculators';
 import { isActiveAutoModeFeature } from './autoMode';
 import { getCanonicalUserInitiatedInteractionCount } from './assumedInteractions';
-
-export interface AggregatedMetrics {
-  stats: MetricsStats;
-  userSummaries: UserSummary[];
-  engagementData: DailyEngagementData[];
-  chatUsersData: DailyChatUsersData[];
-  chatRequestsData: DailyChatRequestsData[];
-  languageStats: LanguageStats[];
-  modelUsageData: DailyModelUsageData[];
-  featureAdoptionData: FeatureAdoptionData;
-  agentModeHeatmapData: AgentModeHeatmapData[];
-  agentImpactData: AgentImpactData[];
-  codeCompletionImpactData: CodeCompletionImpactData[];
-  editModeImpactData: ModeImpactData[];
-  inlineModeImpactData: ModeImpactData[];
-  askModeImpactData: ModeImpactData[];
-  cliImpactData: ModeImpactData[];
-  joinedImpactData: ModeImpactData[];
-  ideStats: IDEStatsData[];
-  multiIDEUsersCount: number;
-  totalUniqueIDEUsers: number;
-  pluginVersionData: PluginVersionAnalysisData;
-  languageFeatureImpactData: LanguageFeatureImpactData;
-  dailyLanguageGenerationsData: DailyLanguageChartData;
-  dailyLanguageLocData: DailyLanguageChartData;
-  modelBreakdownData: ModelBreakdownData;
-  dailyCliSessionData: DailyCliSessionData[];
-  dailyCliTokenData: DailyCliTokenData[];
-  dailyCliAdoptionTrend: DailyCliAdoptionTrend[];
-  dailyAdoptionTrend: DailyAdoptionTrend[];
-  dailyCloudAgentAdoptionData: DailyCloudAgentAdoptionData[];
-  dailyCodeReviewAdoptionData: DailyCodeReviewAdoptionData[];
-  aiAdoptionPhaseData: AiAdoptionPhaseData[];
-  usageDistributionData: UsageDistributionBucket[];
-  dailyAiCreditsData: DailyAiCreditsData[];
-}
 
 interface UserSummaryAccumulator {
   userMap: Map<number, UserSummary>;

--- a/src/read-models/__tests__/featureReadModels.test.ts
+++ b/src/read-models/__tests__/featureReadModels.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from 'vitest';
+import {
+  makeAggregatedMetrics,
+  makeUserSummary,
+} from '../../__tests__/factories/aggregatedMetrics';
+import {
+  selectExecutiveSummaryReadModel,
+  selectOverviewReadModel,
+} from '../overview';
+import { selectUserDetailsRouteReadModel } from '../userDetails';
+import { selectUsersReadModel } from '../users';
+
+describe('feature read models', () => {
+  it('selects only overview fields and preserves series references', () => {
+    const metrics = makeAggregatedMetrics();
+    const model = selectOverviewReadModel(metrics);
+
+    expect(model).toEqual({
+      reportStartDay: metrics.stats.reportStartDay,
+      reportEndDay: metrics.stats.reportEndDay,
+      engagementData: metrics.engagementData,
+      chatUsersData: metrics.chatUsersData,
+      chatRequestsData: metrics.chatRequestsData,
+    });
+    expect(model.engagementData).toBe(metrics.engagementData);
+    expect(model.chatUsersData).toBe(metrics.chatUsersData);
+    expect(model.chatRequestsData).toBe(metrics.chatRequestsData);
+    expect(Object.keys(model)).toEqual([
+      'reportStartDay',
+      'reportEndDay',
+      'engagementData',
+      'chatUsersData',
+      'chatRequestsData',
+    ]);
+  });
+
+  it('selects only executive-summary fields and preserves aggregate references', () => {
+    const metrics = makeAggregatedMetrics();
+    const model = selectExecutiveSummaryReadModel(metrics);
+
+    expect(model).toEqual({
+      reportStartDay: metrics.stats.reportStartDay,
+      reportEndDay: metrics.stats.reportEndDay,
+      joinedImpactData: metrics.joinedImpactData,
+      agentImpactData: metrics.agentImpactData,
+      codeCompletionImpactData: metrics.codeCompletionImpactData,
+      featureAdoptionData: metrics.featureAdoptionData,
+    });
+    expect(model.joinedImpactData).toBe(metrics.joinedImpactData);
+    expect(model.agentImpactData).toBe(metrics.agentImpactData);
+    expect(model.codeCompletionImpactData).toBe(metrics.codeCompletionImpactData);
+    expect(model.featureAdoptionData).toBe(metrics.featureAdoptionData);
+    expect(Object.keys(model)).toEqual([
+      'reportStartDay',
+      'reportEndDay',
+      'joinedImpactData',
+      'agentImpactData',
+      'codeCompletionImpactData',
+      'featureAdoptionData',
+    ]);
+  });
+
+  it('projects the users list without copying it', () => {
+    const users = [makeUserSummary()];
+    const metrics = makeAggregatedMetrics({ userSummaries: users });
+    const model = selectUsersReadModel(metrics);
+
+    expect(model).toEqual({ users });
+    expect(model.users).toBe(users);
+    expect(Object.keys(model)).toEqual(['users']);
+  });
+
+  it('resolves a selected user while preserving summary and dataset identity', () => {
+    const userSummary = makeUserSummary();
+    const metrics = makeAggregatedMetrics({ userSummaries: [userSummary] });
+    const selectedUser = { id: userSummary.user_id, login: userSummary.user_login };
+
+    const model = selectUserDetailsRouteReadModel(metrics, selectedUser);
+
+    expect(model).toEqual({
+      status: 'resolved',
+      selectedUser,
+      userSummary,
+      datasetKey: metrics,
+    });
+    if (model.status === 'resolved') {
+      expect(model.userSummary).toBe(userSummary);
+      expect(model.datasetKey).toBe(metrics);
+      expect(Object.keys(model)).toEqual([
+        'status',
+        'selectedUser',
+        'userSummary',
+        'datasetKey',
+      ]);
+    }
+  });
+
+  it('distinguishes missing selection, pending data, and a missing summary', () => {
+    const selectedUser = { id: 404, login: 'missing' };
+
+    expect(selectUserDetailsRouteReadModel(null, null)).toEqual({
+      status: 'missing-selection',
+    });
+    expect(selectUserDetailsRouteReadModel(null, selectedUser)).toEqual({
+      status: 'pending',
+      selectedUser,
+    });
+    expect(
+      selectUserDetailsRouteReadModel(makeAggregatedMetrics(), selectedUser)
+    ).toEqual({
+      status: 'missing-summary',
+      selectedUser,
+    });
+  });
+
+  it('does not mutate the aggregate input', () => {
+    const metrics = makeAggregatedMetrics({
+      userSummaries: [makeUserSummary()],
+    });
+    const before = structuredClone(metrics);
+
+    selectOverviewReadModel(metrics);
+    selectExecutiveSummaryReadModel(metrics);
+    selectUsersReadModel(metrics);
+    selectUserDetailsRouteReadModel(metrics, { id: 42, login: 'octocat' });
+
+    expect(metrics).toEqual(before);
+  });
+});

--- a/src/read-models/overview.ts
+++ b/src/read-models/overview.ts
@@ -1,0 +1,41 @@
+import type { AggregatedMetrics } from '../types/aggregatedMetrics';
+
+export interface OverviewReadModel {
+  reportStartDay: string;
+  reportEndDay: string;
+  engagementData: AggregatedMetrics['engagementData'];
+  chatUsersData: AggregatedMetrics['chatUsersData'];
+  chatRequestsData: AggregatedMetrics['chatRequestsData'];
+}
+
+export interface ExecutiveSummaryReadModel {
+  reportStartDay: string;
+  reportEndDay: string;
+  joinedImpactData: AggregatedMetrics['joinedImpactData'];
+  agentImpactData: AggregatedMetrics['agentImpactData'];
+  codeCompletionImpactData: AggregatedMetrics['codeCompletionImpactData'];
+  featureAdoptionData: AggregatedMetrics['featureAdoptionData'];
+}
+
+export function selectOverviewReadModel(metrics: AggregatedMetrics): OverviewReadModel {
+  return {
+    reportStartDay: metrics.stats.reportStartDay,
+    reportEndDay: metrics.stats.reportEndDay,
+    engagementData: metrics.engagementData,
+    chatUsersData: metrics.chatUsersData,
+    chatRequestsData: metrics.chatRequestsData,
+  };
+}
+
+export function selectExecutiveSummaryReadModel(
+  metrics: AggregatedMetrics
+): ExecutiveSummaryReadModel {
+  return {
+    reportStartDay: metrics.stats.reportStartDay,
+    reportEndDay: metrics.stats.reportEndDay,
+    joinedImpactData: metrics.joinedImpactData,
+    agentImpactData: metrics.agentImpactData,
+    codeCompletionImpactData: metrics.codeCompletionImpactData,
+    featureAdoptionData: metrics.featureAdoptionData,
+  };
+}

--- a/src/read-models/userDetails.ts
+++ b/src/read-models/userDetails.ts
@@ -1,0 +1,64 @@
+import type { AggregatedMetrics, UserDetailedMetrics } from '../types/aggregatedMetrics';
+import type { UserSummary } from '../types/metrics';
+import type { SelectedUser } from '../types/navigation';
+
+export type UserDetailsRouteReadModel =
+  | { status: 'missing-selection' }
+  | { status: 'pending'; selectedUser: SelectedUser }
+  | { status: 'missing-summary'; selectedUser: SelectedUser }
+  | {
+      status: 'resolved';
+      selectedUser: SelectedUser;
+      userSummary: UserSummary;
+      datasetKey: object;
+    };
+
+export type ResolvedUserDetailsReadModel = Extract<
+  UserDetailsRouteReadModel,
+  { status: 'resolved' }
+>;
+
+export interface UserDetailsViewModel {
+  userDetails: UserDetailedMetrics;
+  userSummary: UserSummary;
+  userLogin: string;
+  userId: number;
+}
+
+export function selectUserDetailsRouteReadModel(
+  metrics: AggregatedMetrics | null,
+  selectedUser: SelectedUser | null
+): UserDetailsRouteReadModel {
+  if (!selectedUser) {
+    return { status: 'missing-selection' };
+  }
+  if (!metrics) {
+    return { status: 'pending', selectedUser };
+  }
+
+  const userSummary = metrics.userSummaries.find(
+    (summary) => summary.user_id === selectedUser.id
+  );
+  if (!userSummary) {
+    return { status: 'missing-summary', selectedUser };
+  }
+
+  return {
+    status: 'resolved',
+    selectedUser,
+    userSummary,
+    datasetKey: metrics,
+  };
+}
+
+export function selectUserDetailsViewModel(
+  routeModel: ResolvedUserDetailsReadModel,
+  userDetails: UserDetailedMetrics
+): UserDetailsViewModel {
+  return {
+    userDetails,
+    userSummary: routeModel.userSummary,
+    userLogin: routeModel.selectedUser.login,
+    userId: routeModel.selectedUser.id,
+  };
+}

--- a/src/read-models/users.ts
+++ b/src/read-models/users.ts
@@ -1,0 +1,11 @@
+import type { AggregatedMetrics } from '../types/aggregatedMetrics';
+
+export interface UsersReadModel {
+  users: AggregatedMetrics['userSummaries'];
+}
+
+export function selectUsersReadModel(metrics: AggregatedMetrics): UsersReadModel {
+  return {
+    users: metrics.userSummaries,
+  };
+}

--- a/src/types/aggregatedMetrics.ts
+++ b/src/types/aggregatedMetrics.ts
@@ -1,10 +1,70 @@
-import type { UserDayData } from './metrics';
 import type {
+  DailyLanguageChartData,
+  IDEStatsData,
+  LanguageFeatureImpactData,
+  MetricsStats,
+  ModelBreakdownData,
+  PluginVersionAnalysisData,
+  UserDayData,
+  UserSummary,
+} from './metrics';
+import type {
+  AgentModeHeatmapData,
   DailyModelUsageData,
+  DailyEngagementData,
+  DailyAdoptionTrend,
+  DailyChatUsersData,
+  DailyChatRequestsData,
+  LanguageStats,
+  FeatureAdoptionData,
   AgentImpactData,
   CodeCompletionImpactData,
   ModeImpactData,
-} from '../domain/calculators/metricCalculators';
+  DailyCliSessionData,
+  DailyCliTokenData,
+  DailyCliAdoptionTrend,
+  DailyCloudAgentAdoptionData,
+  DailyCodeReviewAdoptionData,
+  AiAdoptionPhaseData,
+  UsageDistributionBucket,
+  DailyAiCreditsData,
+} from '../domain/calculators';
+
+export interface AggregatedMetrics {
+  stats: MetricsStats;
+  userSummaries: UserSummary[];
+  engagementData: DailyEngagementData[];
+  chatUsersData: DailyChatUsersData[];
+  chatRequestsData: DailyChatRequestsData[];
+  languageStats: LanguageStats[];
+  modelUsageData: DailyModelUsageData[];
+  featureAdoptionData: FeatureAdoptionData;
+  agentModeHeatmapData: AgentModeHeatmapData[];
+  agentImpactData: AgentImpactData[];
+  codeCompletionImpactData: CodeCompletionImpactData[];
+  editModeImpactData: ModeImpactData[];
+  inlineModeImpactData: ModeImpactData[];
+  askModeImpactData: ModeImpactData[];
+  cliImpactData: ModeImpactData[];
+  joinedImpactData: ModeImpactData[];
+  ideStats: IDEStatsData[];
+  multiIDEUsersCount: number;
+  totalUniqueIDEUsers: number;
+  pluginVersionData: PluginVersionAnalysisData;
+  languageFeatureImpactData: LanguageFeatureImpactData;
+  dailyLanguageGenerationsData: DailyLanguageChartData;
+  dailyLanguageLocData: DailyLanguageChartData;
+  modelBreakdownData: ModelBreakdownData;
+  dailyCliSessionData: DailyCliSessionData[];
+  dailyCliTokenData: DailyCliTokenData[];
+  dailyCliAdoptionTrend: DailyCliAdoptionTrend[];
+  dailyAdoptionTrend: DailyAdoptionTrend[];
+  dailyCloudAgentAdoptionData: DailyCloudAgentAdoptionData[];
+  dailyCodeReviewAdoptionData: DailyCodeReviewAdoptionData[];
+  aiAdoptionPhaseData: AiAdoptionPhaseData[];
+  usageDistributionData: UsageDistributionBucket[];
+  dailyAiCreditsData: DailyAiCreditsData[];
+}
 
 export interface UserDetailedMetrics {
   totalModelRequests: number;

--- a/src/workers/metricsWorkerClient.ts
+++ b/src/workers/metricsWorkerClient.ts
@@ -1,5 +1,4 @@
-import type { AggregatedMetrics } from '../domain/metricsAggregator';
-import type { UserDetailedMetrics } from '../types/aggregatedMetrics';
+import type { AggregatedMetrics, UserDetailedMetrics } from '../types/aggregatedMetrics';
 import type { MultiFileProgress, MultiFileResult } from '../infra/metricsFileParser';
 import type { WorkerRequest, WorkerResponse } from './types';
 import { getBasePath } from '../utils/basePath';

--- a/src/workers/types.ts
+++ b/src/workers/types.ts
@@ -1,5 +1,4 @@
-import type { AggregatedMetrics } from '../domain/metricsAggregator';
-import type { UserDetailedMetrics } from '../types/aggregatedMetrics';
+import type { AggregatedMetrics, UserDetailedMetrics } from '../types/aggregatedMetrics';
 import type { MultiFileProgress, MultiFileResult } from '../infra/metricsFileParser';
 
 export type WorkerRequest =


### PR DESCRIPTION
## Why

This insulates UI consumers from the flat aggregate contract before later aggregation-internal and worker-payload refactors. It establishes narrow, typed feature boundaries without changing worker behavior or user-visible results.

| Commit | Change |
|--------|--------|
| `refactor: move aggregate contract to shared types` | Makes `src/types/aggregatedMetrics.ts` the neutral canonical worker/UI contract. |
| `refactor: add initial feature read models` | Adds pure overview, executive summary, users, and user-details projections, rewires consumers, and covers the boundaries with focused tests. |
| `docs: document feature read-model boundary` | Updates the architecture and data-flow documentation while keeping the flat worker payload explicit. |