### PR TITLE
Add language read-model boundary

### DIFF
--- a/docs/project-overview.md
+++ b/docs/project-overview.md
@@ -41,7 +41,7 @@ Next.js App Router SPA, TypeScript, Tailwind CSS. All rendering is client-side.
 - `MetricsContext` (`src/components/MetricsContext.tsx`) — stores the `AggregatedMetrics` result, loading/error/warning state, and data actions
 - `NavigationContext` (`src/state/NavigationContext.tsx`) — manages current view, selected user/model, and navigation actions
 
-**All view components consume pre-aggregated data.** No component accesses raw `CopilotMetrics[]` directly. The flat `AggregatedMetrics` worker/UI contract is declared in `src/types/aggregatedMetrics.ts`. Feature read-model selectors in `src/read-models/` insulate migrated UI paths from that flat payload; overview, executive summary, users, user details, Copilot adoption, AI adoption phases, and Copilot impact consume only their typed projections. The worker also retains a compact user-detail accumulator so it can serve user details on demand without moving raw records onto the main thread.
+**All view components consume pre-aggregated data.** No component accesses raw `CopilotMetrics[]` directly. The flat `AggregatedMetrics` worker/UI contract is declared in `src/types/aggregatedMetrics.ts`. Feature read-model selectors in `src/read-models/` insulate migrated UI paths from that flat payload; overview, executive summary, users, user details, Copilot adoption, AI adoption phases, Copilot impact, and languages consume only their typed projections. The worker also retains a compact user-detail accumulator so it can serve user details on demand without moving raw records onto the main thread.
 
 ### 3.2. Code Organization
 
@@ -74,8 +74,9 @@ Established boundaries cover:
 - Copilot adoption
 - AI adoption phases
 - Copilot impact
+- languages
 
-Remaining Phase 4 slices are languages, clients and client versions, models and CLI, and AI credits. Grouping the worker payload, moving component files, and decomposing the general `ViewRouter` registry remain separate work.
+Remaining Phase 4 slices are clients and client versions, models and CLI, and AI credits. The worker payload remains flat; grouping it, moving component files, and decomposing the general `ViewRouter` registry remain separate work.
 
 ---
 

--- a/src/components/LanguagesView.tsx
+++ b/src/components/LanguagesView.tsx
@@ -4,17 +4,14 @@ import { LanguageStats } from '../domain/calculators/metricCalculators';
 import { useMemo, useState } from 'react';
 import MetricsTable, { SortState as TableSortState, TableColumn } from './ui/MetricsTable';
 import { DashboardStatsCardGroup, ViewPanel } from './ui';
-import type { LanguageFeatureImpactData, DailyLanguageChartData } from '../types/metrics';
 import LanguageDailyChart from './charts/LanguageDailyChart';
 import { translateFeature } from '../domain/featureTranslations';
 import { sortBySelector, rankBySelector } from '../utils/sorting';
 import { LANGUAGES_SECTIONS } from './layout/contextSections';
+import type { LanguagesReadModel } from '../read-models/languages';
 
 interface LanguagesViewProps {
-  languages: LanguageStats[];
-  languageFeatureImpactData: LanguageFeatureImpactData;
-  dailyLanguageGenerationsData: DailyLanguageChartData;
-  dailyLanguageLocData: DailyLanguageChartData;
+  model: LanguagesReadModel;
 }
 
 type SortField = 'language' | 'totalGenerations' | 'totalAcceptances' | 'totalEngagements' | 'uniqueUsers' | 'locAdded' | 'locDeleted' | 'locSuggestedToAdd' | 'locSuggestedToDelete';
@@ -25,7 +22,13 @@ const formatAcceptanceRate = (lang: LanguageStats) => {
     : '0.0';
 };
 
