### PR TITLE
Modularize client and CLI aggregation

### DIFF
--- a/docs/project-overview.md
+++ b/docs/project-overview.md
@@ -107,9 +107,11 @@ flowchart LR
 
 ### 4.2. Aggregation
 
-`metricsAggregator.ts` retains the single explicit pass over raw records and coordinates concrete metric-family lifecycles in `src/domain/aggregation/` with calculators in `src/domain/calculators/`. Language and model orchestration now own their accumulator creation, per-record nested consumption, and narrow finalization while sharing the parent-owned stats accumulator. Their family results map into the same flat `AggregatedMetrics` object declared in `src/types/aggregatedMetrics.ts`, so the worker protocol and UI payload remain unchanged.
+`metricsAggregator.ts` retains the single explicit pass over raw records and coordinates concrete metric-family lifecycles in `src/domain/aggregation/` with calculators in `src/domain/calculators/`. Language, model, client, and CLI orchestration own their accumulator creation, per-record consumption, and narrow finalization. Language, model, and client families update the parent-owned stats accumulator where their dimensions contribute to global statistics. The client family also owns exact `used_cli` participation in IDE overlap statistics and plugin-version grouping while iterating every reported IDE total.
 
-Phase 5 modular aggregation orchestration has begun with the language and model families. User summaries, engagement/chat, feature adoption, impact, IDE/plugin versions, CLI, advanced adoption, AI adoption phases, AI credits, and user-detail orchestration remain in the top-level coordinator for later slices.
+CLI usage is accumulated once by the CLI family, including zero-filled dates. A narrow, read-only daily-session dependency is shared with engagement, chat, and adoption finalization so those existing calculations retain CLI users and sessions without duplicating accumulation or exposing token internals. Every family result still maps into the same flat `AggregatedMetrics` object declared in `src/types/aggregatedMetrics.ts`, so the worker protocol and UI payload remain unchanged.
+
+Phase 5 modular aggregation orchestration now covers language, model, client/plugin-version, and CLI families. User summaries, engagement/chat, feature adoption, impact, advanced adoption, AI adoption phases, AI credits, and user-detail orchestration remain in the top-level coordinator for later slices.
 
 ### 4.3. Views
 

