### PR TITLE
Add model and CLI read-model boundaries

### DIFF
--- a/docs/project-overview.md
+++ b/docs/project-overview.md
@@ -41,7 +41,7 @@ Next.js App Router SPA, TypeScript, Tailwind CSS. All rendering is client-side.
 - `MetricsContext` (`src/components/MetricsContext.tsx`) — stores the `AggregatedMetrics` result, loading/error/warning state, and data actions
 - `NavigationContext` (`src/state/NavigationContext.tsx`) — manages current view, selected user/model, and navigation actions
 
-**All view components consume pre-aggregated data.** No component accesses raw `CopilotMetrics[]` directly. The flat `AggregatedMetrics` worker/UI contract is declared in `src/types/aggregatedMetrics.ts`. Feature read-model selectors in `src/read-models/` insulate migrated UI paths from that flat payload; overview, executive summary, users, user details, Copilot adoption, AI adoption phases, Copilot impact, languages, clients, and client versions consume only their typed projections. The worker also retains a compact user-detail accumulator so it can serve user details on demand without moving raw records onto the main thread.
+**All view components consume pre-aggregated data.** No component accesses raw `CopilotMetrics[]` directly. The flat `AggregatedMetrics` worker/UI contract is declared in `src/types/aggregatedMetrics.ts`. Feature read-model selectors in `src/read-models/` insulate migrated UI paths from that flat payload; overview, executive summary, users, user details, Copilot adoption, AI adoption phases, Copilot impact, languages, clients, client versions, model details, and CLI adoption consume only their typed projections. The worker also retains a compact user-detail accumulator so it can serve user details on demand without moving raw records onto the main thread.
 
 ### 3.2. Code Organization
 
@@ -66,7 +66,7 @@ Next.js App Router SPA, TypeScript, Tailwind CSS. All rendering is client-side.
 
 ### 3.4. Feature Read-Model Boundaries
 
-The worker payload remains the flat `AggregatedMetrics` object. Pure selectors under `src/read-models/` project stable references from that payload into narrow UI contracts without copying, sorting, filtering, or mutation. They may also relocate deterministic, feature-specific scalar derivations that previously lived in `ViewRouter`, such as the client view's CLI session and LOC totals.
+The worker payload remains the flat `AggregatedMetrics` object. Pure selectors under `src/read-models/` project stable references from that payload into narrow UI contracts without copying, sorting, filtering, or mutation. They may also relocate existing deterministic, feature-specific scalar or date derivations, such as client CLI totals, the model-details auto total, and CLI model chart dates.
 
 Established boundaries cover:
 - overview and executive summary
@@ -76,8 +76,9 @@ Established boundaries cover:
 - Copilot impact
 - languages
 - clients and client versions
+- model details and CLI adoption
 
-Remaining Phase 4 slices are models and CLI, and AI credits. The worker payload remains flat; grouping it, moving component files, and decomposing the general `ViewRouter` registry remain separate work.
+AI credits is the only remaining Phase 4 slice. The worker payload remains flat; grouping it, moving component files, and decomposing the general `ViewRouter` registry remain separate work.
 
 ---
 

--- a/src/components/CLIAdoptionView.tsx
+++ b/src/components/CLIAdoptionView.tsx
@@ -8,31 +8,23 @@ import CLISessionChart from './charts/CLISessionChart';
 import CLITokensChart from './charts/CLITokensChart';
 import ModelsUsageChart from './charts/ModelsUsageChart';
 import { CLI_ADOPTION_SECTIONS } from './layout/contextSections';
-import type { MetricsStats, ModelDailyUsageEntry } from '../types/metrics';
-import type { DailyCliSessionData, DailyCliTokenData, DailyCliAdoptionTrend } from '../domain/calculators/metricCalculators';
+import type { CliAdoptionReadModel } from '../read-models/cliAdoption';
+
 interface CLIAdoptionViewProps {
-  stats: MetricsStats;
-  dailyCliSessionData: DailyCliSessionData[];
-  dailyCliTokenData: DailyCliTokenData[];
-  dailyCliAdoptionTrend: DailyCliAdoptionTrend[];
-  cliModelEntries: ModelDailyUsageEntry[];
-  cliModelDates: string[];
-  cliModelTotal: number;
+  model: CliAdoptionReadModel;
 }
 
