### PR TITLE
Add client read-model boundaries

### DIFF
--- a/docs/project-overview.md
+++ b/docs/project-overview.md
@@ -41,7 +41,7 @@ Next.js App Router SPA, TypeScript, Tailwind CSS. All rendering is client-side.
 - `MetricsContext` (`src/components/MetricsContext.tsx`) — stores the `AggregatedMetrics` result, loading/error/warning state, and data actions
 - `NavigationContext` (`src/state/NavigationContext.tsx`) — manages current view, selected user/model, and navigation actions
 
-**All view components consume pre-aggregated data.** No component accesses raw `CopilotMetrics[]` directly. The flat `AggregatedMetrics` worker/UI contract is declared in `src/types/aggregatedMetrics.ts`. Feature read-model selectors in `src/read-models/` insulate migrated UI paths from that flat payload; overview, executive summary, users, user details, Copilot adoption, AI adoption phases, Copilot impact, and languages consume only their typed projections. The worker also retains a compact user-detail accumulator so it can serve user details on demand without moving raw records onto the main thread.
+**All view components consume pre-aggregated data.** No component accesses raw `CopilotMetrics[]` directly. The flat `AggregatedMetrics` worker/UI contract is declared in `src/types/aggregatedMetrics.ts`. Feature read-model selectors in `src/read-models/` insulate migrated UI paths from that flat payload; overview, executive summary, users, user details, Copilot adoption, AI adoption phases, Copilot impact, languages, clients, and client versions consume only their typed projections. The worker also retains a compact user-detail accumulator so it can serve user details on demand without moving raw records onto the main thread.
 
 ### 3.2. Code Organization
 
@@ -66,7 +66,7 @@ Next.js App Router SPA, TypeScript, Tailwind CSS. All rendering is client-side.
 
 ### 3.4. Feature Read-Model Boundaries
 
-The worker payload remains the flat `AggregatedMetrics` object. Pure selectors under `src/read-models/` project stable references from that payload into narrow UI contracts without copying, sorting, filtering, mutation, or additional aggregation.
+The worker payload remains the flat `AggregatedMetrics` object. Pure selectors under `src/read-models/` project stable references from that payload into narrow UI contracts without copying, sorting, filtering, or mutation. They may also relocate deterministic, feature-specific scalar derivations that previously lived in `ViewRouter`, such as the client view's CLI session and LOC totals.
 
 Established boundaries cover:
 - overview and executive summary
@@ -75,8 +75,9 @@ Established boundaries cover:
 - AI adoption phases
 - Copilot impact
 - languages
+- clients and client versions
 
-Remaining Phase 4 slices are clients and client versions, models and CLI, and AI credits. The worker payload remains flat; grouping it, moving component files, and decomposing the general `ViewRouter` registry remain separate work.
+Remaining Phase 4 slices are models and CLI, and AI credits. The worker payload remains flat; grouping it, moving component files, and decomposing the general `ViewRouter` registry remain separate work.
 
 ---
 

--- a/src/components/ClientVersionsView.tsx
+++ b/src/components/ClientVersionsView.tsx
@@ -9,14 +9,14 @@ import { usePluginVersions } from '../hooks/usePluginVersions';
 import { classifyVsCodeVersion, parseReportDayInclusiveEnd, resolveCurrentStableMinorAtDate } from '../domain/vscodeVersionClassifier';
 import { CLIENT_VERSIONS_SECTIONS } from './layout/contextSections';
 import type { VsCodeVersionClassification } from '../domain/vscodeVersionClassifier';
-import type { MetricsStats, PluginVersionAnalysisData } from '../types/metrics';
+import type { ClientVersionsReadModel } from '../read-models/clients';
 
 interface ClientVersionsViewProps {
-  pluginVersionData: PluginVersionAnalysisData;
-  stats: MetricsStats;
+  model: ClientVersionsReadModel;
 }
 