--- a/src/domain/aggregation/__tests__/cliAggregation.test.ts
+++ b/src/domain/aggregation/__tests__/cliAggregation.test.ts
@@ -1,0 +1,242 @@
+import { describe, expect, it } from 'vitest';
+import { makeMetric } from '../../../__tests__/factories/metrics';
+import {
+  accumulateChatFeature,
+  computeChatRequestsData,
+  computeChatUsersData,
+  createChatAccumulator,
+} from '../../calculators/chatCalculator';
+import {
+  accumulateEngagement,
+  computeAdoptionTrend,
+  computeEngagementData,
+  createEngagementAccumulator,
+} from '../../calculators/engagementCalculator';
+import {
+  accumulateCliAggregation,
+  createCliAggregationAccumulator,
+  finalizeCliAggregation,
+  getCliUsageForDownstreamCalculations,
+} from '../cliAggregation';
+
+function makeCliMetric(
+  day: string,
+  userId: number,
+  sessionCount: number,
+  requestCount: number,
+  promptCount: number,
+  outputTokens: number,
+  promptTokens: number
+) {
+  return makeMetric({
+    day,
+    user_id: userId,
+    totals_by_cli: {
+      session_count: sessionCount,
+      request_count: requestCount,
+      prompt_count: promptCount,
+      token_usage: {
+        output_tokens_sum: outputTokens,
+        prompt_tokens_sum: promptTokens,
+        avg_tokens_per_request: requestCount > 0
+          ? (outputTokens + promptTokens) / requestCount
+          : 0,
+      },
+    },
+  });
+}
+
+describe('CLI aggregation orchestration', () => {
+  it('preserves empty CLI defaults', () => {
+    expect(finalizeCliAggregation(createCliAggregationAccumulator())).toEqual({
+      dailyCliSessionData: [],
+      dailyCliTokenData: [],
+      dailyCliAdoptionTrend: [],
+    });
+  });
+
+  it('coordinates date padding, usage totals, unique users, ordering, and adoption', () => {
+    const accumulator = createCliAggregationAccumulator();
+
+    accumulateCliAggregation(
+      accumulator,
+      makeCliMetric('2024-01-15', 1, 2, 4, 3, 100, 40)
+    );
+    accumulateCliAggregation(
+      accumulator,
+      makeMetric({ day: '2024-01-16', user_id: 3 })
+    );
+    accumulateCliAggregation(
+      accumulator,
+      makeCliMetric('2024-01-15', 2, 1, 5, 4, 200, 60)
+    );
+    accumulateCliAggregation(
+      accumulator,
+      makeCliMetric('2024-01-17', 1, 3, 6, 5, 300, 80)
+    );
+
+    expect(finalizeCliAggregation(accumulator)).toEqual({
+      dailyCliSessionData: [
+        {
+          date: '2024-01-15',
+          sessionCount: 3,
+          requestCount: 9,
+          promptCount: 7,
+          uniqueUsers: 2,
+        },
+        {
+          date: '2024-01-16',
+          sessionCount: 0,
+          requestCount: 0,
+          promptCount: 0,
+          uniqueUsers: 0,
+        },
+        {
+          date: '2024-01-17',
+          sessionCount: 3,
+          requestCount: 6,
+          promptCount: 5,
+          uniqueUsers: 1,
+        },
+      ],
+      dailyCliTokenData: [
+        {
+          date: '2024-01-15',
+          outputTokens: 300,
+          promptTokens: 100,
+          requestCount: 9,
+        },
+        {
+          date: '2024-01-16',
+          outputTokens: 0,
+          promptTokens: 0,
+          requestCount: 0,
+        },
+        {
+          date: '2024-01-17',
+          outputTokens: 300,
+          promptTokens: 80,
+          requestCount: 6,
+        },
+      ],
+      dailyCliAdoptionTrend: [
+        {
+          date: '2024-01-15',
+          newUsers: 2,
+          returningUsers: 0,
+          totalActiveUsers: 2,
+          cumulativeUsers: 2,
+        },
+        {
+          date: '2024-01-16',
+          newUsers: 0,
+          returningUsers: 0,
+          totalActiveUsers: 0,
+          cumulativeUsers: 2,
+        },
+        {
+          date: '2024-01-17',
+          newUsers: 0,
+          returningUsers: 1,
+          totalActiveUsers: 1,
+          cumulativeUsers: 2,
+        },
+      ],
+    });
+  });
+
+  it('exposes one narrow CLI usage dependency to engagement and chat calculations', () => {
+    const accumulator = createCliAggregationAccumulator();
+    const engagementAccumulator = createEngagementAccumulator();
+    const chatAccumulator = createChatAccumulator();
+
+    accumulateCliAggregation(
+      accumulator,
+      makeCliMetric('2024-01-15', 1, 2, 4, 3, 100, 40)
+    );
+    accumulateCliAggregation(
+      accumulator,
+      makeMetric({ day: '2024-01-16', user_id: 2 })
+    );
+    accumulateEngagement(engagementAccumulator, '2024-01-16', 2);
+    accumulateChatFeature(
+      chatAccumulator,
+      '2024-01-16',
+      2,
+      'chat_panel_ask_mode',
+      5
+    );
+
+    const cliUsage = getCliUsageForDownstreamCalculations(accumulator);
+    expect(computeEngagementData(engagementAccumulator, cliUsage)).toEqual([
+      {
+        date: '2024-01-15',
+        activeUsers: 1,
+        totalUsers: 2,
+        engagementPercentage: 50,
+      },
+      {
+        date: '2024-01-16',
+        activeUsers: 1,
+        totalUsers: 2,
+        engagementPercentage: 50,
+      },
+    ]);
+    expect(computeAdoptionTrend(engagementAccumulator, cliUsage)).toEqual([
+      {
+        date: '2024-01-15',
+        newUsers: 1,
+        returningUsers: 0,
+        totalActiveUsers: 1,
+        cumulativeUsers: 1,
+      },
+      {
+        date: '2024-01-16',
+        newUsers: 1,
+        returningUsers: 0,
+        totalActiveUsers: 1,
+        cumulativeUsers: 2,
+      },
+    ]);
+    expect(computeChatUsersData(chatAccumulator, cliUsage)).toEqual([
+      {
+        date: '2024-01-15',
+        askModeUsers: 0,
+        agentModeUsers: 0,
+        editModeUsers: 0,
+        inlineModeUsers: 0,
+        planModeUsers: 0,
+        cliUsers: 1,
+      },
+      {
+        date: '2024-01-16',
+        askModeUsers: 1,
+        agentModeUsers: 0,
+        editModeUsers: 0,
+        inlineModeUsers: 0,
+        planModeUsers: 0,
+        cliUsers: 0,
+      },
+    ]);
+    expect(computeChatRequestsData(chatAccumulator, cliUsage)).toEqual([
+      {
+        date: '2024-01-15',
+        askModeRequests: 0,
+        agentModeRequests: 0,
+        editModeRequests: 0,
+        inlineModeRequests: 0,
+        planModeRequests: 0,
+        cliSessions: 2,
+      },
+      {
+        date: '2024-01-16',
+        askModeRequests: 5,
+        agentModeRequests: 0,
+        editModeRequests: 0,
+        inlineModeRequests: 0,
+        planModeRequests: 0,
+        cliSessions: 0,
+      },
+    ]);
+  });
+});

