### PR TITLE
Complete feature read-model boundaries

### DIFF
--- a/docs/project-overview.md
+++ b/docs/project-overview.md
@@ -41,7 +41,7 @@ Next.js App Router SPA, TypeScript, Tailwind CSS. All rendering is client-side.
 - `MetricsContext` (`src/components/MetricsContext.tsx`) — stores the `AggregatedMetrics` result, loading/error/warning state, and data actions
 - `NavigationContext` (`src/state/NavigationContext.tsx`) — manages current view, selected user/model, and navigation actions
 
-**All view components consume pre-aggregated data.** No component accesses raw `CopilotMetrics[]` directly. The flat `AggregatedMetrics` worker/UI contract is declared in `src/types/aggregatedMetrics.ts`. Feature read-model selectors in `src/read-models/` insulate migrated UI paths from that flat payload; overview, executive summary, users, user details, Copilot adoption, AI adoption phases, Copilot impact, languages, clients, client versions, model details, and CLI adoption consume only their typed projections. The worker also retains a compact user-detail accumulator so it can serve user details on demand without moving raw records onto the main thread.
+**All view components consume pre-aggregated data.** No component accesses raw `CopilotMetrics[]` directly. The flat `AggregatedMetrics` worker/UI contract is declared in `src/types/aggregatedMetrics.ts`. Feature read-model selectors in `src/read-models/` insulate aggregate-backed UI paths from that flat payload; overview, executive summary, users, user details, Copilot adoption, AI adoption phases, Copilot impact, languages, clients, client versions, model details, CLI adoption, and AI credits consume only their typed projections. The worker also retains a compact user-detail accumulator so it can serve user details on demand without moving raw records onto the main thread.
 
 ### 3.2. Code Organization
 
@@ -66,7 +66,7 @@ Next.js App Router SPA, TypeScript, Tailwind CSS. All rendering is client-side.
 
 ### 3.4. Feature Read-Model Boundaries
 
-The worker payload remains the flat `AggregatedMetrics` object. Pure selectors under `src/read-models/` project stable references from that payload into narrow UI contracts without copying, sorting, filtering, or mutation. They may also relocate existing deterministic, feature-specific scalar or date derivations, such as client CLI totals, the model-details auto total, and CLI model chart dates.
+The worker payload remains the flat, unchanged `AggregatedMetrics` object. Pure selectors under `src/read-models/` project stable references from that payload into narrow UI contracts without copying, sorting, filtering, or mutation. Selectors may contain only existing deterministic, feature-specific scalar or date derivations, such as client CLI totals, the model-details auto total, CLI model chart dates, and the AI credits user total.
 
 Established boundaries cover:
 - overview and executive summary
@@ -77,8 +77,9 @@ Established boundaries cover:
 - languages
 - clients and client versions
 - model details and CLI adoption
+- AI credits
 
-AI credits is the only remaining Phase 4 slice. The worker payload remains flat; grouping it, moving component files, and decomposing the general `ViewRouter` registry remain separate work.
+Phase 4 feature read-model boundaries are complete for every aggregate-backed feature surface. The worker payload remains flat and unchanged; grouping it, moving component files, and decomposing the general `ViewRouter` registry remain separate work.
 
 ---
 

--- a/src/components/AiCreditsView.tsx
+++ b/src/components/AiCreditsView.tsx
@@ -5,18 +5,15 @@ import AiCreditsChart from './charts/AiCreditsChart';
 import { ViewPanel } from './ui';
 import MetricsTable, { TableColumn } from './ui/MetricsTable';
 import TopEntriesList from './ui/TopEntriesList';
+import type { AiCreditsReadModel } from '../read-models/aiCredits';
 import { formatAiAdoptionPhase, formatAiCreditCost, formatModelDisplayName, formatNumber, formatPercentage } from '../utils/formatters';
 import { formatIDEName, getIDEIcon } from './icons/IDEIcons';
 import { getModelIcon } from './icons/ModelIcons';
