### PR TITLE
Modularize language and model aggregation

### DIFF
--- a/docs/project-overview.md
+++ b/docs/project-overview.md
@@ -51,6 +51,7 @@ Next.js App Router SPA, TypeScript, Tailwind CSS. All rendering is client-side.
 | `src/components/` | View components, charts, layout, UI primitives |
 | `src/components/charts/` | Chart.js visualizations (via react-chartjs-2) |
 | `src/domain/` | Business logic: aggregator, model config, calculators |
+| `src/domain/aggregation/` | Concrete metric-family accumulator lifecycle orchestration |
 | `src/infra/` | Streaming metrics file parser |
 | `src/domain/calculators/` | Individual metric calculators (stats, engagement, model usage, impact, etc.) |
 | `src/hooks/` | Reusable React hooks (file upload, sorting, search) |
@@ -106,7 +107,9 @@ flowchart LR
 
 ### 4.2. Aggregation
 
-`metricsAggregator.ts` orchestrates all calculators in `src/domain/calculators/` to produce the flat `AggregatedMetrics` object declared in `src/types/aggregatedMetrics.ts`. This includes user summaries, daily time series, language/IDE/model breakdowns, model usage analysis, feature adoption, and LOC impact by mode. The worker payload remains flat; `src/read-models/` provides feature boundaries on the consuming side. See the calculator files for specifics.
+`metricsAggregator.ts` retains the single explicit pass over raw records and coordinates concrete metric-family lifecycles in `src/domain/aggregation/` with calculators in `src/domain/calculators/`. Language and model orchestration now own their accumulator creation, per-record nested consumption, and narrow finalization while sharing the parent-owned stats accumulator. Their family results map into the same flat `AggregatedMetrics` object declared in `src/types/aggregatedMetrics.ts`, so the worker protocol and UI payload remain unchanged.
+
+Phase 5 modular aggregation orchestration has begun with the language and model families. User summaries, engagement/chat, feature adoption, impact, IDE/plugin versions, CLI, advanced adoption, AI adoption phases, AI credits, and user-detail orchestration remain in the top-level coordinator for later slices.
 
 ### 4.3. Views
 
@@ -136,6 +139,7 @@ flowchart TB
 	subgraph WebWorker[Web Worker]
 		MFP[infra/metricsFileParser.ts]
 		MA[metricsAggregator.ts]
+		AGG[aggregation/]
 		CALC[calculators/]
 		MConf[modelConfig.ts]
 	end
@@ -156,6 +160,8 @@ flowchart TB
 	WC -->|postMessage| WT
 	WT --> MFP
 	WT --> MA
+	MA --> AGG
+	AGG --> CALC
 	MA --> CALC
 	CALC --> MConf
 