--- a/src/domain/aggregation/__tests__/clientAggregation.test.ts
+++ b/src/domain/aggregation/__tests__/clientAggregation.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it } from 'vitest';
+import { makeMetric } from '../../../__tests__/factories/metrics';
+import {
+  computeStats,
+  createStatsAccumulator,
+} from '../../calculators/statsCalculator';
+import {
+  accumulateClientAggregation,
+  createClientAggregationAccumulator,
+  finalizeClientAggregation,
+} from '../clientAggregation';
+
+function makeIdeTotal(
+  ide: string,
+  interactions: number,
+  plugin?: string,
+  pluginVersion?: string
+) {
+  return {
+    ide,
+    user_initiated_interaction_count: interactions,
+    code_generation_activity_count: interactions + 1,
+    code_acceptance_activity_count: interactions + 2,
+    loc_added_sum: interactions + 3,
+    loc_deleted_sum: interactions + 4,
+    loc_suggested_to_add_sum: interactions + 5,
+    loc_suggested_to_delete_sum: interactions + 6,
+    last_known_plugin_version: plugin && pluginVersion
+      ? {
+          sampled_at: '2024-01-15T00:00:00Z',
+          plugin,
+          plugin_version: pluginVersion,
+        }
+      : undefined,
+  };
+}
+
+describe('client aggregation orchestration', () => {
+  it('preserves empty client defaults without replacing shared stats', () => {
+    const statsAccumulator = createStatsAccumulator();
+    const accumulator = createClientAggregationAccumulator();
+
+    expect(finalizeClientAggregation(accumulator)).toEqual({
+      ideStats: [],
+      multiIDEUsersCount: 0,
+      totalUniqueIDEUsers: 0,
+      pluginVersionData: {
+        jetbrains: [],
+        vscode: [],
+        totalUniqueIntellijUsers: 0,
+        totalUniqueVsCodeUsers: 0,
+      },
+    });
+    expect(computeStats(statsAccumulator, 0).topIde).toEqual({
+      name: 'N/A',
+      entries: 0,
+    });
+  });
+
+  it('coordinates every IDE total, CLI overlap flags, shared stats, and plugin identities', () => {
+    const statsAccumulator = createStatsAccumulator();
+    const accumulator = createClientAggregationAccumulator();
+
+    accumulateClientAggregation(
+      accumulator,
+      statsAccumulator,
+      makeMetric({
+        user_id: 1,
+        user_login: 'zoe',
+        used_cli: true,
+        totals_by_ide: [
+          makeIdeTotal('vscode', 3, 'copilot-chat', '1.2.0'),
+          makeIdeTotal('intellij', 5, 'copilot', '2024.1'),
+        ],
+      })
+    );
+    accumulateClientAggregation(
+      accumulator,
+      statsAccumulator,
+      makeMetric({
+        user_id: 2,
+        user_login: 'amy',
+        used_cli: false,
+        totals_by_cli: {
+          session_count: 2,
+          request_count: 4,
+          prompt_count: 3,
+          token_usage: {
+            output_tokens_sum: 20,
+            prompt_tokens_sum: 10,
+            avg_tokens_per_request: 7.5,
+          },
+        },
+        totals_by_ide: [
+          makeIdeTotal('vscode', 7, 'copilot-chat', '1.2.0'),
+          makeIdeTotal('intellij', 1, 'copilot', '2024.2-nightly'),
+        ],
+      })
+    );
+    accumulateClientAggregation(
+      accumulator,
+      statsAccumulator,
+      makeMetric({
+        user_id: 3,
+        user_login: 'mia',
+        totals_by_ide: [
+          makeIdeTotal('vscode', 2, 'copilot-chat', '1.1.0'),
+          makeIdeTotal('vscode', 4, 'copilot', 'ignored-version'),
+        ],
+      })
+    );
+
+    const result = finalizeClientAggregation(accumulator);
+    expect(computeStats(statsAccumulator, 3).topIde).toEqual({
+      name: 'vscode',
+      entries: 3,
+    });
+    expect(result.multiIDEUsersCount).toBe(2);
+    expect(result.totalUniqueIDEUsers).toBe(3);
+    expect(result.ideStats).toEqual([
+      {
+        ide: 'vscode',
+        uniqueUsers: 3,
+        cliOverlapUsers: 1,
+        totalEngagements: 16,
+        totalGenerations: 20,
+        totalAcceptances: 24,
+        locAdded: 28,
+        locDeleted: 32,
+        locSuggestedToAdd: 36,
+        locSuggestedToDelete: 40,
+      },
+      {
+        ide: 'intellij',
+        uniqueUsers: 2,
+        cliOverlapUsers: 1,
+        totalEngagements: 6,
+        totalGenerations: 8,
+        totalAcceptances: 10,
+        locAdded: 12,
+        locDeleted: 14,
+        locSuggestedToAdd: 16,
+        locSuggestedToDelete: 18,
+      },
+    ]);
+    expect(result.pluginVersionData).toEqual({
+      jetbrains: [
+        {
+          version: '2024.1',
+          userCount: 1,
+          usernames: ['zoe'],
+        },
+      ],
+      vscode: [
+        {
+          version: '1.2.0',
+          userCount: 2,
+          usernames: ['amy', 'zoe'],
+        },
+        {
+          version: '1.1.0',
+          userCount: 1,
+          usernames: ['mia'],
+        },
+      ],
+      totalUniqueIntellijUsers: 1,
+      totalUniqueVsCodeUsers: 3,
+    });
+  });
+});

