### PR TITLE
Add adoption and impact read-model boundaries

### DIFF
--- a/docs/project-overview.md
+++ b/docs/project-overview.md
@@ -41,7 +41,7 @@ Next.js App Router SPA, TypeScript, Tailwind CSS. All rendering is client-side.
 - `MetricsContext` (`src/components/MetricsContext.tsx`) — stores the `AggregatedMetrics` result, loading/error/warning state, and data actions
 - `NavigationContext` (`src/state/NavigationContext.tsx`) — manages current view, selected user/model, and navigation actions
 
-**All view components consume pre-aggregated data.** No component accesses raw `CopilotMetrics[]` directly. The flat `AggregatedMetrics` worker/UI contract is declared in `src/types/aggregatedMetrics.ts`. Feature read-model selectors in `src/read-models/` insulate migrated UI paths from that flat payload; overview, executive summary, users, and user details consume only their typed projections. The worker also retains a compact user-detail accumulator so it can serve user details on demand without moving raw records onto the main thread.
+**All view components consume pre-aggregated data.** No component accesses raw `CopilotMetrics[]` directly. The flat `AggregatedMetrics` worker/UI contract is declared in `src/types/aggregatedMetrics.ts`. Feature read-model selectors in `src/read-models/` insulate migrated UI paths from that flat payload; overview, executive summary, users, user details, Copilot adoption, AI adoption phases, and Copilot impact consume only their typed projections. The worker also retains a compact user-detail accumulator so it can serve user details on demand without moving raw records onto the main thread.
 
 ### 3.2. Code Organization
 
@@ -63,6 +63,19 @@ Next.js App Router SPA, TypeScript, Tailwind CSS. All rendering is client-side.
 ### 3.3. Model Configuration
 
 `src/domain/modelConfig.ts` contains a curated catalog of known LLM models. Calculators use model helpers for normalization, known-model alias recognition, and explicit unknown/empty model detection.
+
+### 3.4. Feature Read-Model Boundaries
+
+The worker payload remains the flat `AggregatedMetrics` object. Pure selectors under `src/read-models/` project stable references from that payload into narrow UI contracts without copying, sorting, filtering, mutation, or additional aggregation.
+
+Established boundaries cover:
+- overview and executive summary
+- users and on-demand user details
+- Copilot adoption
+- AI adoption phases
+- Copilot impact
+
+Remaining Phase 4 slices are languages, clients and client versions, models and CLI, and AI credits. Grouping the worker payload, moving component files, and decomposing the general `ViewRouter` registry remain separate work.
 
 ---
 

--- a/src/components/AiAdoptionPhaseView.tsx
+++ b/src/components/AiAdoptionPhaseView.tsx
@@ -5,14 +5,16 @@ import MetricsTable, { TableColumn } from './ui/MetricsTable';
 import { ViewPanel } from './ui';
 import TopEntriesList from './ui/TopEntriesList';
 import { AI_ADOPTION_PHASE_SECTIONS } from './layout/contextSections';
-import type { AiAdoptionPhaseData } from '../domain/calculators/metricCalculators';
+import type { AiAdoptionPhaseReadModel } from '../read-models/aiAdoptionPhases';
 import { formatAiAdoptionPhase, formatAiCreditCost, formatModelDisplayName, formatNumber } from '../utils/formatters';
 import { formatIDEName, getIDEIcon } from './icons/IDEIcons';
 import { getModelIcon } from './icons/ModelIcons';
 
 interface AiAdoptionPhaseViewProps {
-  phaseData: AiAdoptionPhaseData[];
+  model: AiAdoptionPhaseReadModel;
 }
+
+type AiAdoptionPhaseData = AiAdoptionPhaseReadModel['aiAdoptionPhaseData'][number];
 
 const AI_ADOPTION_PHASE_BLOG_URL = 'https://github.blog/changelog/2026-05-29-copilot-usage-metrics-api-adds-cohorts-for-ai-adoption/#whats-new';
 const PHASE_PILL_CLASS = 'inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-purple-100 text-purple-800';
@@ -45,7 +47,8 @@ function formatAverage(value: number): string {
   return formatNumber(value, 1);
 }
 