--- a/src/domain/aggregation/__tests__/languageAggregation.test.ts
+++ b/src/domain/aggregation/__tests__/languageAggregation.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from 'vitest';
+import { makeMetric } from '../../../__tests__/factories/metrics';
+import {
+  computeStats,
+  createStatsAccumulator,
+} from '../../calculators/statsCalculator';
+import {
+  accumulateLanguageAggregation,
+  createLanguageAggregationAccumulator,
+  finalizeLanguageAggregation,
+} from '../languageAggregation';
+
+describe('language aggregation orchestration', () => {
+  it('preserves empty family defaults without replacing the shared stats accumulator', () => {
+    const statsAccumulator = createStatsAccumulator();
+    const accumulator = createLanguageAggregationAccumulator();
+
+    expect(finalizeLanguageAggregation(accumulator)).toEqual({
+      languageStats: [],
+      languageFeatureImpactData: { rows: [], features: [] },
+      dailyLanguageGenerationsData: {
+        dates: [],
+        languages: [],
+        data: {},
+        totals: {},
+      },
+      dailyLanguageLocData: {
+        dates: [],
+        languages: [],
+        data: {},
+        totals: {},
+      },
+    });
+    expect(computeStats(statsAccumulator, 0).topLanguage).toEqual({
+      name: 'N/A',
+      engagements: 0,
+    });
+  });
+
+  it('coordinates stats, language totals, impact filtering, ordering, and daily padding', () => {
+    const statsAccumulator = createStatsAccumulator();
+    const accumulator = createLanguageAggregationAccumulator();
+    const laterMetric = makeMetric({
+      user_id: 1,
+      day: '2024-01-16',
+      totals_by_language_feature: [
+        {
+          language: 'typescript',
+          feature: 'code_completion',
+          code_generation_activity_count: 2,
+          code_acceptance_activity_count: 1,
+          loc_added_sum: 10,
+          loc_deleted_sum: 2,
+          loc_suggested_to_add_sum: 20,
+          loc_suggested_to_delete_sum: 4,
+        },
+        {
+          language: 'unknown',
+          feature: 'chat_panel_ask_mode',
+          code_generation_activity_count: 9,
+          code_acceptance_activity_count: 0,
+          loc_added_sum: 100,
+          loc_deleted_sum: 25,
+          loc_suggested_to_add_sum: 0,
+          loc_suggested_to_delete_sum: 0,
+        },
+      ],
+    });
+    const earlierMetric = makeMetric({
+      user_id: 2,
+      day: '2024-01-15',
+      totals_by_language_feature: [
+        {
+          language: 'python',
+          feature: 'chat_panel_ask_mode',
+          code_generation_activity_count: 5,
+          code_acceptance_activity_count: 2,
+          loc_added_sum: 8,
+          loc_deleted_sum: 3,
+          loc_suggested_to_add_sum: 0,
+          loc_suggested_to_delete_sum: 0,
+        },
+        {
+          language: 'typescript',
+          feature: 'chat_panel_ask_mode',
+          code_generation_activity_count: 1,
+          code_acceptance_activity_count: 4,
+          loc_added_sum: 1,
+          loc_deleted_sum: 1,
+          loc_suggested_to_add_sum: 2,
+          loc_suggested_to_delete_sum: 1,
+        },
+      ],
+    });
+
+    accumulateLanguageAggregation(accumulator, statsAccumulator, laterMetric);
+    accumulateLanguageAggregation(accumulator, statsAccumulator, earlierMetric);
+
+    const result = finalizeLanguageAggregation(accumulator);
+    expect(computeStats(statsAccumulator, 2).topLanguage).toEqual({
+      name: 'unknown',
+      engagements: 9,
+    });
+    expect(result.languageStats.map(language => language.language)).toEqual([
+      'unknown',
+      'typescript',
+      'python',
+    ]);
+    expect(result.languageStats.find(language => language.language === 'typescript')).toEqual({
+      language: 'typescript',
+      totalGenerations: 3,
+      totalAcceptances: 5,
+      totalEngagements: 8,
+      uniqueUsers: 2,
+      locAdded: 11,
+      locDeleted: 3,
+      locSuggestedToAdd: 22,
+      locSuggestedToDelete: 5,
+    });
+    expect(result.languageFeatureImpactData).toEqual({
+      rows: [
+        {
+          language: 'typescript',
+          total: 14,
+          features: {
+            chat_panel_ask_mode: 2,
+            code_completion: 12,
+          },
+        },
+        {
+          language: 'python',
+          total: 11,
+          features: {
+            chat_panel_ask_mode: 11,
+            code_completion: 0,
+          },
+        },
+      ],
+      features: ['chat_panel_ask_mode', 'code_completion'],
+    });
+    expect(result.dailyLanguageGenerationsData).toEqual({
+      dates: ['2024-01-15', '2024-01-16'],
+      languages: ['unknown', 'python', 'typescript'],
+      data: {
+        '2024-01-15': { unknown: 0, python: 5, typescript: 1 },
+        '2024-01-16': { unknown: 9, python: 0, typescript: 2 },
+      },
+      totals: { unknown: 9, python: 5, typescript: 3 },
+    });
+  });
+});