-export default function ClientVersionsView({ pluginVersionData, stats }: ClientVersionsViewProps) {
+export default function ClientVersionsView({ model }: ClientVersionsViewProps) {
+  const { pluginVersionData, reportStartDay } = model;
   const { versions: jetbrainsUpdates, isLoading: jbLoading, error: jbError } = usePluginVersions('jetbrains');
   const {
     stableReleases: vsCodeStableReleases,
@@ -41,11 +41,11 @@ export default function ClientVersionsView({ pluginVersionData, stats }: ClientV
   const latestTwentyVersions = React.useMemo(() => latestTwentyUpdates.map(u => u.version), [latestTwentyUpdates]);
 
   const effectiveVsCodeStableMinor = React.useMemo(() => {
-    const releaseWindowMinor = resolveCurrentStableMinorAtDate(vsCodeStableReleases, stats.reportStartDay);
+    const releaseWindowMinor = resolveCurrentStableMinorAtDate(vsCodeStableReleases, reportStartDay);
     if (releaseWindowMinor !== null) return releaseWindowMinor;
     if (vsCodeStableReleases.length > 0) return null;
     return currentStableMinor;
-  }, [currentStableMinor, stats.reportStartDay, vsCodeStableReleases]);
+  }, [currentStableMinor, reportStartDay, vsCodeStableReleases]);
 
   const effectiveVsCodePreviewMinor = React.useMemo(() => {
     if (effectiveVsCodeStableMinor === null) return null;
@@ -75,7 +75,7 @@ export default function ClientVersionsView({ pluginVersionData, stats }: ClientV
     return earliest;
   }, [vsCodeStableReleases]);
 
-  const parsedReportStartDay = React.useMemo(() => parseReportDayInclusiveEnd(stats.reportStartDay), [stats.reportStartDay]);
+  const parsedReportStartDay = React.useMemo(() => parseReportDayInclusiveEnd(reportStartDay), [reportStartDay]);
 
   const hasHistoricalVsCodeMetadataGap = React.useMemo(
     () => {
@@ -535,7 +535,7 @@ export default function ClientVersionsView({ pluginVersionData, stats }: ClientV
             <div className="space-y-1">
               <p>
                 <span className="font-medium text-gray-900">Status evaluation:</span>{' '}
-                This report starts on {formatReportDay(stats.reportStartDay)}, which predates the bundled VS Code stable release history.
+                This report starts on {formatReportDay(reportStartDay)}, which predates the bundled VS Code stable release history.
               </p>
               <p>
                 Historical metadata in this build starts at {formatDate(earliestVsCodeStableReleaseDate ?? '')}, so older report windows are shown without stable or outdated classification.
@@ -555,7 +555,7 @@ export default function ClientVersionsView({ pluginVersionData, stats }: ClientV
             <div className="space-y-1">
               <p>
                 <span className="font-medium text-gray-900">Status evaluation:</span>{' '}
-                Versions are compared against the stable release train available at the start of this report window ({formatReportDay(stats.reportStartDay)}).
+                Versions are compared against the stable release train available at the start of this report window ({formatReportDay(reportStartDay)}).
               </p>
               <p>
                 <span className="font-medium text-gray-900">Stable release train at report start:</span>{' '}

--- a/src/components/ClientsView.tsx
+++ b/src/components/ClientsView.tsx
@@ -11,28 +11,24 @@ import CLIOverlapChart from './charts/CLIOverlapChart';
 import IDEInsights from './IDEInsights';
 import { CLIENT_ANALYSIS_SECTIONS } from './layout/contextSections';
 import { appendCliClientStatsRow } from '../domain/calculators/clientActivityRows';
+import type { ClientsReadModel } from '../read-models/clients';
 
 type IDEStats = IDEStatsData;
 
 interface IDEViewProps {
-  ideStats: IDEStatsData[];
-  multiIDEUsersCount: number;
-  totalUniqueIDEUsers: number;
-  cliUsers: number;
-  cliSessions: number;
-  cliLocAdded: number;
-  cliLocDeleted: number;
+  model: ClientsReadModel;
 }
 
-export default function ClientsView({
-  ideStats,
-  multiIDEUsersCount,
-  totalUniqueIDEUsers,
-  cliUsers,
-  cliSessions,
-  cliLocAdded,
-  cliLocDeleted,
-}: IDEViewProps) {
+export default function ClientsView({ model }: IDEViewProps) {
+  const {
+    ideStats,
+    multiIDEUsersCount,
+    totalUniqueIDEUsers,
+    cliUsers,
+    cliSessions,
+    cliLocAdded,
+    cliLocDeleted,
+  } = model;
 
   const allClients: IDEStats[] = React.useMemo(() => {
     return appendCliClientStatsRow(ideStats, {

--- a/src/components/layout/ViewRouter.tsx
+++ b/src/components/layout/ViewRouter.tsx
@@ -15,6 +15,10 @@ import { selectCopilotAdoptionReadModel } from '../../read-models/adoption';
 import { selectAiAdoptionPhaseReadModel } from '../../read-models/aiAdoptionPhases';
 import { selectCopilotImpactReadModel } from '../../read-models/impact';
 import { selectLanguagesReadModel } from '../../read-models/languages';
+import {
+  selectClientsReadModel,
+  selectClientVersionsReadModel,
+} from '../../read-models/clients';
 import { selectUsersReadModel } from '../../read-models/users';
 import { selectUserDetailsRouteReadModel } from '../../read-models/userDetails';
 import {
@@ -184,11 +188,6 @@ const ViewRouter: React.FC = () => {
   const { 
     stats, 
     userSummaries, 
-    cliImpactData,
-    ideStats,
-    multiIDEUsersCount,
-    totalUniqueIDEUsers,
-    pluginVersionData,
     modelBreakdownData,
     dailyCliSessionData,
     dailyCliTokenData,
@@ -202,6 +201,8 @@ const ViewRouter: React.FC = () => {
   const aiAdoptionPhaseReadModel = selectAiAdoptionPhaseReadModel(aggregatedMetrics);
   const copilotImpactReadModel = selectCopilotImpactReadModel(aggregatedMetrics);
   const languagesReadModel = selectLanguagesReadModel(aggregatedMetrics);
+  const clientsReadModel = selectClientsReadModel(aggregatedMetrics);
+  const clientVersionsReadModel = selectClientVersionsReadModel(aggregatedMetrics);
   const usersReadModel = selectUsersReadModel(aggregatedMetrics);
 
   switch (currentView) {
@@ -230,8 +231,7 @@ const ViewRouter: React.FC = () => {
     case VIEW_MODES.CLIENT_VERSIONS:
       return (
         <ClientVersionsView
-          pluginVersionData={pluginVersionData}
-          stats={stats}
+          model={clientVersionsReadModel}
         />
       );
 
@@ -244,14 +244,8 @@ const ViewRouter: React.FC = () => {
 
     case VIEW_MODES.CLIENT_ANALYSIS:
       return (
-        <ClientsView 
-          ideStats={ideStats}
-          multiIDEUsersCount={multiIDEUsersCount}
-          totalUniqueIDEUsers={totalUniqueIDEUsers}
-          cliUsers={stats.cliUsers}
-          cliSessions={dailyCliSessionData.reduce((sum, d) => sum + d.sessionCount, 0)}
-          cliLocAdded={cliImpactData.reduce((sum, d) => sum + d.locAdded, 0)}
-          cliLocDeleted={cliImpactData.reduce((sum, d) => sum + d.locDeleted, 0)}
+        <ClientsView
+          model={clientsReadModel}
         />
       );
 

--- a/src/components/layout/__tests__/ViewRouter.test.tsx
+++ b/src/components/layout/__tests__/ViewRouter.test.tsx
@@ -10,6 +10,10 @@ import type { CopilotAdoptionReadModel } from '../../../read-models/adoption';
 import type { AiAdoptionPhaseReadModel } from '../../../read-models/aiAdoptionPhases';
 import type { CopilotImpactReadModel } from '../../../read-models/impact';
 import type { LanguagesReadModel } from '../../../read-models/languages';
+import type {
+  ClientsReadModel,
+  ClientVersionsReadModel,
+} from '../../../read-models/clients';
 import ViewRouter from '../ViewRouter';
 
 const mocks = vi.hoisted(() => ({
@@ -29,8 +33,20 @@ const mocks = vi.hoisted(() => ({
   languagesView: vi.fn<
     (props: { model: LanguagesReadModel }) => void
   >(),
+  clientsView: vi.fn<
+    (props: { model: ClientsReadModel }) => void
+  >(),
+  clientVersionsView: vi.fn<
+    (props: { model: ClientVersionsReadModel }) => void
+  >(),
   selectLanguagesReadModel: vi.fn<
     (metrics: AggregatedMetrics) => LanguagesReadModel
+  >(),
+  selectClientsReadModel: vi.fn<
+    (metrics: AggregatedMetrics) => ClientsReadModel
+  >(),
+  selectClientVersionsReadModel: vi.fn<
+    (metrics: AggregatedMetrics) => ClientVersionsReadModel
   >(),
 }));
 
@@ -101,8 +117,27 @@ vi.mock('../../LanguagesView', () => ({
   },
 }));
 
+vi.mock('../../ClientsView', () => ({
+  default: (props: { model: ClientsReadModel }) => {
+    mocks.clientsView(props);
+    return null;
+  },
+}));
+
+vi.mock('../../ClientVersionsView', () => ({
+  default: (props: { model: ClientVersionsReadModel }) => {
+    mocks.clientVersionsView(props);
+    return null;
+  },
+}));
+
 vi.mock('../../../read-models/languages', () => ({
   selectLanguagesReadModel: mocks.selectLanguagesReadModel,
+}));
+
+vi.mock('../../../read-models/clients', () => ({
+  selectClientsReadModel: mocks.selectClientsReadModel,
+  selectClientVersionsReadModel: mocks.selectClientVersionsReadModel,
 }));
 
 describe('ViewRouter', () => {
@@ -112,7 +147,11 @@ describe('ViewRouter', () => {
     mocks.aiAdoptionPhaseView.mockClear();
     mocks.copilotImpactView.mockClear();
     mocks.languagesView.mockClear();
+    mocks.clientsView.mockClear();
+    mocks.clientVersionsView.mockClear();
     mocks.selectLanguagesReadModel.mockReset();
+    mocks.selectClientsReadModel.mockReset();
+    mocks.selectClientVersionsReadModel.mockReset();
     mocks.currentView = VIEW_MODES.USER_DETAILS;
     mocks.selectedUser = null;
     mocks.aggregatedMetrics = aggregateMetrics([makeMetric()]).aggregated;
@@ -121,6 +160,19 @@ describe('ViewRouter', () => {
       languageFeatureImpactData: metrics.languageFeatureImpactData,
       dailyLanguageGenerationsData: metrics.dailyLanguageGenerationsData,
       dailyLanguageLocData: metrics.dailyLanguageLocData,
+    }));
+    mocks.selectClientsReadModel.mockImplementation((metrics) => ({
+      ideStats: metrics.ideStats,
+      multiIDEUsersCount: metrics.multiIDEUsersCount,
+      totalUniqueIDEUsers: metrics.totalUniqueIDEUsers,
+      cliUsers: metrics.stats.cliUsers,
+      cliSessions: 0,
+      cliLocAdded: 0,
+      cliLocDeleted: 0,
+    }));
+    mocks.selectClientVersionsReadModel.mockImplementation((metrics) => ({
+      pluginVersionData: metrics.pluginVersionData,
+      reportStartDay: metrics.stats.reportStartDay,
     }));
   });
 
@@ -205,6 +257,49 @@ describe('ViewRouter', () => {
     expect(mocks.selectLanguagesReadModel).toHaveBeenCalledWith(mocks.aggregatedMetrics);
     expect(mocks.languagesView).toHaveBeenCalledOnce();
     const props = mocks.languagesView.mock.calls[0][0];
+    expect(Object.keys(props)).toEqual(['model']);
+    expect(props.model).toBe(expectedModel);
+  });
+
+  it('routes clients through the selector and one cohesive read model', () => {
+    mocks.currentView = VIEW_MODES.CLIENT_ANALYSIS;
+    const expectedModel: ClientsReadModel = {
+      ideStats: mocks.aggregatedMetrics!.ideStats,
+      multiIDEUsersCount: 4,
+      totalUniqueIDEUsers: 5,
+      cliUsers: 6,
+      cliSessions: 7,
+      cliLocAdded: 8,
+      cliLocDeleted: 9,
+    };
+    mocks.selectClientsReadModel.mockReturnValueOnce(expectedModel);
+
+    renderToStaticMarkup(<ViewRouter />);
+
+    expect(mocks.selectClientsReadModel).toHaveBeenCalledWith(
+      mocks.aggregatedMetrics
+    );
+    expect(mocks.clientsView).toHaveBeenCalledOnce();
+    const props = mocks.clientsView.mock.calls[0][0];
+    expect(Object.keys(props)).toEqual(['model']);
+    expect(props.model).toBe(expectedModel);
+  });
+
+  it('routes client versions through the selector and one cohesive read model', () => {
+    mocks.currentView = VIEW_MODES.CLIENT_VERSIONS;
+    const expectedModel: ClientVersionsReadModel = {
+      pluginVersionData: mocks.aggregatedMetrics!.pluginVersionData,
+      reportStartDay: '2026-01-15',
+    };
+    mocks.selectClientVersionsReadModel.mockReturnValueOnce(expectedModel);
+
+    renderToStaticMarkup(<ViewRouter />);
+
+    expect(mocks.selectClientVersionsReadModel).toHaveBeenCalledWith(
+      mocks.aggregatedMetrics
+    );
+    expect(mocks.clientVersionsView).toHaveBeenCalledOnce();
+    const props = mocks.clientVersionsView.mock.calls[0][0];
     expect(Object.keys(props)).toEqual(['model']);
     expect(props.model).toBe(expectedModel);
   });

--- a/src/read-models/__tests__/clientsReadModels.test.ts
+++ b/src/read-models/__tests__/clientsReadModels.test.ts
@@ -1,0 +1,244 @@
+import { describe, expect, it } from 'vitest';
+import { makeAggregatedMetrics } from '../../__tests__/factories/aggregatedMetrics';
+import type { AggregatedMetrics } from '../../types/aggregatedMetrics';
+import {
+  selectClientsReadModel,
+  selectClientVersionsReadModel,
+} from '../clients';
+
+function makeClientMetrics(): AggregatedMetrics {
+  const defaults = makeAggregatedMetrics();
+
+  return makeAggregatedMetrics({
+    stats: {
+      ...defaults.stats,
+      cliUsers: 7,
+      reportStartDay: '2026-01-15',
+    },
+    ideStats: [{
+      ide: 'vscode',
+      uniqueUsers: 4,
+      cliOverlapUsers: 1,
+      totalEngagements: 12,
+      totalGenerations: 8,
+      totalAcceptances: 5,
+      locAdded: 21,
+      locDeleted: 3,
+      locSuggestedToAdd: 30,
+      locSuggestedToDelete: 4,
+    }],
+    multiIDEUsersCount: 2,
+    totalUniqueIDEUsers: 5,
+    dailyCliSessionData: [
+      {
+        date: '2026-01-15',
+        sessionCount: 3,
+        requestCount: 4,
+        promptCount: 5,
+        uniqueUsers: 2,
+      },
+      {
+        date: '2026-01-16',
+        sessionCount: 8,
+        requestCount: 9,
+        promptCount: 10,
+        uniqueUsers: 3,
+      },
+    ],
+    cliImpactData: [
+      {
+        date: '2026-01-15',
+        locAdded: 13,
+        locDeleted: 2,
+        netChange: 11,
+        userCount: 2,
+        totalUniqueUsers: 7,
+      },
+      {
+        date: '2026-01-16',
+        locAdded: 17,
+        locDeleted: 5,
+        netChange: 12,
+        userCount: 3,
+        totalUniqueUsers: 7,
+      },
+    ],
+    pluginVersionData: {
+      jetbrains: [{
+        version: '1.5.0',
+        userCount: 2,
+        usernames: ['octocat', 'hubot'],
+      }],
+      vscode: [{
+        version: '1.250.0',
+        userCount: 3,
+        usernames: ['octocat', 'hubot', 'monalisa'],
+      }],
+      totalUniqueIntellijUsers: 2,
+      totalUniqueVsCodeUsers: 3,
+    },
+  });
+}
+
+describe('client read models', () => {
+  it('selects the exact clients shape and preserves the IDE stats reference', () => {
+    const metrics = makeClientMetrics();
+
+    const model = selectClientsReadModel(metrics);
+
+    expect(model).toEqual({
+      ideStats: metrics.ideStats,
+      multiIDEUsersCount: 2,
+      totalUniqueIDEUsers: 5,
+      cliUsers: 7,
+      cliSessions: 11,
+      cliLocAdded: 30,
+      cliLocDeleted: 7,
+    });
+    expect(model.ideStats).toBe(metrics.ideStats);
+    expect(model.ideStats[0]).toBe(metrics.ideStats[0]);
+    expect(Object.keys(model)).toEqual([
+      'ideStats',
+      'multiIDEUsersCount',
+      'totalUniqueIDEUsers',
+      'cliUsers',
+      'cliSessions',
+      'cliLocAdded',
+      'cliLocDeleted',
+    ]);
+    expect(model).not.toHaveProperty('stats');
+    expect(model).not.toHaveProperty('dailyCliSessionData');
+    expect(model).not.toHaveProperty('cliImpactData');
+    expect(model).not.toHaveProperty('pluginVersionData');
+  });
+
+  it('uses additive totals without filtering or changing signed values', () => {
+    const defaults = makeAggregatedMetrics();
+    const metrics = makeAggregatedMetrics({
+      stats: { ...defaults.stats, cliUsers: -1 },
+      multiIDEUsersCount: -2,
+      totalUniqueIDEUsers: -3,
+      dailyCliSessionData: [
+        {
+          date: 'invalid',
+          sessionCount: 4.5,
+          requestCount: 0,
+          promptCount: 0,
+          uniqueUsers: 0,
+        },
+        {
+          date: '',
+          sessionCount: -1.25,
+          requestCount: 0,
+          promptCount: 0,
+          uniqueUsers: 0,
+        },
+      ],
+      cliImpactData: [
+        {
+          date: 'invalid',
+          locAdded: 6.5,
+          locDeleted: -2,
+          netChange: 8.5,
+          userCount: 0,
+          totalUniqueUsers: 0,
+        },
+        {
+          date: '',
+          locAdded: -1.5,
+          locDeleted: 3,
+          netChange: -4.5,
+          userCount: 0,
+          totalUniqueUsers: 0,
+        },
+      ],
+    });
+
+    expect(selectClientsReadModel(metrics)).toEqual({
+      ideStats: metrics.ideStats,
+      multiIDEUsersCount: -2,
+      totalUniqueIDEUsers: -3,
+      cliUsers: -1,
+      cliSessions: 3.25,
+      cliLocAdded: 5,
+      cliLocDeleted: 1,
+    });
+  });
+
+  it('selects the exact client versions shape and preserves plugin references', () => {
+    const metrics = makeClientMetrics();
+
+    const model = selectClientVersionsReadModel(metrics);
+
+    expect(model).toEqual({
+      pluginVersionData: metrics.pluginVersionData,
+      reportStartDay: '2026-01-15',
+    });
+    expect(model.pluginVersionData).toBe(metrics.pluginVersionData);
+    expect(model.pluginVersionData.jetbrains).toBe(metrics.pluginVersionData.jetbrains);
+    expect(model.pluginVersionData.jetbrains[0]).toBe(
+      metrics.pluginVersionData.jetbrains[0]
+    );
+    expect(model.pluginVersionData.jetbrains[0].usernames).toBe(
+      metrics.pluginVersionData.jetbrains[0].usernames
+    );
+    expect(model.pluginVersionData.vscode).toBe(metrics.pluginVersionData.vscode);
+    expect(Object.keys(model)).toEqual(['pluginVersionData', 'reportStartDay']);
+    expect(model).not.toHaveProperty('stats');
+    expect(model).not.toHaveProperty('ideStats');
+    expect(model).not.toHaveProperty('userSummaries');
+  });
+
+  it('preserves canonical empty data and the empty report date', () => {
+    const metrics = makeAggregatedMetrics();
+
+    const clients = selectClientsReadModel(metrics);
+    const clientVersions = selectClientVersionsReadModel(metrics);
+
+    expect(clients).toEqual({
+      ideStats: [],
+      multiIDEUsersCount: 0,
+      totalUniqueIDEUsers: 0,
+      cliUsers: 0,
+      cliSessions: 0,
+      cliLocAdded: 0,
+      cliLocDeleted: 0,
+    });
+    expect(clients.ideStats).toBe(metrics.ideStats);
+    expect(clientVersions).toEqual({
+      pluginVersionData: metrics.pluginVersionData,
+      reportStartDay: '',
+    });
+    expect(clientVersions.pluginVersionData).toBe(metrics.pluginVersionData);
+    expect(clientVersions.pluginVersionData.jetbrains).toBe(
+      metrics.pluginVersionData.jetbrains
+    );
+    expect(clientVersions.pluginVersionData.vscode).toBe(
+      metrics.pluginVersionData.vscode
+    );
+  });
+
+  it('passes report dates through verbatim without adding fallback semantics', () => {
+    const defaults = makeAggregatedMetrics();
+    const metrics = makeAggregatedMetrics({
+      stats: {
+        ...defaults.stats,
+        reportStartDay: 'not-a-report-date',
+      },
+    });
+
+    expect(selectClientVersionsReadModel(metrics).reportStartDay).toBe(
+      'not-a-report-date'
+    );
+  });
+
+  it('does not mutate the aggregate input', () => {
+    const metrics = makeClientMetrics();
+    const before = structuredClone(metrics);
+
+    selectClientsReadModel(metrics);
+    selectClientVersionsReadModel(metrics);
+
+    expect(metrics).toEqual(before);
+  });
+});

--- a/src/read-models/clients.ts
+++ b/src/read-models/clients.ts
@@ -1,0 +1,48 @@
+import type { AggregatedMetrics } from '../types/aggregatedMetrics';
+
+export interface ClientsReadModel {
+  ideStats: AggregatedMetrics['ideStats'];
+  multiIDEUsersCount: number;
+  totalUniqueIDEUsers: number;
+  cliUsers: number;
+  cliSessions: number;
+  cliLocAdded: number;
+  cliLocDeleted: number;
+}
+
+export interface ClientVersionsReadModel {
+  pluginVersionData: AggregatedMetrics['pluginVersionData'];
+  reportStartDay: string;
+}
+
+export function selectClientsReadModel(
+  metrics: AggregatedMetrics
+): ClientsReadModel {
+  return {
+    ideStats: metrics.ideStats,
+    multiIDEUsersCount: metrics.multiIDEUsersCount,
+    totalUniqueIDEUsers: metrics.totalUniqueIDEUsers,
+    cliUsers: metrics.stats.cliUsers,
+    cliSessions: metrics.dailyCliSessionData.reduce(
+      (sum, day) => sum + day.sessionCount,
+      0
+    ),
+    cliLocAdded: metrics.cliImpactData.reduce(
+      (sum, day) => sum + day.locAdded,
+      0
+    ),
+    cliLocDeleted: metrics.cliImpactData.reduce(
+      (sum, day) => sum + day.locDeleted,
+      0
+    ),
+  };
+}
+
+export function selectClientVersionsReadModel(
+  metrics: AggregatedMetrics
+): ClientVersionsReadModel {
+  return {
+    pluginVersionData: metrics.pluginVersionData,
+    reportStartDay: metrics.stats.reportStartDay,
+  };
+}


### PR DESCRIPTION
## Why

Clients and client versions still depended directly on the flat worker payload through ViewRouter. This adds narrow typed boundaries while preserving the existing payload, references, totals, and version-date semantics.

| Commit | Change |
|--------|--------|
| `refactor: add client read models` | Add tested client and client-version selectors and route each view through a sole model prop. |
| `docs: document client read-model boundaries` | Record the completed slice, relocated scalar derivations, and remaining Phase 4 boundaries. |