--- a/src/domain/aggregation/cliAggregation.ts
+++ b/src/domain/aggregation/cliAggregation.ts
@@ -1,0 +1,51 @@
+import type { AggregatedMetrics } from '../../types/aggregatedMetrics';
+import type { CopilotMetrics } from '../../types/metrics';
+import {
+  accumulateCliUsage,
+  computeCliAdoptionTrend,
+  computeDailyCliSessionData,
+  computeDailyCliTokenData,
+  createCliUsageAccumulator,
+  ensureCliDates,
+  type CliUsageAccumulator,
+  type CliUsageForDownstreamCalculations,
+} from '../calculators/cliUsageCalculator';
+
+export interface CliAggregationAccumulator {
+  usage: CliUsageAccumulator;
+}
+
+export type CliAggregationResult = Pick<
+  AggregatedMetrics,
+  'dailyCliSessionData' | 'dailyCliTokenData' | 'dailyCliAdoptionTrend'
+>;
+
+export function createCliAggregationAccumulator(): CliAggregationAccumulator {
+  return {
+    usage: createCliUsageAccumulator(),
+  };
+}
+
+export function accumulateCliAggregation(
+  accumulator: CliAggregationAccumulator,
+  metric: CopilotMetrics
+): void {
+  ensureCliDates(accumulator.usage, metric.day);
+  accumulateCliUsage(accumulator.usage, metric.day, metric.user_id, metric);
+}
+
+export function getCliUsageForDownstreamCalculations(
+  accumulator: CliAggregationAccumulator
+): CliUsageForDownstreamCalculations {
+  return accumulator.usage;
+}
+
+export function finalizeCliAggregation(
+  accumulator: CliAggregationAccumulator
+): CliAggregationResult {
+  return {
+    dailyCliSessionData: computeDailyCliSessionData(accumulator.usage),
+    dailyCliTokenData: computeDailyCliTokenData(accumulator.usage),
+    dailyCliAdoptionTrend: computeCliAdoptionTrend(accumulator.usage),
+  };
+}