--- a/src/domain/aggregation/__tests__/modelAggregation.test.ts
+++ b/src/domain/aggregation/__tests__/modelAggregation.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from 'vitest';
+import { makeMetric } from '../../../__tests__/factories/metrics';
+import {
+  computeStats,
+  createStatsAccumulator,
+} from '../../calculators/statsCalculator';
+import {
+  accumulateModelAggregation,
+  createModelAggregationAccumulator,
+  finalizeModelAggregation,
+} from '../modelAggregation';
+
+describe('model aggregation orchestration', () => {
+  it('preserves empty family defaults without replacing the shared stats accumulator', () => {
+    const statsAccumulator = createStatsAccumulator();
+    const accumulator = createModelAggregationAccumulator();
+
+    expect(finalizeModelAggregation(accumulator)).toEqual({
+      modelUsageData: [],
+      agentModeHeatmapData: [],
+      modelBreakdownData: {
+        allModels: [],
+        modelCategories: [],
+        autoModels: [],
+        cliModels: [],
+        autoModeAdoptionTrend: [],
+        dates: [],
+        modelTotal: 0,
+        cliTotal: 0,
+        unknownTotal: 0,
+      },
+    });
+    expect(computeStats(statsAccumulator, 0).topModel).toEqual({
+      name: 'N/A',
+      engagements: 0,
+    });
+  });
+
+  it('coordinates canonical interactions, engagement stats, model ordering, and heatmap dates', () => {
+    const statsAccumulator = createStatsAccumulator();
+    const accumulator = createModelAggregationAccumulator();
+    const laterMetric = makeMetric({
+      user_id: 1,
+      day: '2024-01-16',
+      totals_by_model_feature: [
+        {
+          model: 'gpt-4o',
+          feature: 'code_completion',
+          user_initiated_interaction_count: 0,
+          code_generation_activity_count: 4,
+          code_acceptance_activity_count: 1,
+          loc_added_sum: 0,
+          loc_deleted_sum: 0,
+          loc_suggested_to_add_sum: 0,
+          loc_suggested_to_delete_sum: 0,
+        },
+        {
+          model: 'unknown',
+          feature: 'chat_panel_ask_mode',
+          user_initiated_interaction_count: 3,
+          code_generation_activity_count: 0,
+          code_acceptance_activity_count: 0,
+          loc_added_sum: 0,
+          loc_deleted_sum: 0,
+          loc_suggested_to_add_sum: 0,
+          loc_suggested_to_delete_sum: 0,
+        },
+      ],
+      totals_by_feature: [
+        {
+          feature: 'chat_panel_agent_mode',
+          user_initiated_interaction_count: 4,
+          code_generation_activity_count: 0,
+          code_acceptance_activity_count: 0,
+          loc_added_sum: 0,
+          loc_deleted_sum: 0,
+          loc_suggested_to_add_sum: 0,
+          loc_suggested_to_delete_sum: 0,
+        },
+      ],
+    });
+    const earlierMetric = makeMetric({
+      user_id: 2,
+      day: '2024-01-15',
+      totals_by_model_feature: [
+        {
+          model: 'gpt-5',
+          feature: 'chat_panel_ask_mode',
+          user_initiated_interaction_count: 6,
+          code_generation_activity_count: 1,
+          code_acceptance_activity_count: 1,
+          loc_added_sum: 0,
+          loc_deleted_sum: 0,
+          loc_suggested_to_add_sum: 0,
+          loc_suggested_to_delete_sum: 0,
+        },
+      ],
+      totals_by_feature: [
+        {
+          feature: 'chat_panel_agent_mode',
+          user_initiated_interaction_count: 2,
+          code_generation_activity_count: 0,
+          code_acceptance_activity_count: 0,
+          loc_added_sum: 0,
+          loc_deleted_sum: 0,
+          loc_suggested_to_add_sum: 0,
+          loc_suggested_to_delete_sum: 0,
+        },
+      ],
+    });
+
+    accumulateModelAggregation(accumulator, statsAccumulator, laterMetric);
+    accumulateModelAggregation(accumulator, statsAccumulator, earlierMetric);
+
+    const result = finalizeModelAggregation(accumulator);
+    expect(computeStats(statsAccumulator, 2).topModel).toEqual({
+      name: 'gpt-4o',
+      engagements: 5,
+    });
+    expect(result.modelUsageData).toEqual([
+      {
+        date: '2024-01-15',
+        modelInteractions: 6,
+        unknownModels: 0,
+      },
+      {
+        date: '2024-01-16',
+        modelInteractions: 7,
+        unknownModels: 3,
+      },
+    ]);
+    expect(result.agentModeHeatmapData).toEqual([
+      {
+        date: '2024-01-15',
+        agentModeRequests: 2,
+        uniqueUsers: 1,
+        intensity: 3,
+      },
+      {
+        date: '2024-01-16',
+        agentModeRequests: 4,
+        uniqueUsers: 1,
+        intensity: 5,
+      },
+    ]);
+    expect(result.modelBreakdownData.dates).toEqual([
+      '2024-01-15',
+      '2024-01-16',
+    ]);
+    expect(result.modelBreakdownData.allModels).toEqual([
+      {
+        model: 'gpt-5',
+        total: 6,
+        dailyData: { '2024-01-15': 6 },
+      },
+      {
+        model: 'gpt-4o',
+        total: 4,
+        dailyData: { '2024-01-16': 4 },
+      },
+      {
+        model: 'unknown',
+        total: 3,
+        dailyData: { '2024-01-16': 3 },
+      },
+    ]);
+  });
+});