-import type { DailyAiCreditsData, UsageDistributionBucket } from '../domain/calculators/metricCalculators';
-import type { MetricsStats, UserSummary } from '../types/metrics';
+import type { UsageDistributionBucket } from '../domain/calculators/metricCalculators';
+import type { UserSummary } from '../types/metrics';
 
 interface AiCreditsViewProps {
-  stats: MetricsStats;
-  dailyAiCreditsData: DailyAiCreditsData[];
-  userSummaries: UserSummary[];
-  usageDistributionData: UsageDistributionBucket[];
-  onUserClick: (userLogin: string, userId: number) => void;
+  model: AiCreditsReadModel;
 }
 
 function formatAverage(value: number): string {
@@ -29,20 +26,30 @@ interface TopAiCreditsUser extends UserSummary {
 
 const TOP_USER_COUNT = 5;
 
-export default function AiCreditsView({ stats, dailyAiCreditsData, userSummaries, usageDistributionData, onUserClick }: AiCreditsViewProps) {
+export default function AiCreditsView({ model }: AiCreditsViewProps) {
+  const {
+    reportStartDay,
+    reportEndDay,
+    dailyAiCreditsData,
+    userSummaries,
+    usageDistributionData,
+    totalAiCreditsUsed,
+    onUserClick,
+  } = model;
   const hasAiCreditsData = dailyAiCreditsData.some(entry => entry.aiCreditsUsed > 0);
 
   const topUsers = useMemo<TopAiCreditsUser[]>(() => {
-    const totalCredits = userSummaries.reduce((sum, user) => sum + user.total_ai_credits_used, 0);
     return userSummaries
       .filter(user => user.total_ai_credits_used > 0)
       .sort((a, b) => b.total_ai_credits_used - a.total_ai_credits_used)
       .slice(0, TOP_USER_COUNT)
       .map(user => ({
         ...user,
-        creditsShare: totalCredits > 0 ? (user.total_ai_credits_used / totalCredits) * 100 : 0,
+        creditsShare: totalAiCreditsUsed > 0
+          ? (user.total_ai_credits_used / totalAiCreditsUsed) * 100
+          : 0,
       }));
-  }, [userSummaries]);
+  }, [totalAiCreditsUsed, userSummaries]);
 
   const headerBaseClass = 'px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider';
   const headerRightClass = 'px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider';
@@ -212,8 +219,8 @@ export default function AiCreditsView({ stats, dailyAiCreditsData, userSummaries
         <div id="ai-credits-daily-consumption" className="scroll-mt-28">
           <AiCreditsChart
             data={dailyAiCreditsData}
-            reportStartDay={stats.reportStartDay}
-            reportEndDay={stats.reportEndDay}
+            reportStartDay={reportStartDay}
+            reportEndDay={reportEndDay}
           />
         </div>
       ) : (

--- a/src/components/layout/ViewRouter.tsx
+++ b/src/components/layout/ViewRouter.tsx
@@ -21,6 +21,7 @@ import {
 } from '../../read-models/clients';
 import { selectModelDetailsReadModel } from '../../read-models/models';
 import { selectCliAdoptionReadModel } from '../../read-models/cliAdoption';
+import { selectAiCreditsReadModel } from '../../read-models/aiCredits';
 import { selectUsersReadModel } from '../../read-models/users';
 import { selectUserDetailsRouteReadModel } from '../../read-models/userDetails';
 import {
@@ -187,12 +188,6 @@ const ViewRouter: React.FC = () => {
     );
   }
 
-  const { 
-    stats, 
-    userSummaries,
-    dailyAiCreditsData = [],
-    usageDistributionData = [],
-  } = aggregatedMetrics;
   const overviewReadModel = selectOverviewReadModel(aggregatedMetrics);
   const executiveSummaryReadModel = selectExecutiveSummaryReadModel(aggregatedMetrics);
   const copilotAdoptionReadModel = selectCopilotAdoptionReadModel(aggregatedMetrics);
@@ -203,6 +198,10 @@ const ViewRouter: React.FC = () => {
   const clientVersionsReadModel = selectClientVersionsReadModel(aggregatedMetrics);
   const modelDetailsReadModel = selectModelDetailsReadModel(aggregatedMetrics);
   const cliAdoptionReadModel = selectCliAdoptionReadModel(aggregatedMetrics);
+  const aiCreditsReadModel = selectAiCreditsReadModel(
+    aggregatedMetrics,
+    handleUserClick
+  );
   const usersReadModel = selectUsersReadModel(aggregatedMetrics);
 
   switch (currentView) {
@@ -217,11 +216,7 @@ const ViewRouter: React.FC = () => {
     case VIEW_MODES.AI_CREDITS:
       return (
         <AiCreditsView
-          stats={stats}
-          dailyAiCreditsData={dailyAiCreditsData}
-          userSummaries={userSummaries}
-          usageDistributionData={usageDistributionData}
-          onUserClick={handleUserClick}
+          model={aiCreditsReadModel}
         />
       );
 

--- a/src/components/layout/__tests__/ViewRouter.test.tsx
+++ b/src/components/layout/__tests__/ViewRouter.test.tsx
@@ -16,6 +16,7 @@ import type {
 } from '../../../read-models/clients';
 import type { ModelDetailsReadModel } from '../../../read-models/models';
 import type { CliAdoptionReadModel } from '../../../read-models/cliAdoption';
+import type { AiCreditsReadModel } from '../../../read-models/aiCredits';
 import ViewRouter from '../ViewRouter';
 
 const mocks = vi.hoisted(() => ({
@@ -47,6 +48,9 @@ const mocks = vi.hoisted(() => ({
   cliAdoptionView: vi.fn<
     (props: { model: CliAdoptionReadModel }) => void
   >(),
+  aiCreditsView: vi.fn<
+    (props: { model: AiCreditsReadModel }) => void
+  >(),
   selectLanguagesReadModel: vi.fn<
     (metrics: AggregatedMetrics) => LanguagesReadModel
   >(),
@@ -61,6 +65,12 @@ const mocks = vi.hoisted(() => ({
   >(),
   selectCliAdoptionReadModel: vi.fn<
     (metrics: AggregatedMetrics) => CliAdoptionReadModel
+  >(),
+  selectAiCreditsReadModel: vi.fn<
+    (
+      metrics: AggregatedMetrics,
+      onUserClick: AiCreditsReadModel['onUserClick']
+    ) => AiCreditsReadModel
   >(),
 }));
 
@@ -159,6 +169,13 @@ vi.mock('../../CLIAdoptionView', () => ({
   },
 }));
 
+vi.mock('../../AiCreditsView', () => ({
+  default: (props: { model: AiCreditsReadModel }) => {
+    mocks.aiCreditsView(props);
+    return null;
+  },
+}));
+
 vi.mock('../../../read-models/languages', () => ({
   selectLanguagesReadModel: mocks.selectLanguagesReadModel,
 }));
@@ -176,6 +193,10 @@ vi.mock('../../../read-models/cliAdoption', () => ({
   selectCliAdoptionReadModel: mocks.selectCliAdoptionReadModel,
 }));
 
+vi.mock('../../../read-models/aiCredits', () => ({
+  selectAiCreditsReadModel: mocks.selectAiCreditsReadModel,
+}));
+
 describe('ViewRouter', () => {
   beforeEach(() => {
     mocks.navigateTo.mockClear();
@@ -187,11 +208,13 @@ describe('ViewRouter', () => {
     mocks.clientVersionsView.mockClear();
     mocks.modelDetailsView.mockClear();
     mocks.cliAdoptionView.mockClear();
+    mocks.aiCreditsView.mockClear();
     mocks.selectLanguagesReadModel.mockReset();
     mocks.selectClientsReadModel.mockReset();
     mocks.selectClientVersionsReadModel.mockReset();
     mocks.selectModelDetailsReadModel.mockReset();
     mocks.selectCliAdoptionReadModel.mockReset();
+    mocks.selectAiCreditsReadModel.mockReset();
     mocks.currentView = VIEW_MODES.USER_DETAILS;
     mocks.selectedUser = null;
     mocks.aggregatedMetrics = aggregateMetrics([makeMetric()]).aggregated;
@@ -233,6 +256,15 @@ describe('ViewRouter', () => {
       cliModelDates: metrics.modelBreakdownData.dates,
       cliModelTotal: metrics.modelBreakdownData.cliTotal ?? 0,
       cliShare: 0,
+    }));
+    mocks.selectAiCreditsReadModel.mockImplementation((metrics, onUserClick) => ({
+      reportStartDay: metrics.stats.reportStartDay,
+      reportEndDay: metrics.stats.reportEndDay,
+      dailyAiCreditsData: metrics.dailyAiCreditsData,
+      userSummaries: metrics.userSummaries,
+      usageDistributionData: metrics.usageDistributionData,
+      totalAiCreditsUsed: 0,
+      onUserClick,
     }));
   });
 
@@ -412,6 +444,31 @@ describe('ViewRouter', () => {
     );
     expect(mocks.cliAdoptionView).toHaveBeenCalledOnce();
     const props = mocks.cliAdoptionView.mock.calls[0][0];
+    expect(Object.keys(props)).toEqual(['model']);
+    expect(props.model).toBe(expectedModel);
+  });
+
+  it('routes AI Credits through the selector and a sole model prop', () => {
+    mocks.currentView = VIEW_MODES.AI_CREDITS;
+    const expectedModel: AiCreditsReadModel = {
+      reportStartDay: '2026-01-15',
+      reportEndDay: '2026-01-31',
+      dailyAiCreditsData: mocks.aggregatedMetrics!.dailyAiCreditsData,
+      userSummaries: mocks.aggregatedMetrics!.userSummaries,
+      usageDistributionData: mocks.aggregatedMetrics!.usageDistributionData,
+      totalAiCreditsUsed: 17.25,
+      onUserClick: vi.fn(),
+    };
+    mocks.selectAiCreditsReadModel.mockReturnValueOnce(expectedModel);
+
+    renderToStaticMarkup(<ViewRouter />);
+
+    expect(mocks.selectAiCreditsReadModel).toHaveBeenCalledOnce();
+    const [metrics, onUserClick] = mocks.selectAiCreditsReadModel.mock.calls[0];
+    expect(metrics).toBe(mocks.aggregatedMetrics);
+    expect(onUserClick).toEqual(expect.any(Function));
+    expect(mocks.aiCreditsView).toHaveBeenCalledOnce();
+    const props = mocks.aiCreditsView.mock.calls[0][0];
     expect(Object.keys(props)).toEqual(['model']);
     expect(props.model).toBe(expectedModel);
   });

--- a/src/read-models/__tests__/aiCreditsReadModel.test.ts
+++ b/src/read-models/__tests__/aiCreditsReadModel.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  makeAggregatedMetrics,
+  makeUserSummary,
+} from '../../__tests__/factories/aggregatedMetrics';
+import type { AggregatedMetrics } from '../../types/aggregatedMetrics';
+import { selectAiCreditsReadModel } from '../aiCredits';
+
+function makeAiCreditsMetrics(): AggregatedMetrics {
+  const defaults = makeAggregatedMetrics();
+
+  return makeAggregatedMetrics({
+    stats: {
+      ...defaults.stats,
+      reportStartDay: '2026-01-15',
+      reportEndDay: '2026-01-17',
+    },
+    dailyAiCreditsData: [
+      { date: '2026-01-17', aiCreditsUsed: -0.25, users: 1 },
+      { date: '2026-01-15', aiCreditsUsed: 2.5, users: 2 },
+    ],
+    userSummaries: [
+      makeUserSummary({
+        user_login: 'fractional',
+        user_id: 1,
+        total_ai_credits_used: 2.5,
+      }),
+      makeUserSummary({
+        user_login: 'signed',
+        user_id: 2,
+        total_ai_credits_used: -0.25,
+      }),
+    ],
+    usageDistributionData: [{
+      id: 'power',
+      label: 'Power Users',
+      description: 'Top users',
+      userCount: 1,
+      totalAiCreditsUsed: 2.5,
+      avgAiCreditsUsed: 2.5,
+      avgDaysActive: 1.5,
+      totalLocAdded: 10,
+      totalLocDeleted: 2,
+      topModels: [{ name: 'gpt-5', total: 4, uniqueUsers: 1 }],
+      topClients: [{ name: 'vscode', total: 3, uniqueUsers: 1 }],
+    }],
+  });
+}
+
+describe('AI Credits read model', () => {
+  it('selects the exact shape and preserves every projected source reference', () => {
+    const metrics = makeAiCreditsMetrics();
+    const onUserClick = vi.fn();
+
+    const model = selectAiCreditsReadModel(metrics, onUserClick);
+
+    expect(model).toEqual({
+      reportStartDay: '2026-01-15',
+      reportEndDay: '2026-01-17',
+      dailyAiCreditsData: metrics.dailyAiCreditsData,
+      userSummaries: metrics.userSummaries,
+      usageDistributionData: metrics.usageDistributionData,
+      totalAiCreditsUsed: 2.25,
+      onUserClick,
+    });
+    expect(model.dailyAiCreditsData).toBe(metrics.dailyAiCreditsData);
+    expect(model.dailyAiCreditsData[0]).toBe(metrics.dailyAiCreditsData[0]);
+    expect(model.userSummaries).toBe(metrics.userSummaries);
+    expect(model.userSummaries[0]).toBe(metrics.userSummaries[0]);
+    expect(model.usageDistributionData).toBe(metrics.usageDistributionData);
+    expect(model.usageDistributionData[0]).toBe(
+      metrics.usageDistributionData[0]
+    );
+    expect(model.usageDistributionData[0].topModels).toBe(
+      metrics.usageDistributionData[0].topModels
+    );
+    expect(model.usageDistributionData[0].topModels[0]).toBe(
+      metrics.usageDistributionData[0].topModels[0]
+    );
+    expect(model.usageDistributionData[0].topClients).toBe(
+      metrics.usageDistributionData[0].topClients
+    );
+    expect(model.usageDistributionData[0].topClients[0]).toBe(
+      metrics.usageDistributionData[0].topClients[0]
+    );
+    expect(model.onUserClick).toBe(onUserClick);
+    expect(Object.keys(model)).toEqual([
+      'reportStartDay',
+      'reportEndDay',
+      'dailyAiCreditsData',
+      'userSummaries',
+      'usageDistributionData',
+      'totalAiCreditsUsed',
+      'onUserClick',
+    ]);
+    expect(model).not.toHaveProperty('stats');
+    expect(model).not.toHaveProperty('modelBreakdownData');
+    expect(model).not.toHaveProperty('aiAdoptionPhaseData');
+  });
+
+  it('preserves canonical empty inputs and their references', () => {
+    const metrics = makeAggregatedMetrics();
+    const onUserClick = vi.fn();
+
+    const model = selectAiCreditsReadModel(metrics, onUserClick);
+
+    expect(model).toEqual({
+      reportStartDay: '',
+      reportEndDay: '',
+      dailyAiCreditsData: [],
+      userSummaries: [],
+      usageDistributionData: metrics.usageDistributionData,
+      totalAiCreditsUsed: 0,
+      onUserClick,
+    });
+    expect(model.dailyAiCreditsData).toBe(metrics.dailyAiCreditsData);
+    expect(model.userSummaries).toBe(metrics.userSummaries);
+    expect(model.usageDistributionData).toBe(metrics.usageDistributionData);
+  });
+
+  it('keeps the existing runtime array fallbacks and date scalar semantics', () => {
+    const metrics = makeAggregatedMetrics({
+      stats: {
+        ...makeAggregatedMetrics().stats,
+        reportStartDay: 'not-a-start-date',
+        reportEndDay: 'not-an-end-date',
+      },
+    });
+    Reflect.set(metrics, 'dailyAiCreditsData', undefined);
+    Reflect.set(metrics, 'usageDistributionData', undefined);
+
+    const model = selectAiCreditsReadModel(metrics, vi.fn());
+
+    expect(model.dailyAiCreditsData).toEqual([]);
+    expect(model.usageDistributionData).toEqual([]);
+    expect(model.reportStartDay).toBe('not-a-start-date');
+    expect(model.reportEndDay).toBe('not-an-end-date');
+  });
+
+  it('keeps signed and fractional totals without rounding or clamping', () => {
+    const metrics = makeAggregatedMetrics({
+      userSummaries: [
+        makeUserSummary({ total_ai_credits_used: -4.75 }),
+        makeUserSummary({ total_ai_credits_used: 1.125 }),
+      ],
+    });
+
+    const model = selectAiCreditsReadModel(metrics, vi.fn());
+
+    expect(model.totalAiCreditsUsed).toBe(-3.625);
+  });
+
+  it('does not mutate the aggregate input', () => {
+    const metrics = makeAiCreditsMetrics();
+    const before = structuredClone(metrics);
+
+    selectAiCreditsReadModel(metrics, vi.fn());
+
+    expect(metrics).toEqual(before);
+  });
+});

--- a/src/read-models/aiCredits.ts
+++ b/src/read-models/aiCredits.ts
@@ -1,0 +1,36 @@
+import type { AggregatedMetrics } from '../types/aggregatedMetrics';
+
+export interface AiCreditsReadModel {
+  reportStartDay: AggregatedMetrics['stats']['reportStartDay'];
+  reportEndDay: AggregatedMetrics['stats']['reportEndDay'];
+  dailyAiCreditsData: AggregatedMetrics['dailyAiCreditsData'];
+  userSummaries: AggregatedMetrics['userSummaries'];
+  usageDistributionData: AggregatedMetrics['usageDistributionData'];
+  totalAiCreditsUsed: number;
+  onUserClick: (userLogin: string, userId: number) => void;
+}
+
+export function selectAiCreditsReadModel(
+  metrics: AggregatedMetrics,
+  onUserClick: AiCreditsReadModel['onUserClick']
+): AiCreditsReadModel {
+  const {
+    stats: { reportStartDay, reportEndDay },
+    dailyAiCreditsData = [],
+    userSummaries,
+    usageDistributionData = [],
+  } = metrics;
+
+  return {
+    reportStartDay,
+    reportEndDay,
+    dailyAiCreditsData,
+    userSummaries,
+    usageDistributionData,
+    totalAiCreditsUsed: userSummaries.reduce(
+      (total, user) => total + user.total_ai_credits_used,
+      0
+    ),
+    onUserClick,
+  };
+}


### PR DESCRIPTION
## Why

This completes Phase 4 by insulating the final aggregate-backed AI Credits surface behind a narrow typed read model while leaving the flat worker payload unchanged. It gives every aggregate-consuming feature route a cohesive tested boundary.

| Commit | Change |
|--------|--------|
| `refactor: add AI Credits read model` | Add the exact AI Credits projection, sole model prop route, and focused contract tests. |
| `docs: mark Phase 4 read models complete` | Record full feature-boundary coverage and the unchanged flat worker contract. |