-export default function CLIAdoptionView({
-  stats,
-  dailyCliSessionData,
-  dailyCliTokenData,
-  dailyCliAdoptionTrend,
-  cliModelEntries,
-  cliModelDates,
-  cliModelTotal,
-}: CLIAdoptionViewProps) {
-  const cliShare = stats.uniqueUsers > 0
-    ? Math.round((stats.cliUsers / stats.uniqueUsers) * 1000) / 10
-    : 0;
-
+export default function CLIAdoptionView({ model }: CLIAdoptionViewProps) {
+  const {
+    stats,
+    dailyCliSessionData,
+    dailyCliTokenData,
+    dailyCliAdoptionTrend,
+    cliModelEntries,
+    cliModelDates,
+    cliModelTotal,
+    cliShare,
+  } = model;
   const [trendSection, usersSection, sessionsSection, tokensSection, modelsSection] = CLI_ADOPTION_SECTIONS;
 
   return (

--- a/src/components/ModelDetailsView.tsx
+++ b/src/components/ModelDetailsView.tsx
@@ -1,27 +1,27 @@
 'use client';
 
-import React, { useMemo } from 'react';
+import React from 'react';
 import ModelsUsageChart from './charts/ModelsUsageChart';
 import ModelCategoryDistributionChart from './charts/ModelCategoryDistributionChart';
 import AutoModeAdoptionTrendChart from './charts/AutoModeAdoptionTrendChart';
-import type { ModelBreakdownData } from '../types/metrics';
+import type { ModelDetailsReadModel } from '../read-models/models';
 import { ViewPanel } from './ui';
 import { MODEL_DETAILS_SECTIONS } from './layout/contextSections';
 
 interface ModelDetailsViewProps {
-  modelBreakdownData: ModelBreakdownData;
+  model: ModelDetailsReadModel;
 }
 
-export default function ModelDetailsView({ modelBreakdownData }: ModelDetailsViewProps) {
-  const modelEntries = modelBreakdownData.allModels;
-  const modelTotal = modelBreakdownData.modelTotal;
-  const autoModels = modelBreakdownData.autoModels ?? [];
-  const autoModeAdoptionTrend = modelBreakdownData.autoModeAdoptionTrend ?? [];
-
-  const autoTotal = useMemo(
-    () => autoModels.reduce((sum, entry) => sum + entry.total, 0),
-    [autoModels]
-  );
+export default function ModelDetailsView({ model }: ModelDetailsViewProps) {
+  const {
+    allModels,
+    modelCategories,
+    autoModels,
+    autoModeAdoptionTrend,
+    dates,
+    modelTotal,
+    autoTotal,
+  } = model;
   const [allModelsSection, modelTypesSection, autoModelsSection, autoAdoptionSection] = MODEL_DETAILS_SECTIONS;
 
   return (
@@ -34,17 +34,17 @@ export default function ModelDetailsView({ modelBreakdownData }: ModelDetailsVie
     >
       <div className="space-y-6">
         <div id={allModelsSection.id} className="scroll-mt-28">
-          <ModelsUsageChart modelEntries={modelEntries} dates={modelBreakdownData.dates} totalInteractions={modelTotal} variant="all" />
+          <ModelsUsageChart modelEntries={allModels} dates={dates} totalInteractions={modelTotal} variant="all" />
         </div>
         <div id={modelTypesSection.id} className="scroll-mt-28">
           <ModelCategoryDistributionChart
-            entries={modelBreakdownData.modelCategories}
-            dates={modelBreakdownData.dates}
+            entries={modelCategories}
+            dates={dates}
             totalInteractions={modelTotal}
           />
         </div>
         <div id={autoModelsSection.id} className="scroll-mt-28">
-          <ModelsUsageChart modelEntries={autoModels} dates={modelBreakdownData.dates} totalInteractions={autoTotal} variant="auto" />
+          <ModelsUsageChart modelEntries={autoModels} dates={dates} totalInteractions={autoTotal} variant="auto" />
         </div>
         <div id={autoAdoptionSection.id} className="scroll-mt-28">
           <AutoModeAdoptionTrendChart data={autoModeAdoptionTrend} />

--- a/src/components/layout/ViewRouter.tsx
+++ b/src/components/layout/ViewRouter.tsx
@@ -19,6 +19,8 @@ import {
   selectClientsReadModel,
   selectClientVersionsReadModel,
 } from '../../read-models/clients';
+import { selectModelDetailsReadModel } from '../../read-models/models';
+import { selectCliAdoptionReadModel } from '../../read-models/cliAdoption';
 import { selectUsersReadModel } from '../../read-models/users';
 import { selectUserDetailsRouteReadModel } from '../../read-models/userDetails';
 import {
@@ -187,11 +189,7 @@ const ViewRouter: React.FC = () => {
 
   const { 
     stats, 
-    userSummaries, 
-    modelBreakdownData,
-    dailyCliSessionData,
-    dailyCliTokenData,
-    dailyCliAdoptionTrend,
+    userSummaries,
     dailyAiCreditsData = [],
     usageDistributionData = [],
   } = aggregatedMetrics;
@@ -203,6 +201,8 @@ const ViewRouter: React.FC = () => {
   const languagesReadModel = selectLanguagesReadModel(aggregatedMetrics);
   const clientsReadModel = selectClientsReadModel(aggregatedMetrics);
   const clientVersionsReadModel = selectClientVersionsReadModel(aggregatedMetrics);
+  const modelDetailsReadModel = selectModelDetailsReadModel(aggregatedMetrics);
+  const cliAdoptionReadModel = selectCliAdoptionReadModel(aggregatedMetrics);
   const usersReadModel = selectUsersReadModel(aggregatedMetrics);
 
   switch (currentView) {
@@ -273,17 +273,7 @@ const ViewRouter: React.FC = () => {
     case VIEW_MODES.CLI_ADOPTION:
       return (
         <CLIAdoptionView
-          stats={stats}
-          dailyCliSessionData={dailyCliSessionData}
-          dailyCliTokenData={dailyCliTokenData}
-          dailyCliAdoptionTrend={dailyCliAdoptionTrend}
-          cliModelEntries={modelBreakdownData.cliModels ?? []}
-          cliModelDates={
-            dailyCliSessionData.length > 0
-              ? dailyCliSessionData.map((entry) => entry.date)
-              : modelBreakdownData.dates
-          }
-          cliModelTotal={modelBreakdownData.cliTotal ?? 0}
+          model={cliAdoptionReadModel}
         />
       );
 
@@ -352,7 +342,7 @@ const ViewRouter: React.FC = () => {
     case VIEW_MODES.MODEL_DETAILS:
       return (
         <ModelDetailsView
-          modelBreakdownData={modelBreakdownData}
+          model={modelDetailsReadModel}
         />
       );
 

--- a/src/components/layout/__tests__/ViewRouter.test.tsx
+++ b/src/components/layout/__tests__/ViewRouter.test.tsx
@@ -14,6 +14,8 @@ import type {
   ClientsReadModel,
   ClientVersionsReadModel,
 } from '../../../read-models/clients';
+import type { ModelDetailsReadModel } from '../../../read-models/models';
+import type { CliAdoptionReadModel } from '../../../read-models/cliAdoption';
 import ViewRouter from '../ViewRouter';
 
 const mocks = vi.hoisted(() => ({
@@ -39,6 +41,12 @@ const mocks = vi.hoisted(() => ({
   clientVersionsView: vi.fn<
     (props: { model: ClientVersionsReadModel }) => void
   >(),
+  modelDetailsView: vi.fn<
+    (props: { model: ModelDetailsReadModel }) => void
+  >(),
+  cliAdoptionView: vi.fn<
+    (props: { model: CliAdoptionReadModel }) => void
+  >(),
   selectLanguagesReadModel: vi.fn<
     (metrics: AggregatedMetrics) => LanguagesReadModel
   >(),
@@ -47,6 +55,12 @@ const mocks = vi.hoisted(() => ({
   >(),
   selectClientVersionsReadModel: vi.fn<
     (metrics: AggregatedMetrics) => ClientVersionsReadModel
+  >(),
+  selectModelDetailsReadModel: vi.fn<
+    (metrics: AggregatedMetrics) => ModelDetailsReadModel
+  >(),
+  selectCliAdoptionReadModel: vi.fn<
+    (metrics: AggregatedMetrics) => CliAdoptionReadModel
   >(),
 }));
 
@@ -131,6 +145,20 @@ vi.mock('../../ClientVersionsView', () => ({
   },
 }));
 
+vi.mock('../../ModelDetailsView', () => ({
+  default: (props: { model: ModelDetailsReadModel }) => {
+    mocks.modelDetailsView(props);
+    return null;
+  },
+}));
+
+vi.mock('../../CLIAdoptionView', () => ({
+  default: (props: { model: CliAdoptionReadModel }) => {
+    mocks.cliAdoptionView(props);
+    return null;
+  },
+}));
+
 vi.mock('../../../read-models/languages', () => ({
   selectLanguagesReadModel: mocks.selectLanguagesReadModel,
 }));
@@ -138,6 +166,14 @@ vi.mock('../../../read-models/languages', () => ({
 vi.mock('../../../read-models/clients', () => ({
   selectClientsReadModel: mocks.selectClientsReadModel,
   selectClientVersionsReadModel: mocks.selectClientVersionsReadModel,
+}));
+
+vi.mock('../../../read-models/models', () => ({
+  selectModelDetailsReadModel: mocks.selectModelDetailsReadModel,
+}));
+
+vi.mock('../../../read-models/cliAdoption', () => ({
+  selectCliAdoptionReadModel: mocks.selectCliAdoptionReadModel,
 }));
 
 describe('ViewRouter', () => {
@@ -149,9 +185,13 @@ describe('ViewRouter', () => {
     mocks.languagesView.mockClear();
     mocks.clientsView.mockClear();
     mocks.clientVersionsView.mockClear();
+    mocks.modelDetailsView.mockClear();
+    mocks.cliAdoptionView.mockClear();
     mocks.selectLanguagesReadModel.mockReset();
     mocks.selectClientsReadModel.mockReset();
     mocks.selectClientVersionsReadModel.mockReset();
+    mocks.selectModelDetailsReadModel.mockReset();
+    mocks.selectCliAdoptionReadModel.mockReset();
     mocks.currentView = VIEW_MODES.USER_DETAILS;
     mocks.selectedUser = null;
     mocks.aggregatedMetrics = aggregateMetrics([makeMetric()]).aggregated;
@@ -173,6 +213,26 @@ describe('ViewRouter', () => {
     mocks.selectClientVersionsReadModel.mockImplementation((metrics) => ({
       pluginVersionData: metrics.pluginVersionData,
       reportStartDay: metrics.stats.reportStartDay,
+    }));
+    mocks.selectModelDetailsReadModel.mockImplementation((metrics) => ({
+      allModels: metrics.modelBreakdownData.allModels,
+      modelCategories: metrics.modelBreakdownData.modelCategories,
+      autoModels: metrics.modelBreakdownData.autoModels ?? [],
+      autoModeAdoptionTrend:
+        metrics.modelBreakdownData.autoModeAdoptionTrend ?? [],
+      dates: metrics.modelBreakdownData.dates,
+      modelTotal: metrics.modelBreakdownData.modelTotal,
+      autoTotal: 0,
+    }));
+    mocks.selectCliAdoptionReadModel.mockImplementation((metrics) => ({
+      stats: metrics.stats,
+      dailyCliSessionData: metrics.dailyCliSessionData,
+      dailyCliTokenData: metrics.dailyCliTokenData,
+      dailyCliAdoptionTrend: metrics.dailyCliAdoptionTrend,
+      cliModelEntries: metrics.modelBreakdownData.cliModels ?? [],
+      cliModelDates: metrics.modelBreakdownData.dates,
+      cliModelTotal: metrics.modelBreakdownData.cliTotal ?? 0,
+      cliShare: 0,
     }));
   });
 
@@ -300,6 +360,58 @@ describe('ViewRouter', () => {
     );
     expect(mocks.clientVersionsView).toHaveBeenCalledOnce();
     const props = mocks.clientVersionsView.mock.calls[0][0];
+    expect(Object.keys(props)).toEqual(['model']);
+    expect(props.model).toBe(expectedModel);
+  });
+
+  it('routes model details through the selector and one cohesive read model', () => {
+    mocks.currentView = VIEW_MODES.MODEL_DETAILS;
+    const expectedModel: ModelDetailsReadModel = {
+      allModels: mocks.aggregatedMetrics!.modelBreakdownData.allModels,
+      modelCategories:
+        mocks.aggregatedMetrics!.modelBreakdownData.modelCategories,
+      autoModels: mocks.aggregatedMetrics!.modelBreakdownData.autoModels ?? [],
+      autoModeAdoptionTrend:
+        mocks.aggregatedMetrics!.modelBreakdownData.autoModeAdoptionTrend ?? [],
+      dates: mocks.aggregatedMetrics!.modelBreakdownData.dates,
+      modelTotal: 10,
+      autoTotal: 4,
+    };
+    mocks.selectModelDetailsReadModel.mockReturnValueOnce(expectedModel);
+
+    renderToStaticMarkup(<ViewRouter />);
+
+    expect(mocks.selectModelDetailsReadModel).toHaveBeenCalledWith(
+      mocks.aggregatedMetrics
+    );
+    expect(mocks.modelDetailsView).toHaveBeenCalledOnce();
+    const props = mocks.modelDetailsView.mock.calls[0][0];
+    expect(Object.keys(props)).toEqual(['model']);
+    expect(props.model).toBe(expectedModel);
+  });
+
+  it('routes CLI adoption through the selector and one cohesive read model', () => {
+    mocks.currentView = VIEW_MODES.CLI_ADOPTION;
+    const expectedModel: CliAdoptionReadModel = {
+      stats: mocks.aggregatedMetrics!.stats,
+      dailyCliSessionData: mocks.aggregatedMetrics!.dailyCliSessionData,
+      dailyCliTokenData: mocks.aggregatedMetrics!.dailyCliTokenData,
+      dailyCliAdoptionTrend: mocks.aggregatedMetrics!.dailyCliAdoptionTrend,
+      cliModelEntries:
+        mocks.aggregatedMetrics!.modelBreakdownData.cliModels ?? [],
+      cliModelDates: ['2026-01-15'],
+      cliModelTotal: 7,
+      cliShare: 12.5,
+    };
+    mocks.selectCliAdoptionReadModel.mockReturnValueOnce(expectedModel);
+
+    renderToStaticMarkup(<ViewRouter />);
+
+    expect(mocks.selectCliAdoptionReadModel).toHaveBeenCalledWith(
+      mocks.aggregatedMetrics
+    );
+    expect(mocks.cliAdoptionView).toHaveBeenCalledOnce();
+    const props = mocks.cliAdoptionView.mock.calls[0][0];
     expect(Object.keys(props)).toEqual(['model']);
     expect(props.model).toBe(expectedModel);
   });

--- a/src/read-models/__tests__/modelsCliReadModels.test.ts
+++ b/src/read-models/__tests__/modelsCliReadModels.test.ts
@@ -1,0 +1,357 @@
+import { describe, expect, it } from 'vitest';
+import { makeAggregatedMetrics } from '../../__tests__/factories/aggregatedMetrics';
+import type { AggregatedMetrics } from '../../types/aggregatedMetrics';
+import { selectCliAdoptionReadModel } from '../cliAdoption';
+import { selectModelDetailsReadModel } from '../models';
+
+function makeModelMetrics(): AggregatedMetrics {
+  return makeAggregatedMetrics({
+    modelBreakdownData: {
+      allModels: [{
+        model: 'gpt-5',
+        total: 11,
+        dailyData: { '2026-01-15': 11 },
+      }],
+      modelCategories: [{
+        category: 'Powerful',
+        total: 11,
+        dailyData: { '2026-01-15': 11 },
+      }],
+      autoModels: [
+        {
+          model: 'auto',
+          total: 4.5,
+          dailyData: { '2026-01-15': 4.5 },
+        },
+        {
+          model: 'auto-secondary',
+          total: -1.25,
+          dailyData: { '2026-01-16': -1.25 },
+        },
+      ],
+      cliModels: [{
+        model: 'gpt-5',
+        total: 99,
+        dailyData: { '2026-01-15': 99 },
+      }],
+      autoModeAdoptionTrend: [{
+        date: '2026-01-15',
+        newUsers: 2,
+        returningUsers: 1,
+        totalActiveUsers: 3,
+        cumulativeUsers: 4,
+      }],
+      dates: ['2026-01-15', '2026-01-16'],
+      modelTotal: 11,
+      cliTotal: 99,
+      unknownTotal: 0,
+    },
+  });
+}
+
+function makeCliMetrics(): AggregatedMetrics {
+  const defaults = makeAggregatedMetrics();
+
+  return makeAggregatedMetrics({
+    stats: {
+      ...defaults.stats,
+      uniqueUsers: 9,
+      cliUsers: 3,
+      reportStartDay: '2026-01-01',
+      reportEndDay: '2026-01-31',
+    },
+    dailyCliSessionData: [
+      {
+        date: '2026-01-16',
+        sessionCount: 2,
+        requestCount: 4,
+        promptCount: 3,
+        uniqueUsers: 2,
+      },
+      {
+        date: '2026-01-15',
+        sessionCount: 1,
+        requestCount: 2,
+        promptCount: 1,
+        uniqueUsers: 1,
+      },
+    ],
+    dailyCliTokenData: [{
+      date: '2026-01-15',
+      outputTokens: 100,
+      promptTokens: 50,
+      requestCount: 2,
+    }],
+    dailyCliAdoptionTrend: [{
+      date: '2026-01-15',
+      newUsers: 1,
+      returningUsers: 0,
+      totalActiveUsers: 1,
+      cumulativeUsers: 1,
+    }],
+    modelBreakdownData: {
+      ...defaults.modelBreakdownData,
+      cliModels: [{
+        model: 'gpt-5',
+        total: 6,
+        dailyData: { '2026-01-15': 6 },
+      }],
+      dates: ['fallback-model-date'],
+      cliTotal: 6,
+    },
+  });
+}
+
+describe('model details read model', () => {
+  it('selects the exact shape, preserves references, and relocates the additive auto total', () => {
+    const metrics = makeModelMetrics();
+
+    const model = selectModelDetailsReadModel(metrics);
+
+    expect(model).toEqual({
+      allModels: metrics.modelBreakdownData.allModels,
+      modelCategories: metrics.modelBreakdownData.modelCategories,
+      autoModels: metrics.modelBreakdownData.autoModels,
+      autoModeAdoptionTrend: metrics.modelBreakdownData.autoModeAdoptionTrend,
+      dates: metrics.modelBreakdownData.dates,
+      modelTotal: 11,
+      autoTotal: 3.25,
+    });
+    expect(model.allModels).toBe(metrics.modelBreakdownData.allModels);
+    expect(model.allModels[0]).toBe(metrics.modelBreakdownData.allModels[0]);
+    expect(model.allModels[0].dailyData).toBe(
+      metrics.modelBreakdownData.allModels[0].dailyData
+    );
+    expect(model.modelCategories).toBe(metrics.modelBreakdownData.modelCategories);
+    expect(model.modelCategories[0]).toBe(
+      metrics.modelBreakdownData.modelCategories[0]
+    );
+    expect(model.modelCategories[0].dailyData).toBe(
+      metrics.modelBreakdownData.modelCategories[0].dailyData
+    );
+    expect(model.autoModels).toBe(metrics.modelBreakdownData.autoModels);
+    expect(model.autoModels[0]).toBe(metrics.modelBreakdownData.autoModels?.[0]);
+    expect(model.autoModels[0].dailyData).toBe(
+      metrics.modelBreakdownData.autoModels?.[0].dailyData
+    );
+    expect(model.autoModeAdoptionTrend).toBe(
+      metrics.modelBreakdownData.autoModeAdoptionTrend
+    );
+    expect(model.autoModeAdoptionTrend[0]).toBe(
+      metrics.modelBreakdownData.autoModeAdoptionTrend?.[0]
+    );
+    expect(model.dates).toBe(metrics.modelBreakdownData.dates);
+    expect(Object.keys(model)).toEqual([
+      'allModels',
+      'modelCategories',
+      'autoModels',
+      'autoModeAdoptionTrend',
+      'dates',
+      'modelTotal',
+      'autoTotal',
+    ]);
+    expect(model).not.toHaveProperty('modelBreakdownData');
+    expect(model).not.toHaveProperty('cliModels');
+    expect(model).not.toHaveProperty('cliTotal');
+    expect(model).not.toHaveProperty('stats');
+  });
+
+  it('preserves canonical empty model data and its references', () => {
+    const metrics = makeAggregatedMetrics();
+
+    const model = selectModelDetailsReadModel(metrics);
+
+    expect(model).toEqual({
+      allModels: [],
+      modelCategories: [],
+      autoModels: [],
+      autoModeAdoptionTrend: [],
+      dates: [],
+      modelTotal: 0,
+      autoTotal: 0,
+    });
+    expect(model.allModels).toBe(metrics.modelBreakdownData.allModels);
+    expect(model.modelCategories).toBe(metrics.modelBreakdownData.modelCategories);
+    expect(model.autoModels).toBe(metrics.modelBreakdownData.autoModels);
+    expect(model.autoModeAdoptionTrend).toBe(
+      metrics.modelBreakdownData.autoModeAdoptionTrend
+    );
+    expect(model.dates).toBe(metrics.modelBreakdownData.dates);
+  });
+
+  it('keeps the existing optional-array fallbacks', () => {
+    const defaults = makeAggregatedMetrics();
+    const metrics = makeAggregatedMetrics({
+      modelBreakdownData: {
+        ...defaults.modelBreakdownData,
+        autoModels: undefined,
+        autoModeAdoptionTrend: undefined,
+      },
+    });
+
+    expect(selectModelDetailsReadModel(metrics)).toEqual({
+      allModels: metrics.modelBreakdownData.allModels,
+      modelCategories: metrics.modelBreakdownData.modelCategories,
+      autoModels: [],
+      autoModeAdoptionTrend: [],
+      dates: metrics.modelBreakdownData.dates,
+      modelTotal: 0,
+      autoTotal: 0,
+    });
+  });
+
+  it('does not mutate the aggregate input', () => {
+    const metrics = makeModelMetrics();
+    const before = structuredClone(metrics);
+
+    selectModelDetailsReadModel(metrics);
+
+    expect(metrics).toEqual(before);
+  });
+});
+
+describe('CLI adoption read model', () => {
+  it('selects the exact shape and preserves every projected source reference', () => {
+    const metrics = makeCliMetrics();
+
+    const model = selectCliAdoptionReadModel(metrics);
+
+    expect(model).toEqual({
+      stats: metrics.stats,
+      dailyCliSessionData: metrics.dailyCliSessionData,
+      dailyCliTokenData: metrics.dailyCliTokenData,
+      dailyCliAdoptionTrend: metrics.dailyCliAdoptionTrend,
+      cliModelEntries: metrics.modelBreakdownData.cliModels,
+      cliModelDates: ['2026-01-16', '2026-01-15'],
+      cliModelTotal: 6,
+      cliShare: 33.3,
+    });
+    expect(model.stats).toBe(metrics.stats);
+    expect(model.stats.reportStartDay).toBe('2026-01-01');
+    expect(model.stats.reportEndDay).toBe('2026-01-31');
+    expect(model.dailyCliSessionData).toBe(metrics.dailyCliSessionData);
+    expect(model.dailyCliSessionData[0]).toBe(metrics.dailyCliSessionData[0]);
+    expect(model.dailyCliTokenData).toBe(metrics.dailyCliTokenData);
+    expect(model.dailyCliTokenData[0]).toBe(metrics.dailyCliTokenData[0]);
+    expect(model.dailyCliAdoptionTrend).toBe(metrics.dailyCliAdoptionTrend);
+    expect(model.dailyCliAdoptionTrend[0]).toBe(
+      metrics.dailyCliAdoptionTrend[0]
+    );
+    expect(model.cliModelEntries).toBe(metrics.modelBreakdownData.cliModels);
+    expect(model.cliModelEntries[0]).toBe(
+      metrics.modelBreakdownData.cliModels?.[0]
+    );
+    expect(model.cliModelEntries[0].dailyData).toBe(
+      metrics.modelBreakdownData.cliModels?.[0].dailyData
+    );
+    expect(model.cliModelDates).not.toBe(metrics.modelBreakdownData.dates);
+    expect(Object.keys(model)).toEqual([
+      'stats',
+      'dailyCliSessionData',
+      'dailyCliTokenData',
+      'dailyCliAdoptionTrend',
+      'cliModelEntries',
+      'cliModelDates',
+      'cliModelTotal',
+      'cliShare',
+    ]);
+    expect(model).not.toHaveProperty('modelBreakdownData');
+    expect(model).not.toHaveProperty('userSummaries');
+    expect(model).not.toHaveProperty('dailyAiCreditsData');
+  });
+
+  it('falls back to the model date reference only when CLI sessions are empty', () => {
+    const defaults = makeAggregatedMetrics();
+    const metrics = makeAggregatedMetrics({
+      dailyCliSessionData: [],
+      modelBreakdownData: {
+        ...defaults.modelBreakdownData,
+        dates: ['2026-02-01', '2026-02-02'],
+      },
+    });
+
+    const model = selectCliAdoptionReadModel(metrics);
+
+    expect(model.cliModelDates).toBe(metrics.modelBreakdownData.dates);
+    expect(model.cliModelDates).toEqual(['2026-02-01', '2026-02-02']);
+  });
+
+  it('keeps CLI model entry, total, and share fallback semantics', () => {
+    const defaults = makeAggregatedMetrics();
+    const metrics = makeAggregatedMetrics({
+      stats: {
+        ...defaults.stats,
+        uniqueUsers: 0,
+        cliUsers: 8,
+        reportStartDay: 'not-a-start-date',
+        reportEndDay: 'not-an-end-date',
+      },
+      modelBreakdownData: {
+        ...defaults.modelBreakdownData,
+        cliModels: undefined,
+        cliTotal: undefined,
+      },
+    });
+
+    const model = selectCliAdoptionReadModel(metrics);
+
+    expect(model.cliModelEntries).toEqual([]);
+    expect(model.cliModelDates).toBe(metrics.modelBreakdownData.dates);
+    expect(model.cliModelTotal).toBe(0);
+    expect(model.cliShare).toBe(0);
+    expect(model.stats.reportStartDay).toBe('not-a-start-date');
+    expect(model.stats.reportEndDay).toBe('not-an-end-date');
+  });
+
+  it('does not replace defined signed totals or alter the share calculation', () => {
+    const defaults = makeAggregatedMetrics();
+    const metrics = makeAggregatedMetrics({
+      stats: {
+        ...defaults.stats,
+        uniqueUsers: 3,
+        cliUsers: -1,
+      },
+      modelBreakdownData: {
+        ...defaults.modelBreakdownData,
+        cliTotal: -4.5,
+      },
+    });
+
+    const model = selectCliAdoptionReadModel(metrics);
+
+    expect(model.cliModelTotal).toBe(-4.5);
+    expect(model.cliShare).toBe(-33.3);
+  });
+
+  it('preserves canonical empty CLI data and its references', () => {
+    const metrics = makeAggregatedMetrics();
+
+    const model = selectCliAdoptionReadModel(metrics);
+
+    expect(model).toEqual({
+      stats: metrics.stats,
+      dailyCliSessionData: [],
+      dailyCliTokenData: [],
+      dailyCliAdoptionTrend: [],
+      cliModelEntries: [],
+      cliModelDates: [],
+      cliModelTotal: 0,
+      cliShare: 0,
+    });
+    expect(model.stats).toBe(metrics.stats);
+    expect(model.dailyCliSessionData).toBe(metrics.dailyCliSessionData);
+    expect(model.dailyCliTokenData).toBe(metrics.dailyCliTokenData);
+    expect(model.dailyCliAdoptionTrend).toBe(metrics.dailyCliAdoptionTrend);
+    expect(model.cliModelEntries).toBe(metrics.modelBreakdownData.cliModels);
+    expect(model.cliModelDates).toBe(metrics.modelBreakdownData.dates);
+  });
+
+  it('does not mutate the aggregate input', () => {
+    const metrics = makeCliMetrics();
+    const before = structuredClone(metrics);
+
+    selectCliAdoptionReadModel(metrics);
+
+    expect(metrics).toEqual(before);
+  });
+});

--- a/src/read-models/cliAdoption.ts
+++ b/src/read-models/cliAdoption.ts
@@ -1,0 +1,39 @@
+import type { AggregatedMetrics } from '../types/aggregatedMetrics';
+
+export interface CliAdoptionReadModel {
+  stats: AggregatedMetrics['stats'];
+  dailyCliSessionData: AggregatedMetrics['dailyCliSessionData'];
+  dailyCliTokenData: AggregatedMetrics['dailyCliTokenData'];
+  dailyCliAdoptionTrend: AggregatedMetrics['dailyCliAdoptionTrend'];
+  cliModelEntries: NonNullable<
+    AggregatedMetrics['modelBreakdownData']['cliModels']
+  >;
+  cliModelDates: string[];
+  cliModelTotal: number;
+  cliShare: number;
+}
+
+export function selectCliAdoptionReadModel(
+  metrics: AggregatedMetrics
+): CliAdoptionReadModel {
+  const { stats, dailyCliSessionData, dailyCliTokenData, dailyCliAdoptionTrend } =
+    metrics;
+  const { cliModels = [], dates, cliTotal = 0 } = metrics.modelBreakdownData;
+
+  return {
+    stats,
+    dailyCliSessionData,
+    dailyCliTokenData,
+    dailyCliAdoptionTrend,
+    cliModelEntries: cliModels,
+    cliModelDates:
+      dailyCliSessionData.length > 0
+        ? dailyCliSessionData.map((entry) => entry.date)
+        : dates,
+    cliModelTotal: cliTotal,
+    cliShare:
+      stats.uniqueUsers > 0
+        ? Math.round((stats.cliUsers / stats.uniqueUsers) * 1000) / 10
+        : 0,
+  };
+}

--- a/src/read-models/models.ts
+++ b/src/read-models/models.ts
@@ -1,0 +1,36 @@
+import type { AggregatedMetrics } from '../types/aggregatedMetrics';
+
+export interface ModelDetailsReadModel {
+  allModels: AggregatedMetrics['modelBreakdownData']['allModels'];
+  modelCategories: AggregatedMetrics['modelBreakdownData']['modelCategories'];
+  autoModels: NonNullable<AggregatedMetrics['modelBreakdownData']['autoModels']>;
+  autoModeAdoptionTrend: NonNullable<
+    AggregatedMetrics['modelBreakdownData']['autoModeAdoptionTrend']
+  >;
+  dates: AggregatedMetrics['modelBreakdownData']['dates'];
+  modelTotal: number;
+  autoTotal: number;
+}
+
+export function selectModelDetailsReadModel(
+  metrics: AggregatedMetrics
+): ModelDetailsReadModel {
+  const {
+    allModels,
+    modelCategories,
+    autoModels = [],
+    autoModeAdoptionTrend = [],
+    dates,
+    modelTotal,
+  } = metrics.modelBreakdownData;
+
+  return {
+    allModels,
+    modelCategories,
+    autoModels,
+    autoModeAdoptionTrend,
+    dates,
+    modelTotal,
+    autoTotal: autoModels.reduce((sum, entry) => sum + entry.total, 0),
+  };
+}


### PR DESCRIPTION
## Why

Model-details and CLI-adoption still depended on flat aggregate forwarding and router-owned derivations. This completes their Phase 4 read-model boundaries while preserving the flat worker payload and existing UI semantics.

| Commit | Change |
|--------|--------|
| `refactor: add model and CLI read models` | Adds typed selectors, rewires both views to sole `model` props, and characterizes reference, date, total, and fallback contracts. |
| `docs: record model and CLI read-model coverage` | Records the completed boundaries and leaves AI credits as the only remaining Phase 4 slice. |