--- a/src/domain/aggregation/languageAggregation.ts
+++ b/src/domain/aggregation/languageAggregation.ts
@@ -1,0 +1,93 @@
+import type { AggregatedMetrics } from '../../types/aggregatedMetrics';
+import type { CopilotMetrics } from '../../types/metrics';
+import {
+  accumulateLanguageFeatureImpact,
+  accumulateDailyLanguage,
+  computeDailyLanguageChartData,
+  computeLanguageFeatureImpactData,
+  createLanguageFeatureImpactAccumulator,
+  type LanguageFeatureImpactAccumulator,
+} from '../calculators/languageFeatureImpactCalculator';
+import {
+  accumulateLanguageStats,
+  computeLanguageStats,
+  createLanguageAccumulator,
+  type LanguageAccumulator,
+} from '../calculators/languageCalculator';
+import {
+  accumulateLanguageEngagement,
+  type StatsAccumulator,
+} from '../calculators/statsCalculator';
+
+export interface LanguageAggregationAccumulator {
+  language: LanguageAccumulator;
+  featureImpact: LanguageFeatureImpactAccumulator;
+}
+
+export type LanguageAggregationResult = Pick<
+  AggregatedMetrics,
+  | 'languageStats'
+  | 'languageFeatureImpactData'
+  | 'dailyLanguageGenerationsData'
+  | 'dailyLanguageLocData'
+>;
+
+export function createLanguageAggregationAccumulator(): LanguageAggregationAccumulator {
+  return {
+    language: createLanguageAccumulator(),
+    featureImpact: createLanguageFeatureImpactAccumulator(),
+  };
+}
+
+export function accumulateLanguageAggregation(
+  accumulator: LanguageAggregationAccumulator,
+  statsAccumulator: StatsAccumulator,
+  metric: CopilotMetrics
+): void {
+  for (const languageFeature of metric.totals_by_language_feature) {
+    const engagements =
+      languageFeature.code_generation_activity_count
+      + languageFeature.code_acceptance_activity_count;
+    accumulateLanguageEngagement(
+      statsAccumulator,
+      languageFeature.language,
+      engagements
+    );
+    accumulateLanguageStats(
+      accumulator.language,
+      metric.user_id,
+      languageFeature.language,
+      languageFeature.code_generation_activity_count,
+      languageFeature.code_acceptance_activity_count,
+      languageFeature.loc_added_sum,
+      languageFeature.loc_deleted_sum,
+      languageFeature.loc_suggested_to_add_sum,
+      languageFeature.loc_suggested_to_delete_sum
+    );
+    accumulateLanguageFeatureImpact(accumulator.featureImpact, languageFeature);
+    accumulateDailyLanguage(
+      accumulator.featureImpact,
+      metric.day,
+      languageFeature
+    );
+  }
+}
+
+export function finalizeLanguageAggregation(
+  accumulator: LanguageAggregationAccumulator
+): LanguageAggregationResult {
+  return {
+    languageStats: computeLanguageStats(accumulator.language),
+    languageFeatureImpactData: computeLanguageFeatureImpactData(
+      accumulator.featureImpact
+    ),
+    dailyLanguageGenerationsData: computeDailyLanguageChartData(
+      accumulator.featureImpact,
+      'generations'
+    ),
+    dailyLanguageLocData: computeDailyLanguageChartData(
+      accumulator.featureImpact,
+      'loc'
+    ),
+  };
+}