--- a/src/domain/aggregation/clientAggregation.ts
+++ b/src/domain/aggregation/clientAggregation.ts
@@ -1,0 +1,68 @@
+import type { AggregatedMetrics } from '../../types/aggregatedMetrics';
+import type { CopilotMetrics } from '../../types/metrics';
+import {
+  accumulateIDEStats,
+  computeIDEStatsData,
+  createIDEStatsAccumulator,
+  markCliUser,
+  type IDEStatsAccumulator,
+} from '../calculators/ideStatsCalculator';
+import {
+  accumulatePluginVersion,
+  computePluginVersionData,
+  createPluginVersionAccumulator,
+  type PluginVersionAccumulator,
+} from '../calculators/pluginVersionCalculator';
+import {
+  accumulateIdeUser,
+  type StatsAccumulator,
+} from '../calculators/statsCalculator';
+
+export interface ClientAggregationAccumulator {
+  ideStats: IDEStatsAccumulator;
+  pluginVersions: PluginVersionAccumulator;
+}
+
+export type ClientAggregationResult = Pick<
+  AggregatedMetrics,
+  | 'ideStats'
+  | 'multiIDEUsersCount'
+  | 'totalUniqueIDEUsers'
+  | 'pluginVersionData'
+>;
+
+export function createClientAggregationAccumulator(): ClientAggregationAccumulator {
+  return {
+    ideStats: createIDEStatsAccumulator(),
+    pluginVersions: createPluginVersionAccumulator(),
+  };
+}
+
+export function accumulateClientAggregation(
+  accumulator: ClientAggregationAccumulator,
+  statsAccumulator: StatsAccumulator,
+  metric: CopilotMetrics
+): void {
+  for (const ideTotal of metric.totals_by_ide) {
+    accumulateIdeUser(statsAccumulator, ideTotal.ide, metric.user_id);
+    accumulateIDEStats(accumulator.ideStats, metric.user_id, ideTotal);
+    accumulatePluginVersion(
+      accumulator.pluginVersions,
+      metric.user_login,
+      ideTotal
+    );
+  }
+
+  if (metric.used_cli) {
+    markCliUser(accumulator.ideStats, metric.user_id);
+  }
+}
+
+export function finalizeClientAggregation(
+  accumulator: ClientAggregationAccumulator
+): ClientAggregationResult {
+  return {
+    ...computeIDEStatsData(accumulator.ideStats),
+    pluginVersionData: computePluginVersionData(accumulator.pluginVersions),
+  };
+}

--- a/src/domain/calculators/chatCalculator.ts
+++ b/src/domain/calculators/chatCalculator.ts
@@ -1,4 +1,4 @@
-import { CliUsageAccumulator } from './cliUsageCalculator';
+import type { CliUsageForDownstreamCalculations } from './cliUsageCalculator';
 import { compareByDateAsc } from './statsCalculators';
 import { getChatModeBucket } from '../featureCategories';
 
@@ -104,7 +104,10 @@ export function accumulateChatFeature(
   }
 }
 