-export default function LanguagesView({ languages, languageFeatureImpactData, dailyLanguageGenerationsData, dailyLanguageLocData }: LanguagesViewProps) {
+export default function LanguagesView({ model }: LanguagesViewProps) {
+  const {
+    languageStats: languages,
+    languageFeatureImpactData,
+    dailyLanguageGenerationsData,
+    dailyLanguageLocData,
+  } = model;
   const [tableSortState, setTableSortState] = useState<TableSortState>({
     field: 'totalEngagements',
     direction: 'desc',

--- a/src/components/layout/ViewRouter.tsx
+++ b/src/components/layout/ViewRouter.tsx
@@ -14,6 +14,7 @@ import {
 import { selectCopilotAdoptionReadModel } from '../../read-models/adoption';
 import { selectAiAdoptionPhaseReadModel } from '../../read-models/aiAdoptionPhases';
 import { selectCopilotImpactReadModel } from '../../read-models/impact';
+import { selectLanguagesReadModel } from '../../read-models/languages';
 import { selectUsersReadModel } from '../../read-models/users';
 import { selectUserDetailsRouteReadModel } from '../../read-models/userDetails';
 import {
@@ -183,15 +184,11 @@ const ViewRouter: React.FC = () => {
   const { 
     stats, 
     userSummaries, 
-    languageStats,
     cliImpactData,
     ideStats,
     multiIDEUsersCount,
     totalUniqueIDEUsers,
     pluginVersionData,
-    languageFeatureImpactData,
-    dailyLanguageGenerationsData,
-    dailyLanguageLocData,
     modelBreakdownData,
     dailyCliSessionData,
     dailyCliTokenData,
@@ -204,6 +201,7 @@ const ViewRouter: React.FC = () => {
   const copilotAdoptionReadModel = selectCopilotAdoptionReadModel(aggregatedMetrics);
   const aiAdoptionPhaseReadModel = selectAiAdoptionPhaseReadModel(aggregatedMetrics);
   const copilotImpactReadModel = selectCopilotImpactReadModel(aggregatedMetrics);
+  const languagesReadModel = selectLanguagesReadModel(aggregatedMetrics);
   const usersReadModel = selectUsersReadModel(aggregatedMetrics);
 
   switch (currentView) {
@@ -240,10 +238,7 @@ const ViewRouter: React.FC = () => {
     case VIEW_MODES.LANGUAGES:
       return (
         <LanguagesView
-          languages={languageStats}
-          languageFeatureImpactData={languageFeatureImpactData}
-          dailyLanguageGenerationsData={dailyLanguageGenerationsData}
-          dailyLanguageLocData={dailyLanguageLocData}
+          model={languagesReadModel}
         />
       );
 

--- a/src/components/layout/__tests__/ViewRouter.test.tsx
+++ b/src/components/layout/__tests__/ViewRouter.test.tsx
@@ -9,6 +9,7 @@ import { VIEW_MODES, type ViewMode } from '../../../types/navigation';
 import type { CopilotAdoptionReadModel } from '../../../read-models/adoption';
 import type { AiAdoptionPhaseReadModel } from '../../../read-models/aiAdoptionPhases';
 import type { CopilotImpactReadModel } from '../../../read-models/impact';
+import type { LanguagesReadModel } from '../../../read-models/languages';
 import ViewRouter from '../ViewRouter';
 
 const mocks = vi.hoisted(() => ({
@@ -24,6 +25,12 @@ const mocks = vi.hoisted(() => ({
   >(),
   copilotImpactView: vi.fn<
     (props: { model: CopilotImpactReadModel }) => void
+  >(),
+  languagesView: vi.fn<
+    (props: { model: LanguagesReadModel }) => void
+  >(),
+  selectLanguagesReadModel: vi.fn<
+    (metrics: AggregatedMetrics) => LanguagesReadModel
   >(),
 }));
 
@@ -87,15 +94,34 @@ vi.mock('../../CopilotImpactView', () => ({
   },
 }));
 
+vi.mock('../../LanguagesView', () => ({
+  default: (props: { model: LanguagesReadModel }) => {
+    mocks.languagesView(props);
+    return null;
+  },
+}));
+
+vi.mock('../../../read-models/languages', () => ({
+  selectLanguagesReadModel: mocks.selectLanguagesReadModel,
+}));
+
 describe('ViewRouter', () => {
   beforeEach(() => {
     mocks.navigateTo.mockClear();
     mocks.copilotAdoptionView.mockClear();
     mocks.aiAdoptionPhaseView.mockClear();
     mocks.copilotImpactView.mockClear();
+    mocks.languagesView.mockClear();
+    mocks.selectLanguagesReadModel.mockReset();
     mocks.currentView = VIEW_MODES.USER_DETAILS;
     mocks.selectedUser = null;
     mocks.aggregatedMetrics = aggregateMetrics([makeMetric()]).aggregated;
+    mocks.selectLanguagesReadModel.mockImplementation((metrics) => ({
+      languageStats: metrics.languageStats,
+      languageFeatureImpactData: metrics.languageFeatureImpactData,
+      dailyLanguageGenerationsData: metrics.dailyLanguageGenerationsData,
+      dailyLanguageLocData: metrics.dailyLanguageLocData,
+    }));
   });
 
   describe('user-detail redirects', () => {
@@ -162,5 +188,24 @@ describe('ViewRouter', () => {
       cliImpactData: mocks.aggregatedMetrics?.cliImpactData,
       joinedImpactData: mocks.aggregatedMetrics?.joinedImpactData,
     });
+  });
+
+  it('routes languages through one cohesive read model', () => {
+    mocks.currentView = VIEW_MODES.LANGUAGES;
+    const expectedModel = {
+      languageStats: mocks.aggregatedMetrics!.languageStats,
+      languageFeatureImpactData: mocks.aggregatedMetrics!.languageFeatureImpactData,
+      dailyLanguageGenerationsData: mocks.aggregatedMetrics!.dailyLanguageGenerationsData,
+      dailyLanguageLocData: mocks.aggregatedMetrics!.dailyLanguageLocData,
+    };
+    mocks.selectLanguagesReadModel.mockReturnValueOnce(expectedModel);
+
+    renderToStaticMarkup(<ViewRouter />);
+
+    expect(mocks.selectLanguagesReadModel).toHaveBeenCalledWith(mocks.aggregatedMetrics);
+    expect(mocks.languagesView).toHaveBeenCalledOnce();
+    const props = mocks.languagesView.mock.calls[0][0];
+    expect(Object.keys(props)).toEqual(['model']);
+    expect(props.model).toBe(expectedModel);
   });
 });

--- a/src/read-models/__tests__/languagesReadModel.test.ts
+++ b/src/read-models/__tests__/languagesReadModel.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from 'vitest';
+import { makeAggregatedMetrics } from '../../__tests__/factories/aggregatedMetrics';
+import type { AggregatedMetrics } from '../../types/aggregatedMetrics';
+import { selectLanguagesReadModel } from '../languages';
+
+function makeLanguageMetrics(): AggregatedMetrics {
+  return makeAggregatedMetrics({
+    languageStats: [{
+      language: 'typescript',
+      totalGenerations: 12,
+      totalAcceptances: 6,
+      totalEngagements: 18,
+      uniqueUsers: 2,
+      locAdded: 24,
+      locDeleted: 4,
+      locSuggestedToAdd: 30,
+      locSuggestedToDelete: 5,
+    }],
+    languageFeatureImpactData: {
+      features: ['code_completion'],
+      rows: [{
+        language: 'typescript',
+        total: 28,
+        features: { code_completion: 28 },
+      }],
+    },
+    dailyLanguageGenerationsData: {
+      dates: ['2026-01-15'],
+      languages: ['typescript'],
+      data: { '2026-01-15': { typescript: 12 } },
+      totals: { typescript: 12 },
+    },
+    dailyLanguageLocData: {
+      dates: ['2026-01-15'],
+      languages: ['typescript'],
+      data: { '2026-01-15': { typescript: 28 } },
+      totals: { typescript: 28 },
+    },
+  });
+}
+
+describe('languages read model', () => {
+  it('selects the exact language shape and preserves every reference', () => {
+    const metrics = makeLanguageMetrics();
+
+    const model = selectLanguagesReadModel(metrics);
+
+    expect(model).toEqual({
+      languageStats: metrics.languageStats,
+      languageFeatureImpactData: metrics.languageFeatureImpactData,
+      dailyLanguageGenerationsData: metrics.dailyLanguageGenerationsData,
+      dailyLanguageLocData: metrics.dailyLanguageLocData,
+    });
+    expect(model.languageStats).toBe(metrics.languageStats);
+    expect(model.languageFeatureImpactData).toBe(metrics.languageFeatureImpactData);
+    expect(model.dailyLanguageGenerationsData).toBe(metrics.dailyLanguageGenerationsData);
+    expect(model.dailyLanguageLocData).toBe(metrics.dailyLanguageLocData);
+    expect(model.languageStats[0]).toBe(metrics.languageStats[0]);
+    expect(model.languageFeatureImpactData.features).toBe(
+      metrics.languageFeatureImpactData.features
+    );
+    expect(model.languageFeatureImpactData.rows).toBe(
+      metrics.languageFeatureImpactData.rows
+    );
+    expect(model.languageFeatureImpactData.rows[0]).toBe(
+      metrics.languageFeatureImpactData.rows[0]
+    );
+    expect(model.languageFeatureImpactData.rows[0].features).toBe(
+      metrics.languageFeatureImpactData.rows[0].features
+    );
+    expect(model.dailyLanguageGenerationsData.dates).toBe(
+      metrics.dailyLanguageGenerationsData.dates
+    );
+    expect(model.dailyLanguageGenerationsData.languages).toBe(
+      metrics.dailyLanguageGenerationsData.languages
+    );
+    expect(model.dailyLanguageGenerationsData.data).toBe(
+      metrics.dailyLanguageGenerationsData.data
+    );
+    expect(model.dailyLanguageGenerationsData.data['2026-01-15']).toBe(
+      metrics.dailyLanguageGenerationsData.data['2026-01-15']
+    );
+    expect(model.dailyLanguageGenerationsData.totals).toBe(
+      metrics.dailyLanguageGenerationsData.totals
+    );
+    expect(model.dailyLanguageLocData.dates).toBe(
+      metrics.dailyLanguageLocData.dates
+    );
+    expect(model.dailyLanguageLocData.languages).toBe(
+      metrics.dailyLanguageLocData.languages
+    );
+    expect(model.dailyLanguageLocData.data).toBe(
+      metrics.dailyLanguageLocData.data
+    );
+    expect(model.dailyLanguageLocData.data['2026-01-15']).toBe(
+      metrics.dailyLanguageLocData.data['2026-01-15']
+    );
+    expect(model.dailyLanguageLocData.totals).toBe(
+      metrics.dailyLanguageLocData.totals
+    );
+    expect(Object.keys(model)).toEqual([
+      'languageStats',
+      'languageFeatureImpactData',
+      'dailyLanguageGenerationsData',
+      'dailyLanguageLocData',
+    ]);
+    expect(model).not.toHaveProperty('stats');
+    expect(model).not.toHaveProperty('userSummaries');
+    expect(model).not.toHaveProperty('modelBreakdownData');
+  });
+
+  it('preserves canonical empty language data', () => {
+    const metrics = makeAggregatedMetrics();
+
+    const model = selectLanguagesReadModel(metrics);
+
+    expect(model.languageStats).toBe(metrics.languageStats);
+    expect(model.languageFeatureImpactData).toBe(metrics.languageFeatureImpactData);
+    expect(model.dailyLanguageGenerationsData).toBe(metrics.dailyLanguageGenerationsData);
+    expect(model.dailyLanguageLocData).toBe(metrics.dailyLanguageLocData);
+    expect(model).toEqual({
+      languageStats: [],
+      languageFeatureImpactData: {
+        features: [],
+        rows: [],
+      },
+      dailyLanguageGenerationsData: {
+        dates: [],
+        languages: [],
+        data: {},
+        totals: {},
+      },
+      dailyLanguageLocData: {
+        dates: [],
+        languages: [],
+        data: {},
+        totals: {},
+      },
+    });
+  });
+
+  it('does not mutate the aggregate input', () => {
+    const metrics = makeLanguageMetrics();
+    const before = structuredClone(metrics);
+
+    selectLanguagesReadModel(metrics);
+
+    expect(metrics).toEqual(before);
+  });
+});

--- a/src/read-models/languages.ts
+++ b/src/read-models/languages.ts
@@ -1,0 +1,19 @@
+import type { AggregatedMetrics } from '../types/aggregatedMetrics';
+
+export interface LanguagesReadModel {
+  languageStats: AggregatedMetrics['languageStats'];
+  languageFeatureImpactData: AggregatedMetrics['languageFeatureImpactData'];
+  dailyLanguageGenerationsData: AggregatedMetrics['dailyLanguageGenerationsData'];
+  dailyLanguageLocData: AggregatedMetrics['dailyLanguageLocData'];
+}
+
+export function selectLanguagesReadModel(
+  metrics: AggregatedMetrics
+): LanguagesReadModel {
+  return {
+    languageStats: metrics.languageStats,
+    languageFeatureImpactData: metrics.languageFeatureImpactData,
+    dailyLanguageGenerationsData: metrics.dailyLanguageGenerationsData,
+    dailyLanguageLocData: metrics.dailyLanguageLocData,
+  };
+}


### PR DESCRIPTION
## Why

The languages UI still depended directly on four flat aggregate fields. This change adds a narrow, reference-preserving read-model boundary while keeping the worker payload and runtime behavior unchanged.

| Commit | Change |
|--------|--------|
| `refactor: add languages read-model boundary` | Add the typed selector, route LanguagesView through one model prop, and cover identity, shape, empty data, mutation, and routing contracts. |
| `docs: document languages read model` | Mark languages as covered and identify the remaining Phase 4 slices while preserving the flat worker-payload constraint. |