--- a/src/domain/aggregation/modelAggregation.ts
+++ b/src/domain/aggregation/modelAggregation.ts
@@ -1,0 +1,87 @@
+import type { AggregatedMetrics } from '../../types/aggregatedMetrics';
+import type { CopilotMetrics } from '../../types/metrics';
+import { getCanonicalUserInitiatedInteractionCount } from '../assumedInteractions';
+import {
+  accumulateModelBreakdown,
+  computeModelBreakdownData,
+  createModelBreakdownAccumulator,
+  type ModelBreakdownAccumulator,
+} from '../calculators/modelBreakdownCalculator';
+import {
+  accumulateAgentHeatmapFromFeature,
+  accumulateModelFeature,
+  computeAgentModeHeatmapData,
+  computeDailyModelUsageData,
+  createModelUsageAccumulator,
+  type ModelUsageAccumulator,
+} from '../calculators/modelUsageCalculator';
+import {
+  accumulateModelEngagement,
+  type StatsAccumulator,
+} from '../calculators/statsCalculator';
+
+export interface ModelAggregationAccumulator {
+  usage: ModelUsageAccumulator;
+  breakdown: ModelBreakdownAccumulator;
+}
+
+export type ModelAggregationResult = Pick<
+  AggregatedMetrics,
+  'modelUsageData' | 'agentModeHeatmapData' | 'modelBreakdownData'
+>;
+
+export function createModelAggregationAccumulator(): ModelAggregationAccumulator {
+  return {
+    usage: createModelUsageAccumulator(),
+    breakdown: createModelBreakdownAccumulator(),
+  };
+}
+
+export function accumulateModelAggregation(
+  accumulator: ModelAggregationAccumulator,
+  statsAccumulator: StatsAccumulator,
+  metric: CopilotMetrics
+): void {
+  for (const modelFeature of metric.totals_by_model_feature) {
+    const engagements =
+      modelFeature.code_generation_activity_count
+      + modelFeature.code_acceptance_activity_count;
+    accumulateModelEngagement(
+      statsAccumulator,
+      modelFeature.model,
+      engagements
+    );
+    accumulateModelFeature(
+      accumulator.usage,
+      metric.day,
+      modelFeature.model,
+      getCanonicalUserInitiatedInteractionCount(modelFeature)
+    );
+    accumulateModelBreakdown(
+      accumulator.breakdown,
+      metric.day,
+      metric.user_id,
+      modelFeature
+    );
+  }
+
+  for (const feature of metric.totals_by_feature) {
+    accumulateAgentHeatmapFromFeature(
+      accumulator.usage,
+      metric.day,
+      metric.user_id,
+      feature.feature,
+      feature.user_initiated_interaction_count
+    );
+  }
+}
+
+export function finalizeModelAggregation(
+  accumulator: ModelAggregationAccumulator
+): ModelAggregationResult {
+  return {
+    modelUsageData: computeDailyModelUsageData(accumulator.usage),
+    agentModeHeatmapData: computeAgentModeHeatmapData(accumulator.usage),
+    modelBreakdownData: computeModelBreakdownData(accumulator.breakdown),
+  };
+}