-export default function AiAdoptionPhaseView({ phaseData }: AiAdoptionPhaseViewProps) {
+export default function AiAdoptionPhaseView({ model }: AiAdoptionPhaseViewProps) {
+  const { aiAdoptionPhaseData } = model;
   const rightHeaderClass = 'px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider';
   const rightCellClass = 'px-6 py-4 whitespace-nowrap text-sm text-gray-900 text-right';
   const [comparisonSection, assignmentSection] = AI_ADOPTION_PHASE_SECTIONS;
@@ -164,7 +167,7 @@ export default function AiAdoptionPhaseView({ phaseData }: AiAdoptionPhaseViewPr
           <p className="mt-1 text-sm text-gray-600">Averages are calculated per user in each phase.</p>
         </div>
         <MetricsTable<AiAdoptionPhaseData>
-          data={phaseData}
+          data={aiAdoptionPhaseData}
           columns={columns}
           tableClassName="w-full divide-y divide-gray-200"
           tableContainerClassName="overflow-x-auto"

--- a/src/components/CopilotAdoptionView.tsx
+++ b/src/components/CopilotAdoptionView.tsx
@@ -8,25 +8,13 @@ import CloudAgentAdoptionChart from './charts/CloudAgentAdoptionChart';
 import CodeReviewAdoptionChart from './charts/CodeReviewAdoptionChart';
 import { ViewPanel } from './ui';
 import { COPILOT_ADOPTION_SECTIONS } from './layout/contextSections';
-import type {
-  FeatureAdoptionData,
-  AgentModeHeatmapData,
-  DailyAdoptionTrend,
-  DailyCloudAgentAdoptionData,
-  DailyCodeReviewAdoptionData,
-} from '../domain/calculators/metricCalculators';
-import type { MetricsStats } from '../types/metrics';
+import type { CopilotAdoptionReadModel } from '../read-models/adoption';
 
 interface CopilotAdoptionViewProps {
-  featureAdoptionData: FeatureAdoptionData | null;
-  agentModeHeatmapData: AgentModeHeatmapData[];
-  stats: MetricsStats;
-  dailyAdoptionTrend: DailyAdoptionTrend[];
-  dailyCloudAgentAdoptionData?: DailyCloudAgentAdoptionData[];
-  dailyCodeReviewAdoptionData?: DailyCodeReviewAdoptionData[];
+  model: CopilotAdoptionReadModel;
 }
 
-const EMPTY_FEATURE_ADOPTION_DATA: FeatureAdoptionData = {
+const EMPTY_FEATURE_ADOPTION_DATA: CopilotAdoptionReadModel['featureAdoptionData'] = {
   totalUsers: 0,
   completionUsers: 0,
   completionOnlyUsers: 0,
@@ -41,14 +29,15 @@ const EMPTY_FEATURE_ADOPTION_DATA: FeatureAdoptionData = {
   advancedUsers: 0,
 };
 
-export default function CopilotAdoptionView({
-  featureAdoptionData,
-  agentModeHeatmapData,
-  stats,
-  dailyAdoptionTrend,
-  dailyCloudAgentAdoptionData = [],
-  dailyCodeReviewAdoptionData = [],
-}: CopilotAdoptionViewProps) {
+export default function CopilotAdoptionView({ model }: CopilotAdoptionViewProps) {
+  const {
+    featureAdoptionData,
+    agentModeHeatmapData,
+    stats,
+    dailyAdoptionTrend,
+    dailyCloudAgentAdoptionData,
+    dailyCodeReviewAdoptionData,
+  } = model;
   const adoptionData = featureAdoptionData ?? EMPTY_FEATURE_ADOPTION_DATA;
   const hasCloudAgentAdoption = adoptionData.codingAgentUsers > 0;
   const hasCodeReviewAdoption = adoptionData.codeReviewUsers > 0;

--- a/src/components/CopilotImpactView.tsx
+++ b/src/components/CopilotImpactView.tsx
@@ -5,18 +5,22 @@ import ModeImpactChart from './charts/ModeImpactChart';
 import { ViewPanel } from './ui';
 import InsightsCard from './ui/InsightsCard';
 import { COPILOT_IMPACT_SECTIONS } from './layout/contextSections';
-import type { AgentImpactData, CodeCompletionImpactData, ModeImpactData } from '../domain/calculators/metricCalculators';
+import type { CopilotImpactReadModel } from '../read-models/impact';
+
 interface CopilotImpactViewProps {
-  agentImpactData: AgentImpactData[];
-  codeCompletionImpactData: CodeCompletionImpactData[];
-  editModeImpactData: ModeImpactData[];
-  inlineModeImpactData: ModeImpactData[];
-  askModeImpactData: ModeImpactData[];
-  cliImpactData: ModeImpactData[];
-  joinedImpactData: ModeImpactData[];
+  model: CopilotImpactReadModel;
 }
 
-export default function CopilotImpactView({ agentImpactData, codeCompletionImpactData, editModeImpactData, inlineModeImpactData, askModeImpactData, cliImpactData, joinedImpactData }: CopilotImpactViewProps) {
+export default function CopilotImpactView({ model }: CopilotImpactViewProps) {
+  const {
+    agentImpactData,
+    codeCompletionImpactData,
+    editModeImpactData,
+    inlineModeImpactData,
+    askModeImpactData,
+    cliImpactData,
+    joinedImpactData,
+  } = model;
   const [
     combinedSection,
     agentSection,

--- a/src/components/layout/ViewRouter.tsx
+++ b/src/components/layout/ViewRouter.tsx
@@ -11,6 +11,9 @@ import {
   selectExecutiveSummaryReadModel,
   selectOverviewReadModel,
 } from '../../read-models/overview';
+import { selectCopilotAdoptionReadModel } from '../../read-models/adoption';
+import { selectAiAdoptionPhaseReadModel } from '../../read-models/aiAdoptionPhases';
+import { selectCopilotImpactReadModel } from '../../read-models/impact';
 import { selectUsersReadModel } from '../../read-models/users';
 import { selectUserDetailsRouteReadModel } from '../../read-models/userDetails';
 import {
@@ -181,15 +184,7 @@ const ViewRouter: React.FC = () => {
     stats, 
     userSummaries, 
     languageStats,
-    featureAdoptionData,
-    agentModeHeatmapData,
-    agentImpactData,
-    codeCompletionImpactData,
-    editModeImpactData,
-    inlineModeImpactData,
-    askModeImpactData,
     cliImpactData,
-    joinedImpactData,
     ideStats,
     multiIDEUsersCount,
     totalUniqueIDEUsers,
@@ -201,15 +196,14 @@ const ViewRouter: React.FC = () => {
     dailyCliSessionData,
     dailyCliTokenData,
     dailyCliAdoptionTrend,
-    dailyAdoptionTrend,
-    dailyCloudAgentAdoptionData = [],
-    dailyCodeReviewAdoptionData = [],
-    aiAdoptionPhaseData = [],
     dailyAiCreditsData = [],
     usageDistributionData = [],
   } = aggregatedMetrics;
   const overviewReadModel = selectOverviewReadModel(aggregatedMetrics);
   const executiveSummaryReadModel = selectExecutiveSummaryReadModel(aggregatedMetrics);
+  const copilotAdoptionReadModel = selectCopilotAdoptionReadModel(aggregatedMetrics);
+  const aiAdoptionPhaseReadModel = selectAiAdoptionPhaseReadModel(aggregatedMetrics);
+  const copilotImpactReadModel = selectCopilotImpactReadModel(aggregatedMetrics);
   const usersReadModel = selectUsersReadModel(aggregatedMetrics);
 
   switch (currentView) {
@@ -269,32 +263,21 @@ const ViewRouter: React.FC = () => {
     case VIEW_MODES.COPILOT_IMPACT:
       return (
         <CopilotImpactView
-          agentImpactData={agentImpactData}
-          codeCompletionImpactData={codeCompletionImpactData}
-          editModeImpactData={editModeImpactData}
-          inlineModeImpactData={inlineModeImpactData}
-          askModeImpactData={askModeImpactData}
-          cliImpactData={cliImpactData}
-          joinedImpactData={joinedImpactData}
+          model={copilotImpactReadModel}
         />
       );
 
     case VIEW_MODES.COPILOT_ADOPTION:
       return (
         <CopilotAdoptionView
-          featureAdoptionData={featureAdoptionData}
-          agentModeHeatmapData={agentModeHeatmapData}
-          stats={stats}
-          dailyAdoptionTrend={dailyAdoptionTrend}
-          dailyCloudAgentAdoptionData={dailyCloudAgentAdoptionData}
-          dailyCodeReviewAdoptionData={dailyCodeReviewAdoptionData}
+          model={copilotAdoptionReadModel}
         />
       );
 
     case VIEW_MODES.AI_ADOPTION_PHASES:
       return (
         <AiAdoptionPhaseView
-          phaseData={aiAdoptionPhaseData}
+          model={aiAdoptionPhaseReadModel}
         />
       );
 

--- a/src/components/layout/__tests__/ViewRouter.test.tsx
+++ b/src/components/layout/__tests__/ViewRouter.test.tsx
@@ -5,13 +5,26 @@ import {
   aggregateMetrics,
 } from '../../../domain/metricsAggregator';
 import type { AggregatedMetrics } from '../../../types/aggregatedMetrics';
-import { VIEW_MODES } from '../../../types/navigation';
+import { VIEW_MODES, type ViewMode } from '../../../types/navigation';
+import type { CopilotAdoptionReadModel } from '../../../read-models/adoption';
+import type { AiAdoptionPhaseReadModel } from '../../../read-models/aiAdoptionPhases';
+import type { CopilotImpactReadModel } from '../../../read-models/impact';
 import ViewRouter from '../ViewRouter';
 
 const mocks = vi.hoisted(() => ({
   navigateTo: vi.fn(),
+  currentView: 'userDetails' as ViewMode,
   selectedUser: null as { id: number; login: string } | null,
   aggregatedMetrics: null as AggregatedMetrics | null,
+  copilotAdoptionView: vi.fn<
+    (props: { model: CopilotAdoptionReadModel }) => void
+  >(),
+  aiAdoptionPhaseView: vi.fn<
+    (props: { model: AiAdoptionPhaseReadModel }) => void
+  >(),
+  copilotImpactView: vi.fn<
+    (props: { model: CopilotImpactReadModel }) => void
+  >(),
 }));
 
 vi.mock('../../MetricsContext', () => ({
@@ -26,7 +39,7 @@ vi.mock('../../MetricsContext', () => ({
 
 vi.mock('../../../state/NavigationContext', () => ({
   useNavigation: () => ({
-    currentView: VIEW_MODES.USER_DETAILS,
+    currentView: mocks.currentView,
     selectedUser: mocks.selectedUser,
     navigateTo: mocks.navigateTo,
     selectUser: vi.fn(),
@@ -53,24 +66,101 @@ vi.mock('../../../workers/MetricsWorkerContext', () => ({
   }),
 }));
 
-describe('ViewRouter user-detail redirects', () => {
+vi.mock('../../CopilotAdoptionView', () => ({
+  default: (props: { model: CopilotAdoptionReadModel }) => {
+    mocks.copilotAdoptionView(props);
+    return null;
+  },
+}));
+
+vi.mock('../../AiAdoptionPhaseView', () => ({
+  default: (props: { model: AiAdoptionPhaseReadModel }) => {
+    mocks.aiAdoptionPhaseView(props);
+    return null;
+  },
+}));
+
+vi.mock('../../CopilotImpactView', () => ({
+  default: (props: { model: CopilotImpactReadModel }) => {
+    mocks.copilotImpactView(props);
+    return null;
+  },
+}));
+
+describe('ViewRouter', () => {
   beforeEach(() => {
     mocks.navigateTo.mockClear();
+    mocks.copilotAdoptionView.mockClear();
+    mocks.aiAdoptionPhaseView.mockClear();
+    mocks.copilotImpactView.mockClear();
+    mocks.currentView = VIEW_MODES.USER_DETAILS;
     mocks.selectedUser = null;
     mocks.aggregatedMetrics = aggregateMetrics([makeMetric()]).aggregated;
   });
 
-  it('does not navigate during render when no user is selected', () => {
-    renderToStaticMarkup(<ViewRouter />);
+  describe('user-detail redirects', () => {
+    it('does not navigate during render when no user is selected', () => {
+      renderToStaticMarkup(<ViewRouter />);
 
-    expect(mocks.navigateTo).not.toHaveBeenCalled();
+      expect(mocks.navigateTo).not.toHaveBeenCalled();
+    });
+
+    it('does not navigate during render when the selected user summary is missing', () => {
+      mocks.selectedUser = { id: 999, login: 'missing-user' };
+
+      renderToStaticMarkup(<ViewRouter />);
+
+      expect(mocks.navigateTo).not.toHaveBeenCalled();
+    });
   });
 
-  it('does not navigate during render when the selected user summary is missing', () => {
-    mocks.selectedUser = { id: 999, login: 'missing-user' };
+  it('routes Copilot adoption through one cohesive read model', () => {
+    mocks.currentView = VIEW_MODES.COPILOT_ADOPTION;
 
     renderToStaticMarkup(<ViewRouter />);
 
-    expect(mocks.navigateTo).not.toHaveBeenCalled();
+    expect(mocks.copilotAdoptionView).toHaveBeenCalledOnce();
+    const props = mocks.copilotAdoptionView.mock.calls[0][0];
+    expect(Object.keys(props)).toEqual(['model']);
+    expect(props.model).toEqual({
+      featureAdoptionData: mocks.aggregatedMetrics?.featureAdoptionData,
+      agentModeHeatmapData: mocks.aggregatedMetrics?.agentModeHeatmapData,
+      stats: mocks.aggregatedMetrics?.stats,
+      dailyAdoptionTrend: mocks.aggregatedMetrics?.dailyAdoptionTrend,
+      dailyCloudAgentAdoptionData: mocks.aggregatedMetrics?.dailyCloudAgentAdoptionData,
+      dailyCodeReviewAdoptionData: mocks.aggregatedMetrics?.dailyCodeReviewAdoptionData,
+    });
+  });
+
+  it('routes AI adoption phases through one cohesive read model', () => {
+    mocks.currentView = VIEW_MODES.AI_ADOPTION_PHASES;
+
+    renderToStaticMarkup(<ViewRouter />);
+
+    expect(mocks.aiAdoptionPhaseView).toHaveBeenCalledOnce();
+    const props = mocks.aiAdoptionPhaseView.mock.calls[0][0];
+    expect(Object.keys(props)).toEqual(['model']);
+    expect(props.model).toEqual({
+      aiAdoptionPhaseData: mocks.aggregatedMetrics?.aiAdoptionPhaseData,
+    });
+  });
+
+  it('routes Copilot impact through one cohesive read model', () => {
+    mocks.currentView = VIEW_MODES.COPILOT_IMPACT;
+
+    renderToStaticMarkup(<ViewRouter />);
+
+    expect(mocks.copilotImpactView).toHaveBeenCalledOnce();
+    const props = mocks.copilotImpactView.mock.calls[0][0];
+    expect(Object.keys(props)).toEqual(['model']);
+    expect(props.model).toEqual({
+      agentImpactData: mocks.aggregatedMetrics?.agentImpactData,
+      codeCompletionImpactData: mocks.aggregatedMetrics?.codeCompletionImpactData,
+      editModeImpactData: mocks.aggregatedMetrics?.editModeImpactData,
+      inlineModeImpactData: mocks.aggregatedMetrics?.inlineModeImpactData,
+      askModeImpactData: mocks.aggregatedMetrics?.askModeImpactData,
+      cliImpactData: mocks.aggregatedMetrics?.cliImpactData,
+      joinedImpactData: mocks.aggregatedMetrics?.joinedImpactData,
+    });
   });
 });

--- a/src/read-models/__tests__/adoptionImpactReadModels.test.ts
+++ b/src/read-models/__tests__/adoptionImpactReadModels.test.ts
@@ -1,0 +1,204 @@
+import { describe, expect, it } from 'vitest';
+import { makeAggregatedMetrics } from '../../__tests__/factories/aggregatedMetrics';
+import type { AggregatedMetrics } from '../../types/aggregatedMetrics';
+import {
+  selectCopilotAdoptionReadModel,
+} from '../adoption';
+import {
+  selectAiAdoptionPhaseReadModel,
+} from '../aiAdoptionPhases';
+import { selectCopilotImpactReadModel } from '../impact';
+
+const IMPACT_POINT = {
+  date: '2026-01-15',
+  locAdded: 12,
+  locDeleted: 3,
+  netChange: 9,
+  userCount: 2,
+  totalUniqueUsers: 4,
+};
+
+function makeFeatureMetrics(): AggregatedMetrics {
+  const defaults = makeAggregatedMetrics();
+
+  return makeAggregatedMetrics({
+    featureAdoptionData: {
+      ...defaults.featureAdoptionData,
+      totalUsers: 4,
+      agentModeUsers: 2,
+    },
+    agentModeHeatmapData: [{
+      date: '2026-01-15',
+      agentModeRequests: 8,
+      uniqueUsers: 2,
+      intensity: 4,
+    }],
+    stats: {
+      ...defaults.stats,
+      reportStartDay: '2026-01-15',
+      reportEndDay: '2026-01-16',
+    },
+    dailyAdoptionTrend: [{
+      date: '2026-01-15',
+      newUsers: 2,
+      returningUsers: 1,
+      totalActiveUsers: 3,
+      cumulativeUsers: 4,
+    }],
+    dailyCloudAgentAdoptionData: [{
+      date: '2026-01-15',
+      uniqueUsers: 1,
+    }],
+    dailyCodeReviewAdoptionData: [{
+      date: '2026-01-15',
+      activeUsers: 1,
+      passiveUsers: 1,
+      totalUsers: 2,
+    }],
+    aiAdoptionPhaseData: [{
+      phase: {
+        phase_number: 2,
+        phase: 'Phase 2',
+        version: 'v1',
+      },
+      userCount: 2,
+      avgUserInitiatedInteractions: 5,
+      totalLocAdded: 20,
+      totalLocDeleted: 4,
+      avgLocAdded: 10,
+      avgLocDeleted: 2,
+      avgAiCreditsUsed: 1.5,
+      avgDaysActive: 3,
+      topModels: [{ name: 'gpt-4.1', total: 8, uniqueUsers: 2 }],
+      topClients: [{ name: 'vscode', total: 7, uniqueUsers: 2 }],
+      topLanguages: [{ name: 'typescript', total: 6, uniqueUsers: 2 }],
+    }],
+    agentImpactData: [{ ...IMPACT_POINT, locAdded: 13, netChange: 10 }],
+    codeCompletionImpactData: [{ ...IMPACT_POINT, locAdded: 14, netChange: 11 }],
+    editModeImpactData: [{ ...IMPACT_POINT, locAdded: 15, netChange: 12 }],
+    inlineModeImpactData: [{ ...IMPACT_POINT, locAdded: 16, netChange: 13 }],
+    askModeImpactData: [{ ...IMPACT_POINT, locAdded: 17, netChange: 14 }],
+    cliImpactData: [{ ...IMPACT_POINT, locAdded: 18, netChange: 15 }],
+    joinedImpactData: [{ ...IMPACT_POINT, locAdded: 19, netChange: 16 }],
+  });
+}
+
+describe('adoption and impact read models', () => {
+  it('selects the exact Copilot adoption shape and preserves every reference', () => {
+    const metrics = makeFeatureMetrics();
+
+    const model = selectCopilotAdoptionReadModel(metrics);
+
+    expect(model).toEqual({
+      featureAdoptionData: metrics.featureAdoptionData,
+      agentModeHeatmapData: metrics.agentModeHeatmapData,
+      stats: metrics.stats,
+      dailyAdoptionTrend: metrics.dailyAdoptionTrend,
+      dailyCloudAgentAdoptionData: metrics.dailyCloudAgentAdoptionData,
+      dailyCodeReviewAdoptionData: metrics.dailyCodeReviewAdoptionData,
+    });
+    expect(model.featureAdoptionData).toBe(metrics.featureAdoptionData);
+    expect(model.agentModeHeatmapData).toBe(metrics.agentModeHeatmapData);
+    expect(model.stats).toBe(metrics.stats);
+    expect(model.dailyAdoptionTrend).toBe(metrics.dailyAdoptionTrend);
+    expect(model.dailyCloudAgentAdoptionData).toBe(metrics.dailyCloudAgentAdoptionData);
+    expect(model.dailyCodeReviewAdoptionData).toBe(metrics.dailyCodeReviewAdoptionData);
+    expect(Object.keys(model)).toEqual([
+      'featureAdoptionData',
+      'agentModeHeatmapData',
+      'stats',
+      'dailyAdoptionTrend',
+      'dailyCloudAgentAdoptionData',
+      'dailyCodeReviewAdoptionData',
+    ]);
+    expect(model).not.toHaveProperty('userSummaries');
+  });
+
+  it('selects the exact AI adoption phase shape without copying it', () => {
+    const metrics = makeFeatureMetrics();
+
+    const model = selectAiAdoptionPhaseReadModel(metrics);
+
+    expect(model).toEqual({
+      aiAdoptionPhaseData: metrics.aiAdoptionPhaseData,
+    });
+    expect(model.aiAdoptionPhaseData).toBe(metrics.aiAdoptionPhaseData);
+    expect(Object.keys(model)).toEqual(['aiAdoptionPhaseData']);
+    expect(model).not.toHaveProperty('featureAdoptionData');
+  });
+
+  it('selects the exact Copilot impact shape and preserves every series reference', () => {
+    const metrics = makeFeatureMetrics();
+
+    const model = selectCopilotImpactReadModel(metrics);
+
+    expect(model).toEqual({
+      agentImpactData: metrics.agentImpactData,
+      codeCompletionImpactData: metrics.codeCompletionImpactData,
+      editModeImpactData: metrics.editModeImpactData,
+      inlineModeImpactData: metrics.inlineModeImpactData,
+      askModeImpactData: metrics.askModeImpactData,
+      cliImpactData: metrics.cliImpactData,
+      joinedImpactData: metrics.joinedImpactData,
+    });
+    expect(model.agentImpactData).toBe(metrics.agentImpactData);
+    expect(model.codeCompletionImpactData).toBe(metrics.codeCompletionImpactData);
+    expect(model.editModeImpactData).toBe(metrics.editModeImpactData);
+    expect(model.inlineModeImpactData).toBe(metrics.inlineModeImpactData);
+    expect(model.askModeImpactData).toBe(metrics.askModeImpactData);
+    expect(model.cliImpactData).toBe(metrics.cliImpactData);
+    expect(model.joinedImpactData).toBe(metrics.joinedImpactData);
+    expect(Object.keys(model)).toEqual([
+      'agentImpactData',
+      'codeCompletionImpactData',
+      'editModeImpactData',
+      'inlineModeImpactData',
+      'askModeImpactData',
+      'cliImpactData',
+      'joinedImpactData',
+    ]);
+    expect(model).not.toHaveProperty('stats');
+  });
+
+  it('preserves canonical empty arrays', () => {
+    const metrics = makeAggregatedMetrics();
+
+    const adoption = selectCopilotAdoptionReadModel(metrics);
+    const phases = selectAiAdoptionPhaseReadModel(metrics);
+    const impact = selectCopilotImpactReadModel(metrics);
+
+    expect(adoption.agentModeHeatmapData).toBe(metrics.agentModeHeatmapData);
+    expect(adoption.dailyAdoptionTrend).toBe(metrics.dailyAdoptionTrend);
+    expect(adoption.dailyCloudAgentAdoptionData).toBe(metrics.dailyCloudAgentAdoptionData);
+    expect(adoption.dailyCodeReviewAdoptionData).toBe(metrics.dailyCodeReviewAdoptionData);
+    expect(phases.aiAdoptionPhaseData).toBe(metrics.aiAdoptionPhaseData);
+    expect(Object.values(impact)).toEqual([
+      metrics.agentImpactData,
+      metrics.codeCompletionImpactData,
+      metrics.editModeImpactData,
+      metrics.inlineModeImpactData,
+      metrics.askModeImpactData,
+      metrics.cliImpactData,
+      metrics.joinedImpactData,
+    ]);
+    expect([
+      adoption.agentModeHeatmapData,
+      adoption.dailyAdoptionTrend,
+      adoption.dailyCloudAgentAdoptionData,
+      adoption.dailyCodeReviewAdoptionData,
+      phases.aiAdoptionPhaseData,
+      ...Object.values(impact),
+    ].every((series) => series.length === 0)).toBe(true);
+  });
+
+  it('does not mutate the aggregate input', () => {
+    const metrics = makeFeatureMetrics();
+    const before = structuredClone(metrics);
+
+    selectCopilotAdoptionReadModel(metrics);
+    selectAiAdoptionPhaseReadModel(metrics);
+    selectCopilotImpactReadModel(metrics);
+
+    expect(metrics).toEqual(before);
+  });
+});

--- a/src/read-models/adoption.ts
+++ b/src/read-models/adoption.ts
@@ -1,0 +1,23 @@
+import type { AggregatedMetrics } from '../types/aggregatedMetrics';
+
+export interface CopilotAdoptionReadModel {
+  featureAdoptionData: AggregatedMetrics['featureAdoptionData'];
+  agentModeHeatmapData: AggregatedMetrics['agentModeHeatmapData'];
+  stats: AggregatedMetrics['stats'];
+  dailyAdoptionTrend: AggregatedMetrics['dailyAdoptionTrend'];
+  dailyCloudAgentAdoptionData: AggregatedMetrics['dailyCloudAgentAdoptionData'];
+  dailyCodeReviewAdoptionData: AggregatedMetrics['dailyCodeReviewAdoptionData'];
+}
+
+export function selectCopilotAdoptionReadModel(
+  metrics: AggregatedMetrics
+): CopilotAdoptionReadModel {
+  return {
+    featureAdoptionData: metrics.featureAdoptionData,
+    agentModeHeatmapData: metrics.agentModeHeatmapData,
+    stats: metrics.stats,
+    dailyAdoptionTrend: metrics.dailyAdoptionTrend,
+    dailyCloudAgentAdoptionData: metrics.dailyCloudAgentAdoptionData,
+    dailyCodeReviewAdoptionData: metrics.dailyCodeReviewAdoptionData,
+  };
+}

--- a/src/read-models/aiAdoptionPhases.ts
+++ b/src/read-models/aiAdoptionPhases.ts
@@ -1,0 +1,13 @@
+import type { AggregatedMetrics } from '../types/aggregatedMetrics';
+
+export interface AiAdoptionPhaseReadModel {
+  aiAdoptionPhaseData: AggregatedMetrics['aiAdoptionPhaseData'];
+}
+
+export function selectAiAdoptionPhaseReadModel(
+  metrics: AggregatedMetrics
+): AiAdoptionPhaseReadModel {
+  return {
+    aiAdoptionPhaseData: metrics.aiAdoptionPhaseData,
+  };
+}

--- a/src/read-models/impact.ts
+++ b/src/read-models/impact.ts
@@ -1,0 +1,25 @@
+import type { AggregatedMetrics } from '../types/aggregatedMetrics';
+
+export interface CopilotImpactReadModel {
+  agentImpactData: AggregatedMetrics['agentImpactData'];
+  codeCompletionImpactData: AggregatedMetrics['codeCompletionImpactData'];
+  editModeImpactData: AggregatedMetrics['editModeImpactData'];
+  inlineModeImpactData: AggregatedMetrics['inlineModeImpactData'];
+  askModeImpactData: AggregatedMetrics['askModeImpactData'];
+  cliImpactData: AggregatedMetrics['cliImpactData'];
+  joinedImpactData: AggregatedMetrics['joinedImpactData'];
+}
+
+export function selectCopilotImpactReadModel(
+  metrics: AggregatedMetrics
+): CopilotImpactReadModel {
+  return {
+    agentImpactData: metrics.agentImpactData,
+    codeCompletionImpactData: metrics.codeCompletionImpactData,
+    editModeImpactData: metrics.editModeImpactData,
+    inlineModeImpactData: metrics.inlineModeImpactData,
+    askModeImpactData: metrics.askModeImpactData,
+    cliImpactData: metrics.cliImpactData,
+    joinedImpactData: metrics.joinedImpactData,
+  };
+}


### PR DESCRIPTION
## Why

This continues insulating UI consumers from the flat `AggregatedMetrics` contract before later worker-payload and aggregator refactors. Adoption, AI-adoption-phase, and impact views now depend on narrow typed projections while the worker payload remains unchanged.

| Commit | Change |
|--------|--------|
| `refactor: add adoption and impact read models` | Add pure selectors with stable references, rewire the three views and router, and protect the contracts with focused tests. |
| `docs: document adoption and impact read models` | Record the established read-model boundaries, flat worker payload, and remaining Phase 4 slices. |