-export function computeChatUsersData(accumulator: ChatAccumulator, cliAccumulator?: CliUsageAccumulator): DailyChatUsersData[] {
+export function computeChatUsersData(
+  accumulator: ChatAccumulator,
+  cliAccumulator?: CliUsageForDownstreamCalculations
+): DailyChatUsersData[] {
   const allDates = new Set<string>(accumulator.dailyChatUsers.keys());
   if (cliAccumulator) {
     for (const date of cliAccumulator.dailySessions.keys()) {
@@ -129,7 +132,10 @@ export function computeChatUsersData(accumulator: ChatAccumulator, cliAccumulato
     .sort(compareByDateAsc);
 }
 
-export function computeChatRequestsData(accumulator: ChatAccumulator, cliAccumulator?: CliUsageAccumulator): DailyChatRequestsData[] {
+export function computeChatRequestsData(
+  accumulator: ChatAccumulator,
+  cliAccumulator?: CliUsageForDownstreamCalculations
+): DailyChatRequestsData[] {
   const allDates = new Set<string>(accumulator.dailyChatRequests.keys());
   if (cliAccumulator) {
     for (const date of cliAccumulator.dailySessions.keys()) {

--- a/src/domain/calculators/cliUsageCalculator.ts
+++ b/src/domain/calculators/cliUsageCalculator.ts
@@ -33,13 +33,27 @@ export interface DailyCliTokenData {
   requestCount: number;
 }
 
+interface CliDailySessionAccumulator {
+  sessionCount: number;
+  requestCount: number;
+  promptCount: number;
+  users: Set<number>;
+}
+
+export interface CliUsageForDownstreamCalculations {
+  readonly dailySessions: ReadonlyMap<
+    string,
+    {
+      readonly sessionCount: number;
+      readonly requestCount: number;
+      readonly promptCount: number;
+      readonly users: ReadonlySet<number>;
+    }
+  >;
+}
+
 export interface CliUsageAccumulator {
-  dailySessions: Map<string, {
-    sessionCount: number;
-    requestCount: number;
-    promptCount: number;
-    users: Set<number>;
-  }>;
+  dailySessions: Map<string, CliDailySessionAccumulator>;
   dailyTokens: Map<string, {
     outputTokens: number;
     promptTokens: number;

--- a/src/domain/calculators/engagementCalculator.ts
+++ b/src/domain/calculators/engagementCalculator.ts
@@ -1,4 +1,4 @@
-import { CliUsageAccumulator } from './cliUsageCalculator';
+import type { CliUsageForDownstreamCalculations } from './cliUsageCalculator';
 import { compareDatesAsc, compareByDateAsc } from './statsCalculators';
 import { type AdoptionTrendEntry, computeAdoptionTrendFromUserSets } from './adoptionTrendHelpers';
 
@@ -36,7 +36,7 @@ export function accumulateEngagement(
 
 export function computeEngagementData(
   accumulator: EngagementAccumulator,
-  cliAccumulator?: CliUsageAccumulator
+  cliAccumulator?: CliUsageForDownstreamCalculations
 ): DailyEngagementData[] {
   const cliAllUsers = new Set<number>();
   if (cliAccumulator) {
@@ -85,7 +85,7 @@ export type DailyAdoptionTrend = AdoptionTrendEntry;
 
 export function computeAdoptionTrend(
   accumulator: EngagementAccumulator,
-  cliAccumulator?: CliUsageAccumulator
+  cliAccumulator?: CliUsageForDownstreamCalculations
 ): DailyAdoptionTrend[] {
   const allDates = new Set(accumulator.dailyEngagement.keys());
   if (cliAccumulator) {

--- a/src/domain/calculators/index.ts
+++ b/src/domain/calculators/index.ts
@@ -137,6 +137,7 @@ export {
   type DailyCliTokenData,
   type DailyCliAdoptionTrend,
   type CliUsageAccumulator,
+  type CliUsageForDownstreamCalculations,
   createCliUsageAccumulator,
   accumulateCliUsage,
   ensureCliDates,

--- a/src/domain/metricsAggregator.ts
+++ b/src/domain/metricsAggregator.ts
@@ -5,6 +5,17 @@ import {
 import type { AggregatedMetrics } from '../types/aggregatedMetrics';
 import { resolveCopilotCloudAgentUsage } from './copilotCloudAgentUsage';
 import {
+  accumulateClientAggregation,
+  createClientAggregationAccumulator,
+  finalizeClientAggregation,
+} from './aggregation/clientAggregation';
+import {
+  accumulateCliAggregation,
+  createCliAggregationAccumulator,
+  finalizeCliAggregation,
+  getCliUsageForDownstreamCalculations,
+} from './aggregation/cliAggregation';
+import {
   accumulateLanguageAggregation,
   createLanguageAggregationAccumulator,
   finalizeLanguageAggregation,
@@ -17,7 +28,6 @@ import {
 import {
   createStatsAccumulator,
   accumulateUserUsage,
-  accumulateIdeUser,
   computeStats,
 
   createEngagementAccumulator,
@@ -50,25 +60,9 @@ import {
   computeCliImpactData,
   computeJoinedImpactData,
 
-  createIDEStatsAccumulator,
-  accumulateIDEStats,
-  markCliUser,
-  computeIDEStatsData,
-
-  createPluginVersionAccumulator,
-  accumulatePluginVersion,
-  computePluginVersionData,
-
   type UserDetailAccumulator,
   createUserDetailAccumulator,
   accumulateUserDetail,
-
-  createCliUsageAccumulator,
-  accumulateCliUsage,
-  ensureCliDates,
-  computeDailyCliSessionData,
-  computeDailyCliTokenData,
-  computeCliAdoptionTrend,
 
   createAdvancedAdoptionAccumulator,
   accumulateCloudAgentAdoption,
@@ -250,13 +244,12 @@ export function aggregateMetrics(
   const userSummaryAccumulator = createUserSummaryAccumulator();
   const engagementAccumulator = createEngagementAccumulator();
   const chatAccumulator = createChatAccumulator();
+  const clientAggregationAccumulator = createClientAggregationAccumulator();
+  const cliAggregationAccumulator = createCliAggregationAccumulator();
   const languageAggregationAccumulator = createLanguageAggregationAccumulator();
   const modelAggregationAccumulator = createModelAggregationAccumulator();
   const featureAdoptionAccumulator = createFeatureAdoptionAccumulator();
   const impactAccumulator = createImpactAccumulator();
-  const ideStatsAccumulator = createIDEStatsAccumulator();
-  const pluginVersionAccumulator = createPluginVersionAccumulator();
-  const cliUsageAccumulator = createCliUsageAccumulator();
   const advancedAdoptionAccumulator = createAdvancedAdoptionAccumulator();
   const aiAdoptionPhaseAccumulator = createAiAdoptionPhaseAccumulator();
   const aiCreditsAccumulator = createAiCreditsAccumulator();
@@ -286,17 +279,12 @@ export function aggregateMetrics(
     accumulateEngagement(engagementAccumulator, date, userId);
 
     ensureImpactDates(impactAccumulator, date);
-    ensureCliDates(cliUsageAccumulator, date);
-
-    for (const ideTotal of metric.totals_by_ide) {
-      accumulateIdeUser(statsAccumulator, ideTotal.ide, userId);
-      accumulateIDEStats(ideStatsAccumulator, userId, ideTotal);
-      accumulatePluginVersion(pluginVersionAccumulator, metric.user_login, ideTotal);
-    }
-
-    if (metric.used_cli) {
-      markCliUser(ideStatsAccumulator, userId);
-    }
+    accumulateClientAggregation(
+      clientAggregationAccumulator,
+      statsAccumulator,
+      metric
+    );
+    accumulateCliAggregation(cliAggregationAccumulator, metric);
 
     accumulateLanguageAggregation(
       languageAggregationAccumulator,
@@ -326,8 +314,6 @@ export function aggregateMetrics(
       metric.used_copilot_code_review_active ?? false,
       metric.used_copilot_code_review_passive ?? false
     );
-    accumulateCliUsage(cliUsageAccumulator, date, userId, metric);
-
     for (const feature of metric.totals_by_feature) {
       accumulateFeatureAdoption(
         featureAdoptionAccumulator,
@@ -355,14 +341,21 @@ export function aggregateMetrics(
     languageAggregationAccumulator
   );
   const modelAggregation = finalizeModelAggregation(modelAggregationAccumulator);
+  const clientAggregation = finalizeClientAggregation(
+    clientAggregationAccumulator
+  );
+  const cliAggregation = finalizeCliAggregation(cliAggregationAccumulator);
+  const cliUsage = getCliUsageForDownstreamCalculations(
+    cliAggregationAccumulator
+  );
 
   return {
     aggregated: {
       stats: computeStats(statsAccumulator, filteredMetricsCount),
       userSummaries,
-      engagementData: computeEngagementData(engagementAccumulator, cliUsageAccumulator),
-      chatUsersData: computeChatUsersData(chatAccumulator, cliUsageAccumulator),
-      chatRequestsData: computeChatRequestsData(chatAccumulator, cliUsageAccumulator),
+      engagementData: computeEngagementData(engagementAccumulator, cliUsage),
+      chatUsersData: computeChatUsersData(chatAccumulator, cliUsage),
+      chatRequestsData: computeChatRequestsData(chatAccumulator, cliUsage),
       languageStats: languageAggregation.languageStats,
       modelUsageData: modelAggregation.modelUsageData,
       featureAdoptionData: computeFeatureAdoptionData(featureAdoptionAccumulator),
@@ -374,17 +367,19 @@ export function aggregateMetrics(
       askModeImpactData: computeAskModeImpactData(impactAccumulator),
       cliImpactData: computeCliImpactData(impactAccumulator),
       joinedImpactData: computeJoinedImpactData(impactAccumulator),
-      ...computeIDEStatsData(ideStatsAccumulator),
-      pluginVersionData: computePluginVersionData(pluginVersionAccumulator),
+      ideStats: clientAggregation.ideStats,
+      multiIDEUsersCount: clientAggregation.multiIDEUsersCount,
+      totalUniqueIDEUsers: clientAggregation.totalUniqueIDEUsers,
+      pluginVersionData: clientAggregation.pluginVersionData,
       languageFeatureImpactData: languageAggregation.languageFeatureImpactData,
       dailyLanguageGenerationsData:
         languageAggregation.dailyLanguageGenerationsData,
       dailyLanguageLocData: languageAggregation.dailyLanguageLocData,
       modelBreakdownData: modelAggregation.modelBreakdownData,
-      dailyCliSessionData: computeDailyCliSessionData(cliUsageAccumulator),
-      dailyCliTokenData: computeDailyCliTokenData(cliUsageAccumulator),
-      dailyCliAdoptionTrend: computeCliAdoptionTrend(cliUsageAccumulator),
-      dailyAdoptionTrend: computeAdoptionTrend(engagementAccumulator, cliUsageAccumulator),
+      dailyCliSessionData: cliAggregation.dailyCliSessionData,
+      dailyCliTokenData: cliAggregation.dailyCliTokenData,
+      dailyCliAdoptionTrend: cliAggregation.dailyCliAdoptionTrend,
+      dailyAdoptionTrend: computeAdoptionTrend(engagementAccumulator, cliUsage),
       dailyCloudAgentAdoptionData: computeDailyCloudAgentAdoptionData(advancedAdoptionAccumulator),
       dailyCodeReviewAdoptionData: computeDailyCodeReviewAdoptionData(advancedAdoptionAccumulator),
       aiAdoptionPhaseData: computeAiAdoptionPhaseData(aiAdoptionPhaseAccumulator),


### PR DESCRIPTION
## Why

This change continues Phase 5 by moving client/plugin-version and CLI lifecycle wiring behind concrete aggregation modules while preserving the worker's single raw-record pass and flat payload contract.

| Commit | Change |
|--------|--------|
| `refactor: modularize client and CLI aggregation` | Add typed client and CLI lifecycles, characterize their boundaries, and expose the single CLI accumulator through a narrow read-only downstream dependency. |
| `docs: record client and CLI orchestration` | Document the completed slice, shared CLI dependency, and remaining orchestration families. |