--- a/src/domain/metricsAggregator.ts
+++ b/src/domain/metricsAggregator.ts
@@ -5,11 +5,19 @@ import {
 import type { AggregatedMetrics } from '../types/aggregatedMetrics';
 import { resolveCopilotCloudAgentUsage } from './copilotCloudAgentUsage';
 import {
+  accumulateLanguageAggregation,
+  createLanguageAggregationAccumulator,
+  finalizeLanguageAggregation,
+} from './aggregation/languageAggregation';
+import {
+  accumulateModelAggregation,
+  createModelAggregationAccumulator,
+  finalizeModelAggregation,
+} from './aggregation/modelAggregation';
+import {
   createStatsAccumulator,
   accumulateUserUsage,
   accumulateIdeUser,
-  accumulateLanguageEngagement,
-  accumulateModelEngagement,
   computeStats,
 
   createEngagementAccumulator,
@@ -21,16 +29,6 @@ import {
   accumulateChatFeature,
   computeChatUsersData,
   computeChatRequestsData,
-
-  createLanguageAccumulator,
-  accumulateLanguageStats,
-  computeLanguageStats,
-
-  createModelUsageAccumulator,
-  accumulateModelFeature,
-  accumulateAgentHeatmapFromFeature,
-  computeDailyModelUsageData,
-  computeAgentModeHeatmapData,
 
   createFeatureAdoptionAccumulator,
   accumulateFeatureAdoption,
@@ -61,16 +59,6 @@ import {
   accumulatePluginVersion,
   computePluginVersionData,
 
-  createLanguageFeatureImpactAccumulator,
-  accumulateLanguageFeatureImpact,
-  accumulateDailyLanguage,
-  computeLanguageFeatureImpactData,
-  computeDailyLanguageChartData,
-
-  createModelBreakdownAccumulator,
-  accumulateModelBreakdown,
-  computeModelBreakdownData,
-
   type UserDetailAccumulator,
   createUserDetailAccumulator,
   accumulateUserDetail,
@@ -99,7 +87,6 @@ import {
   computeDailyAiCreditsData,
 } from './calculators';
 import { isActiveAutoModeFeature } from './autoMode';
-import { getCanonicalUserInitiatedInteractionCount } from './assumedInteractions';
 
 interface UserSummaryAccumulator {
   userMap: Map<number, UserSummary>;
@@ -263,14 +250,12 @@ export function aggregateMetrics(
   const userSummaryAccumulator = createUserSummaryAccumulator();
   const engagementAccumulator = createEngagementAccumulator();
   const chatAccumulator = createChatAccumulator();
-  const languageAccumulator = createLanguageAccumulator();
-  const modelUsageAccumulator = createModelUsageAccumulator();
+  const languageAggregationAccumulator = createLanguageAggregationAccumulator();
+  const modelAggregationAccumulator = createModelAggregationAccumulator();
   const featureAdoptionAccumulator = createFeatureAdoptionAccumulator();
   const impactAccumulator = createImpactAccumulator();
   const ideStatsAccumulator = createIDEStatsAccumulator();
   const pluginVersionAccumulator = createPluginVersionAccumulator();
-  const languageFeatureImpactAccumulator = createLanguageFeatureImpactAccumulator();
-  const modelBreakdownAccumulator = createModelBreakdownAccumulator();
   const cliUsageAccumulator = createCliUsageAccumulator();
   const advancedAdoptionAccumulator = createAdvancedAdoptionAccumulator();
   const aiAdoptionPhaseAccumulator = createAiAdoptionPhaseAccumulator();
@@ -313,39 +298,16 @@ export function aggregateMetrics(
       markCliUser(ideStatsAccumulator, userId);
     }
 
-    for (const langFeature of metric.totals_by_language_feature) {
-      const engagements = langFeature.code_generation_activity_count + langFeature.code_acceptance_activity_count;
-      accumulateLanguageEngagement(statsAccumulator, langFeature.language, engagements);
-
-      accumulateLanguageStats(
-        languageAccumulator,
-        userId,
-        langFeature.language,
-        langFeature.code_generation_activity_count,
-        langFeature.code_acceptance_activity_count,
-        langFeature.loc_added_sum,
-        langFeature.loc_deleted_sum,
-        langFeature.loc_suggested_to_add_sum,
-        langFeature.loc_suggested_to_delete_sum
-      );
-
-      accumulateLanguageFeatureImpact(languageFeatureImpactAccumulator, langFeature);
-      accumulateDailyLanguage(languageFeatureImpactAccumulator, date, langFeature);
-    }
-
-    for (const modelFeature of metric.totals_by_model_feature) {
-      const engagements = modelFeature.code_generation_activity_count + modelFeature.code_acceptance_activity_count;
-      accumulateModelEngagement(statsAccumulator, modelFeature.model, engagements);
-
-      accumulateModelFeature(
-        modelUsageAccumulator,
-        date,
-        modelFeature.model,
-        getCanonicalUserInitiatedInteractionCount(modelFeature)
-      );
-
-      accumulateModelBreakdown(modelBreakdownAccumulator, date, userId, modelFeature);
-    }
+    accumulateLanguageAggregation(
+      languageAggregationAccumulator,
+      statsAccumulator,
+      metric
+    );
+    accumulateModelAggregation(
+      modelAggregationAccumulator,
+      statsAccumulator,
+      metric
+    );
 
     const featureImpacts: FeatureImpactInput[] = [];
 
@@ -383,54 +345,51 @@ export function aggregateMetrics(
         feature.user_initiated_interaction_count
       );
 
-      accumulateAgentHeatmapFromFeature(
-        modelUsageAccumulator,
-        date,
-        userId,
-        feature.feature,
-        feature.user_initiated_interaction_count
-      );
-
       featureImpacts.push(createFeatureImpactInput(feature));
     }
 
     accumulateFeatureImpacts(impactAccumulator, date, userId, featureImpacts);
   }
   const userSummaries = computeUserSummaries(userSummaryAccumulator);
+  const languageAggregation = finalizeLanguageAggregation(
+    languageAggregationAccumulator
+  );
+  const modelAggregation = finalizeModelAggregation(modelAggregationAccumulator);
 
   return {
     aggregated: {
-    stats: computeStats(statsAccumulator, filteredMetricsCount),
-    userSummaries,
-    engagementData: computeEngagementData(engagementAccumulator, cliUsageAccumulator),
-    chatUsersData: computeChatUsersData(chatAccumulator, cliUsageAccumulator),
-    chatRequestsData: computeChatRequestsData(chatAccumulator, cliUsageAccumulator),
-    languageStats: computeLanguageStats(languageAccumulator),
-    modelUsageData: computeDailyModelUsageData(modelUsageAccumulator),
-    featureAdoptionData: computeFeatureAdoptionData(featureAdoptionAccumulator),
-    agentModeHeatmapData: computeAgentModeHeatmapData(modelUsageAccumulator),
-    agentImpactData: computeAgentImpactData(impactAccumulator),
-    codeCompletionImpactData: computeCodeCompletionImpactData(impactAccumulator),
-    editModeImpactData: computeEditModeImpactData(impactAccumulator),
-    inlineModeImpactData: computeInlineModeImpactData(impactAccumulator),
-    askModeImpactData: computeAskModeImpactData(impactAccumulator),
-    cliImpactData: computeCliImpactData(impactAccumulator),
-    joinedImpactData: computeJoinedImpactData(impactAccumulator),
-    ...computeIDEStatsData(ideStatsAccumulator),
-    pluginVersionData: computePluginVersionData(pluginVersionAccumulator),
-    languageFeatureImpactData: computeLanguageFeatureImpactData(languageFeatureImpactAccumulator),
-    dailyLanguageGenerationsData: computeDailyLanguageChartData(languageFeatureImpactAccumulator, 'generations'),
-    dailyLanguageLocData: computeDailyLanguageChartData(languageFeatureImpactAccumulator, 'loc'),
-    modelBreakdownData: computeModelBreakdownData(modelBreakdownAccumulator),
-    dailyCliSessionData: computeDailyCliSessionData(cliUsageAccumulator),
-    dailyCliTokenData: computeDailyCliTokenData(cliUsageAccumulator),
-    dailyCliAdoptionTrend: computeCliAdoptionTrend(cliUsageAccumulator),
-    dailyAdoptionTrend: computeAdoptionTrend(engagementAccumulator, cliUsageAccumulator),
-    dailyCloudAgentAdoptionData: computeDailyCloudAgentAdoptionData(advancedAdoptionAccumulator),
-    dailyCodeReviewAdoptionData: computeDailyCodeReviewAdoptionData(advancedAdoptionAccumulator),
-    aiAdoptionPhaseData: computeAiAdoptionPhaseData(aiAdoptionPhaseAccumulator),
-    usageDistributionData: computeUsageDistributionData(aiAdoptionPhaseAccumulator),
-    dailyAiCreditsData: computeDailyAiCreditsData(aiCreditsAccumulator),
+      stats: computeStats(statsAccumulator, filteredMetricsCount),
+      userSummaries,
+      engagementData: computeEngagementData(engagementAccumulator, cliUsageAccumulator),
+      chatUsersData: computeChatUsersData(chatAccumulator, cliUsageAccumulator),
+      chatRequestsData: computeChatRequestsData(chatAccumulator, cliUsageAccumulator),
+      languageStats: languageAggregation.languageStats,
+      modelUsageData: modelAggregation.modelUsageData,
+      featureAdoptionData: computeFeatureAdoptionData(featureAdoptionAccumulator),
+      agentModeHeatmapData: modelAggregation.agentModeHeatmapData,
+      agentImpactData: computeAgentImpactData(impactAccumulator),
+      codeCompletionImpactData: computeCodeCompletionImpactData(impactAccumulator),
+      editModeImpactData: computeEditModeImpactData(impactAccumulator),
+      inlineModeImpactData: computeInlineModeImpactData(impactAccumulator),
+      askModeImpactData: computeAskModeImpactData(impactAccumulator),
+      cliImpactData: computeCliImpactData(impactAccumulator),
+      joinedImpactData: computeJoinedImpactData(impactAccumulator),
+      ...computeIDEStatsData(ideStatsAccumulator),
+      pluginVersionData: computePluginVersionData(pluginVersionAccumulator),
+      languageFeatureImpactData: languageAggregation.languageFeatureImpactData,
+      dailyLanguageGenerationsData:
+        languageAggregation.dailyLanguageGenerationsData,
+      dailyLanguageLocData: languageAggregation.dailyLanguageLocData,
+      modelBreakdownData: modelAggregation.modelBreakdownData,
+      dailyCliSessionData: computeDailyCliSessionData(cliUsageAccumulator),
+      dailyCliTokenData: computeDailyCliTokenData(cliUsageAccumulator),
+      dailyCliAdoptionTrend: computeCliAdoptionTrend(cliUsageAccumulator),
+      dailyAdoptionTrend: computeAdoptionTrend(engagementAccumulator, cliUsageAccumulator),
+      dailyCloudAgentAdoptionData: computeDailyCloudAgentAdoptionData(advancedAdoptionAccumulator),
+      dailyCodeReviewAdoptionData: computeDailyCodeReviewAdoptionData(advancedAdoptionAccumulator),
+      aiAdoptionPhaseData: computeAiAdoptionPhaseData(aiAdoptionPhaseAccumulator),
+      usageDistributionData: computeUsageDistributionData(aiAdoptionPhaseAccumulator),
+      dailyAiCreditsData: computeDailyAiCreditsData(aiCreditsAccumulator),
     },
     userDetailAccumulator,
   };


### PR DESCRIPTION
## Why

Phase 5 begins decomposing the aggregation coordinator without changing the worker payload or introducing another pass over raw metrics. This first slice gives language and model aggregation concrete, independently tested lifecycle boundaries while keeping shared stats ownership explicit.

| Commit | Change |
|--------|--------|
| `refactor: modularize language and model aggregation` | Extract language/model accumulator creation, per-record consumption, and narrow finalization with boundary characterization tests. |
| `docs: document aggregation orchestration boundary` | Document the new Phase 5 boundary and the families that remain in the coordinator. |