### PR TITLE
Add typed standard view routing

### DIFF
--- a/docs/project-overview.md
+++ b/docs/project-overview.md
@@ -41,7 +41,7 @@ Next.js App Router SPA, TypeScript, Tailwind CSS. All rendering is client-side.
 - `MetricsContext` (`src/components/MetricsContext.tsx`) — stores the `AggregatedMetrics` result, loading/error/warning state, and data actions
 - `NavigationContext` (`src/state/NavigationContext.tsx`) — manages current view, selected user/model, and navigation actions
 
-**All view components consume pre-aggregated data.** No component accesses raw `CopilotMetrics[]` directly. The flat `AggregatedMetrics` worker/UI contract is declared in `src/types/aggregatedMetrics.ts`. Feature read-model selectors in `src/read-models/` insulate aggregate-backed UI paths from that flat payload; overview, executive summary, users, user details, Copilot adoption, AI adoption phases, Copilot impact, languages, clients, client versions, model details, CLI adoption, and AI credits consume only their typed projections. The worker also retains a compact user-detail accumulator so it can serve user details on demand without moving raw records onto the main thread.
+**All view components consume pre-aggregated data.** No component accesses raw `CopilotMetrics[]` directly. The flat `AggregatedMetrics` worker/UI contract is declared in `src/types/aggregatedMetrics.ts`. Feature read-model selectors in `src/read-models/` insulate aggregate-backed UI paths from that flat payload; overview, executive summary, users, user details, Copilot adoption, AI adoption phases, Copilot impact, languages, clients, client versions, model details, CLI adoption, and AI credits consume only their typed projections. Standard route adapters in `src/components/layout/routes/` own the selector and existing view for each non-user-details route, so only the selected route computes its projection. The worker also retains a compact user-detail accumulator so it can serve user details on demand without moving raw records onto the main thread.
 
 ### 3.2. Code Organization
 
@@ -49,6 +49,7 @@ Next.js App Router SPA, TypeScript, Tailwind CSS. All rendering is client-side.
 |---|---|
 | `src/app/` | Next.js App Router entry points and providers |
 | `src/components/` | View components, charts, layout, UI primitives |
+| `src/components/layout/routes/` | Typed standard-route adapters and registry |
 | `src/components/charts/` | Chart.js visualizations (via react-chartjs-2) |
 | `src/domain/` | Business logic: aggregator, model config, calculators |
 | `src/domain/aggregation/` | Concrete metric-family accumulator lifecycle orchestration |
@@ -80,7 +81,7 @@ Established boundaries cover:
 - model details and CLI adoption
 - AI credits
 
-Phase 4 feature read-model boundaries are complete for every aggregate-backed feature surface. The worker payload remains flat and unchanged; grouping it, moving component files, and decomposing the general `ViewRouter` registry remain separate work.
+Phase 4 feature read-model boundaries are complete for every aggregate-backed feature surface. The worker payload remains flat and unchanged. The typed standard-route registry now delegates all non-user-details routes without moving feature components; user-details request orchestration remains the only specialized route logic in `ViewRouter` pending the next slice.
 
 ---
 
@@ -92,8 +93,10 @@ flowchart LR
   B --> C[MetricsWorkerProvider-owned client]
   C -->|postMessage: parseAndAggregate| W[Web Worker: parse + aggregate]
   W -->|parseAndAggregateResult| D[MetricsContext stores AggregatedMetrics + warnings]
-  D --> RM[Feature read-model selectors]
-  RM --> E[ViewRouter renders current view]
+  D --> VR[ViewRouter resolves current route]
+  VR --> SR[Selected standard route adapter]
+  SR --> RM[Feature read-model selector]
+  RM --> E[Existing feature view]
   E --> F[Chart components]
 ```
 
@@ -115,7 +118,7 @@ Phase 5 modular aggregation orchestration is complete. The top-level coordinator
 
 ### 4.3. Views
 
-`ViewRouter` (`src/components/layout/ViewRouter.tsx`) maps the current `ViewMode` to the appropriate component. Migrated views receive typed read models rather than the full aggregate contract. Views include: overview dashboard, users list, user details, languages, IDEs, Copilot impact, model usage analysis, adoption, AI adoption phases, and model details.
+`ViewRouter` (`src/components/layout/ViewRouter.tsx`) retains global upload, fatal-error, loading, and specialized user-details request states. Every standard `ViewMode` delegates through the typed registry in `src/components/layout/routes/`; the selected adapter invokes its feature selector lazily and renders the existing view with a narrow shared route context. User-details orchestration remains in `ViewRouter` for the next routing slice.
 
 Charts use **Chart.js** via **react-chartjs-2**, wrapped in a `ChartContainer` component for consistent styling.
 
@@ -152,8 +155,10 @@ flowchart TB
 		WT[metricsWorker.ts]
 	end
 
-	VR --> Views[View Components + Charts]
-	VR --> RM[read-models/]
+	VR --> SR[Standard route outlet + registry]
+	SR --> Views[View Components + Charts]
+	SR --> RM[read-models/]
+	VR --> UD[User-details orchestration]
 
 	MWP --> MWC
 	MWC --> WC

--- a/src/components/layout/ViewRouter.tsx
+++ b/src/components/layout/ViewRouter.tsx
@@ -7,22 +7,6 @@ import { useMetrics } from '../MetricsContext';
 import { useFileUpload } from '../../hooks/useFileUpload';
 import { useResetAppState } from '../../hooks/useResetAppState';
 import { useMetricsWorker } from '../../workers/MetricsWorkerContext';
-import {
-  selectExecutiveSummaryReadModel,
-  selectOverviewReadModel,
-} from '../../read-models/overview';
-import { selectCopilotAdoptionReadModel } from '../../read-models/adoption';
-import { selectAiAdoptionPhaseReadModel } from '../../read-models/aiAdoptionPhases';
-import { selectCopilotImpactReadModel } from '../../read-models/impact';
-import { selectLanguagesReadModel } from '../../read-models/languages';
-import {
-  selectClientsReadModel,
-  selectClientVersionsReadModel,
-} from '../../read-models/clients';
-import { selectModelDetailsReadModel } from '../../read-models/models';
-import { selectCliAdoptionReadModel } from '../../read-models/cliAdoption';
-import { selectAiCreditsReadModel } from '../../read-models/aiCredits';
-import { selectUsersReadModel } from '../../read-models/users';
 import { selectUserDetailsRouteReadModel } from '../../read-models/userDetails';
 import {
   resolveUserDetailsRouteState,
@@ -30,20 +14,8 @@ import {
 } from './userDetailsRouteState';
 import { runUserDetailsRequest } from './userDetailsRequest';
 import { FileUploadArea } from '../features/file-upload';
-import { OverviewDashboard } from '../features/overview';
-import UniqueUsersView from '../UniqueUsersView';
 import UserDetailsView from '../UserDetailsView';
-import LanguagesView from '../LanguagesView';
-import ClientsView from '../ClientsView';
-import CopilotImpactView from '../CopilotImpactView';
-import CopilotAdoptionView from '../CopilotAdoptionView';
-import AiAdoptionPhaseView from '../AiAdoptionPhaseView';
-import CLIAdoptionView from '../CLIAdoptionView';
-import ModelDetailsView from '../ModelDetailsView';
-import ExecutiveSummaryView from '../ExecutiveSummaryView';
-import AiCreditsView from '../AiCreditsView';
-import ClientVersionsView from '../ClientVersionsView';
-import AboutView from '../AboutView';
+import { StandardRouteOutlet } from './routes';
 
 const ViewRouter: React.FC = () => {
   const { 
@@ -188,168 +160,65 @@ const ViewRouter: React.FC = () => {
     );
   }
 
-  const overviewReadModel = selectOverviewReadModel(aggregatedMetrics);
-  const executiveSummaryReadModel = selectExecutiveSummaryReadModel(aggregatedMetrics);
-  const copilotAdoptionReadModel = selectCopilotAdoptionReadModel(aggregatedMetrics);
-  const aiAdoptionPhaseReadModel = selectAiAdoptionPhaseReadModel(aggregatedMetrics);
-  const copilotImpactReadModel = selectCopilotImpactReadModel(aggregatedMetrics);
-  const languagesReadModel = selectLanguagesReadModel(aggregatedMetrics);
-  const clientsReadModel = selectClientsReadModel(aggregatedMetrics);
-  const clientVersionsReadModel = selectClientVersionsReadModel(aggregatedMetrics);
-  const modelDetailsReadModel = selectModelDetailsReadModel(aggregatedMetrics);
-  const cliAdoptionReadModel = selectCliAdoptionReadModel(aggregatedMetrics);
-  const aiCreditsReadModel = selectAiCreditsReadModel(
-    aggregatedMetrics,
-    handleUserClick
-  );
-  const usersReadModel = selectUsersReadModel(aggregatedMetrics);
+  if (currentView === VIEW_MODES.USER_DETAILS) {
+    if (
+      userDetailsRouteState.status === 'inactive'
+      || userDetailsRouteState.status === 'redirect'
+    ) {
+      return null;
+    }
 
-  switch (currentView) {
-    case VIEW_MODES.EXECUTIVE_SUMMARY:
+    if (userDetailsRouteState.status === 'loading') {
       return (
-        <ExecutiveSummaryView
-          model={executiveSummaryReadModel}
-          enterpriseName={enterpriseName}
-        />
+        <div className="flex items-center justify-center h-64">
+          <div className="text-center">
+            <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-500 mx-auto mb-4"></div>
+            <p className="text-gray-500 dark:text-gray-400">Loading user details...</p>
+          </div>
+        </div>
       );
+    }
 
-    case VIEW_MODES.AI_CREDITS:
+    if (userDetailsRouteState.status === 'error') {
       return (
-        <AiCreditsView
-          model={aiCreditsReadModel}
-        />
-      );
-
-    case VIEW_MODES.ABOUT:
-      return <AboutView />;
-
-    case VIEW_MODES.CLIENT_VERSIONS:
-      return (
-        <ClientVersionsView
-          model={clientVersionsReadModel}
-        />
-      );
-
-    case VIEW_MODES.LANGUAGES:
-      return (
-        <LanguagesView
-          model={languagesReadModel}
-        />
-      );
-
-    case VIEW_MODES.CLIENT_ANALYSIS:
-      return (
-        <ClientsView
-          model={clientsReadModel}
-        />
-      );
-
-    case VIEW_MODES.COPILOT_IMPACT:
-      return (
-        <CopilotImpactView
-          model={copilotImpactReadModel}
-        />
-      );
-
-    case VIEW_MODES.COPILOT_ADOPTION:
-      return (
-        <CopilotAdoptionView
-          model={copilotAdoptionReadModel}
-        />
-      );
-
-    case VIEW_MODES.AI_ADOPTION_PHASES:
-      return (
-        <AiAdoptionPhaseView
-          model={aiAdoptionPhaseReadModel}
-        />
-      );
-
-    case VIEW_MODES.CLI_ADOPTION:
-      return (
-        <CLIAdoptionView
-          model={cliAdoptionReadModel}
-        />
-      );
-
-    case VIEW_MODES.USERS:
-      return (
-        <UniqueUsersView 
-          model={usersReadModel}
-          onUserClick={handleUserClick}
-        />
-      );
-
-    case VIEW_MODES.USER_DETAILS:
-      if (
-        userDetailsRouteState.status === 'inactive'
-        || userDetailsRouteState.status === 'redirect'
-      ) {
-        return null;
-      }
-
-      if (userDetailsRouteState.status === 'loading') {
-        return (
-          <div className="flex items-center justify-center h-64">
-            <div className="text-center">
-              <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-500 mx-auto mb-4"></div>
-              <p className="text-gray-500 dark:text-gray-400">Loading user details...</p>
+        <div className="flex items-center justify-center h-64">
+          <div className="text-center max-w-md">
+            <p className="text-red-600 dark:text-red-400 font-medium mb-2">
+              Failed to load user details
+            </p>
+            <p className="text-sm text-gray-500 dark:text-gray-400">
+              {userDetailsRouteState.message}
+            </p>
+            <div className="mt-4 flex items-center justify-center gap-3">
+              <button
+                onClick={retryUserDetails}
+                className="px-4 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-md transition-colors"
+              >
+                Retry
+              </button>
+              <button
+                onClick={() => navigateTo(VIEW_MODES.USERS)}
+                className="px-4 py-2 text-sm font-medium text-blue-600 hover:text-blue-800 border border-blue-300 hover:border-blue-400 rounded-md transition-colors"
+              >
+                Back to Users
+              </button>
             </div>
           </div>
-        );
-      }
-
-      if (userDetailsRouteState.status === 'error') {
-        return (
-          <div className="flex items-center justify-center h-64">
-            <div className="text-center max-w-md">
-              <p className="text-red-600 dark:text-red-400 font-medium mb-2">
-                Failed to load user details
-              </p>
-              <p className="text-sm text-gray-500 dark:text-gray-400">
-                {userDetailsRouteState.message}
-              </p>
-              <div className="mt-4 flex items-center justify-center gap-3">
-                <button
-                  onClick={retryUserDetails}
-                  className="px-4 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-md transition-colors"
-                >
-                  Retry
-                </button>
-                <button
-                  onClick={() => navigateTo(VIEW_MODES.USERS)}
-                  className="px-4 py-2 text-sm font-medium text-blue-600 hover:text-blue-800 border border-blue-300 hover:border-blue-400 rounded-md transition-colors"
-                >
-                  Back to Users
-                </button>
-              </div>
-            </div>
-          </div>
-        );
-      }
-
-      return (
-        <UserDetailsView
-          model={userDetailsRouteState.model}
-        />
+        </div>
       );
+    }
 
-    case VIEW_MODES.MODEL_DETAILS:
-      return (
-        <ModelDetailsView
-          model={modelDetailsReadModel}
-        />
-      );
-
-    case VIEW_MODES.OVERVIEW:
-    default:
-      return (
-        <OverviewDashboard
-          model={overviewReadModel}
-          enterpriseName={enterpriseName}
-        />
-      );
+    return <UserDetailsView model={userDetailsRouteState.model} />;
   }
+
+  return (
+    <StandardRouteOutlet
+      view={currentView}
+      aggregatedMetrics={aggregatedMetrics}
+      enterpriseName={enterpriseName}
+      onUserSelect={handleUserClick}
+    />
+  );
 };
 
 export default ViewRouter;

--- a/src/components/layout/__tests__/ViewRouter.test.tsx
+++ b/src/components/layout/__tests__/ViewRouter.test.tsx
@@ -1,77 +1,25 @@
 import { renderToStaticMarkup } from 'react-dom/server';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { makeMetric } from '../../../__tests__/factories/metrics';
-import {
-  aggregateMetrics,
-} from '../../../domain/metricsAggregator';
+import { aggregateMetrics } from '../../../domain/metricsAggregator';
 import type { AggregatedMetrics } from '../../../types/aggregatedMetrics';
 import { VIEW_MODES, type ViewMode } from '../../../types/navigation';
-import type { CopilotAdoptionReadModel } from '../../../read-models/adoption';
-import type { AiAdoptionPhaseReadModel } from '../../../read-models/aiAdoptionPhases';
-import type { CopilotImpactReadModel } from '../../../read-models/impact';
-import type { LanguagesReadModel } from '../../../read-models/languages';
-import type {
-  ClientsReadModel,
-  ClientVersionsReadModel,
-} from '../../../read-models/clients';
-import type { ModelDetailsReadModel } from '../../../read-models/models';
-import type { CliAdoptionReadModel } from '../../../read-models/cliAdoption';
-import type { AiCreditsReadModel } from '../../../read-models/aiCredits';
 import ViewRouter from '../ViewRouter';
+
+interface StandardRouteOutletProps {
+  view: ViewMode;
+  aggregatedMetrics: AggregatedMetrics;
+  enterpriseName: string | null;
+  onUserSelect: (userLogin: string, userId: number) => void;
+}
 
 const mocks = vi.hoisted(() => ({
   navigateTo: vi.fn(),
+  selectUser: vi.fn(),
+  standardRouteOutlet: vi.fn<(props: StandardRouteOutletProps) => void>(),
   currentView: 'userDetails' as ViewMode,
   selectedUser: null as { id: number; login: string } | null,
   aggregatedMetrics: null as AggregatedMetrics | null,
-  copilotAdoptionView: vi.fn<
-    (props: { model: CopilotAdoptionReadModel }) => void
-  >(),
-  aiAdoptionPhaseView: vi.fn<
-    (props: { model: AiAdoptionPhaseReadModel }) => void
-  >(),
-  copilotImpactView: vi.fn<
-    (props: { model: CopilotImpactReadModel }) => void
-  >(),
-  languagesView: vi.fn<
-    (props: { model: LanguagesReadModel }) => void
-  >(),
-  clientsView: vi.fn<
-    (props: { model: ClientsReadModel }) => void
-  >(),
-  clientVersionsView: vi.fn<
-    (props: { model: ClientVersionsReadModel }) => void
-  >(),
-  modelDetailsView: vi.fn<
-    (props: { model: ModelDetailsReadModel }) => void
-  >(),
-  cliAdoptionView: vi.fn<
-    (props: { model: CliAdoptionReadModel }) => void
-  >(),
-  aiCreditsView: vi.fn<
-    (props: { model: AiCreditsReadModel }) => void
-  >(),
-  selectLanguagesReadModel: vi.fn<
-    (metrics: AggregatedMetrics) => LanguagesReadModel
-  >(),
-  selectClientsReadModel: vi.fn<
-    (metrics: AggregatedMetrics) => ClientsReadModel
-  >(),
-  selectClientVersionsReadModel: vi.fn<
-    (metrics: AggregatedMetrics) => ClientVersionsReadModel
-  >(),
-  selectModelDetailsReadModel: vi.fn<
-    (metrics: AggregatedMetrics) => ModelDetailsReadModel
-  >(),
-  selectCliAdoptionReadModel: vi.fn<
-    (metrics: AggregatedMetrics) => CliAdoptionReadModel
-  >(),
-  selectAiCreditsReadModel: vi.fn<
-    (
-      metrics: AggregatedMetrics,
-      onUserClick: AiCreditsReadModel['onUserClick']
-    ) => AiCreditsReadModel
-  >(),
 }));
 
 vi.mock('../../MetricsContext', () => ({
@@ -89,7 +37,7 @@ vi.mock('../../../state/NavigationContext', () => ({
     currentView: mocks.currentView,
     selectedUser: mocks.selectedUser,
     navigateTo: mocks.navigateTo,
-    selectUser: vi.fn(),
+    selectUser: mocks.selectUser,
   }),
 }));
 
@@ -113,159 +61,21 @@ vi.mock('../../../workers/MetricsWorkerContext', () => ({
   }),
 }));
 
-vi.mock('../../CopilotAdoptionView', () => ({
-  default: (props: { model: CopilotAdoptionReadModel }) => {
-    mocks.copilotAdoptionView(props);
+vi.mock('../routes', () => ({
+  StandardRouteOutlet: (props: StandardRouteOutletProps) => {
+    mocks.standardRouteOutlet(props);
     return null;
   },
-}));
-
-vi.mock('../../AiAdoptionPhaseView', () => ({
-  default: (props: { model: AiAdoptionPhaseReadModel }) => {
-    mocks.aiAdoptionPhaseView(props);
-    return null;
-  },
-}));
-
-vi.mock('../../CopilotImpactView', () => ({
-  default: (props: { model: CopilotImpactReadModel }) => {
-    mocks.copilotImpactView(props);
-    return null;
-  },
-}));
-
-vi.mock('../../LanguagesView', () => ({
-  default: (props: { model: LanguagesReadModel }) => {
-    mocks.languagesView(props);
-    return null;
-  },
-}));
-
-vi.mock('../../ClientsView', () => ({
-  default: (props: { model: ClientsReadModel }) => {
-    mocks.clientsView(props);
-    return null;
-  },
-}));
-
-vi.mock('../../ClientVersionsView', () => ({
-  default: (props: { model: ClientVersionsReadModel }) => {
-    mocks.clientVersionsView(props);
-    return null;
-  },
-}));
-
-vi.mock('../../ModelDetailsView', () => ({
-  default: (props: { model: ModelDetailsReadModel }) => {
-    mocks.modelDetailsView(props);
-    return null;
-  },
-}));
-
-vi.mock('../../CLIAdoptionView', () => ({
-  default: (props: { model: CliAdoptionReadModel }) => {
-    mocks.cliAdoptionView(props);
-    return null;
-  },
-}));
-
-vi.mock('../../AiCreditsView', () => ({
-  default: (props: { model: AiCreditsReadModel }) => {
-    mocks.aiCreditsView(props);
-    return null;
-  },
-}));
-
-vi.mock('../../../read-models/languages', () => ({
-  selectLanguagesReadModel: mocks.selectLanguagesReadModel,
-}));
-
-vi.mock('../../../read-models/clients', () => ({
-  selectClientsReadModel: mocks.selectClientsReadModel,
-  selectClientVersionsReadModel: mocks.selectClientVersionsReadModel,
-}));
-
-vi.mock('../../../read-models/models', () => ({
-  selectModelDetailsReadModel: mocks.selectModelDetailsReadModel,
-}));
-
-vi.mock('../../../read-models/cliAdoption', () => ({
-  selectCliAdoptionReadModel: mocks.selectCliAdoptionReadModel,
-}));
-
-vi.mock('../../../read-models/aiCredits', () => ({
-  selectAiCreditsReadModel: mocks.selectAiCreditsReadModel,
 }));
 
 describe('ViewRouter', () => {
   beforeEach(() => {
     mocks.navigateTo.mockClear();
-    mocks.copilotAdoptionView.mockClear();
-    mocks.aiAdoptionPhaseView.mockClear();
-    mocks.copilotImpactView.mockClear();
-    mocks.languagesView.mockClear();
-    mocks.clientsView.mockClear();
-    mocks.clientVersionsView.mockClear();
-    mocks.modelDetailsView.mockClear();
-    mocks.cliAdoptionView.mockClear();
-    mocks.aiCreditsView.mockClear();
-    mocks.selectLanguagesReadModel.mockReset();
-    mocks.selectClientsReadModel.mockReset();
-    mocks.selectClientVersionsReadModel.mockReset();
-    mocks.selectModelDetailsReadModel.mockReset();
-    mocks.selectCliAdoptionReadModel.mockReset();
-    mocks.selectAiCreditsReadModel.mockReset();
+    mocks.selectUser.mockClear();
+    mocks.standardRouteOutlet.mockClear();
     mocks.currentView = VIEW_MODES.USER_DETAILS;
     mocks.selectedUser = null;
     mocks.aggregatedMetrics = aggregateMetrics([makeMetric()]).aggregated;
-    mocks.selectLanguagesReadModel.mockImplementation((metrics) => ({
-      languageStats: metrics.languageStats,
-      languageFeatureImpactData: metrics.languageFeatureImpactData,
-      dailyLanguageGenerationsData: metrics.dailyLanguageGenerationsData,
-      dailyLanguageLocData: metrics.dailyLanguageLocData,
-    }));
-    mocks.selectClientsReadModel.mockImplementation((metrics) => ({
-      ideStats: metrics.ideStats,
-      multiIDEUsersCount: metrics.multiIDEUsersCount,
-      totalUniqueIDEUsers: metrics.totalUniqueIDEUsers,
-      cliUsers: metrics.stats.cliUsers,
-      cliSessions: 0,
-      cliLocAdded: 0,
-      cliLocDeleted: 0,
-    }));
-    mocks.selectClientVersionsReadModel.mockImplementation((metrics) => ({
-      pluginVersionData: metrics.pluginVersionData,
-      reportStartDay: metrics.stats.reportStartDay,
-    }));
-    mocks.selectModelDetailsReadModel.mockImplementation((metrics) => ({
-      allModels: metrics.modelBreakdownData.allModels,
-      modelCategories: metrics.modelBreakdownData.modelCategories,
-      autoModels: metrics.modelBreakdownData.autoModels ?? [],
-      autoModeAdoptionTrend:
-        metrics.modelBreakdownData.autoModeAdoptionTrend ?? [],
-      dates: metrics.modelBreakdownData.dates,
-      modelTotal: metrics.modelBreakdownData.modelTotal,
-      autoTotal: 0,
-    }));
-    mocks.selectCliAdoptionReadModel.mockImplementation((metrics) => ({
-      stats: metrics.stats,
-      dailyCliSessionData: metrics.dailyCliSessionData,
-      dailyCliTokenData: metrics.dailyCliTokenData,
-      dailyCliAdoptionTrend: metrics.dailyCliAdoptionTrend,
-      cliModelEntries: metrics.modelBreakdownData.cliModels ?? [],
-      cliModelDates: metrics.modelBreakdownData.dates,
-      cliModelTotal: metrics.modelBreakdownData.cliTotal ?? 0,
-      cliShare: 0,
-    }));
-    mocks.selectAiCreditsReadModel.mockImplementation((metrics, onUserClick) => ({
-      reportStartDay: metrics.stats.reportStartDay,
-      reportEndDay: metrics.stats.reportEndDay,
-      dailyAiCreditsData: metrics.dailyAiCreditsData,
-      userSummaries: metrics.userSummaries,
-      usageDistributionData: metrics.usageDistributionData,
-      totalAiCreditsUsed: 0,
-      onUserClick,
-    }));
   });
 
   describe('user-detail redirects', () => {
@@ -284,192 +94,27 @@ describe('ViewRouter', () => {
     });
   });
 
-  it('routes Copilot adoption through one cohesive read model', () => {
-    mocks.currentView = VIEW_MODES.COPILOT_ADOPTION;
-
-    renderToStaticMarkup(<ViewRouter />);
-
-    expect(mocks.copilotAdoptionView).toHaveBeenCalledOnce();
-    const props = mocks.copilotAdoptionView.mock.calls[0][0];
-    expect(Object.keys(props)).toEqual(['model']);
-    expect(props.model).toEqual({
-      featureAdoptionData: mocks.aggregatedMetrics?.featureAdoptionData,
-      agentModeHeatmapData: mocks.aggregatedMetrics?.agentModeHeatmapData,
-      stats: mocks.aggregatedMetrics?.stats,
-      dailyAdoptionTrend: mocks.aggregatedMetrics?.dailyAdoptionTrend,
-      dailyCloudAgentAdoptionData: mocks.aggregatedMetrics?.dailyCloudAgentAdoptionData,
-      dailyCodeReviewAdoptionData: mocks.aggregatedMetrics?.dailyCodeReviewAdoptionData,
-    });
-  });
-
-  it('routes AI adoption phases through one cohesive read model', () => {
-    mocks.currentView = VIEW_MODES.AI_ADOPTION_PHASES;
-
-    renderToStaticMarkup(<ViewRouter />);
-
-    expect(mocks.aiAdoptionPhaseView).toHaveBeenCalledOnce();
-    const props = mocks.aiAdoptionPhaseView.mock.calls[0][0];
-    expect(Object.keys(props)).toEqual(['model']);
-    expect(props.model).toEqual({
-      aiAdoptionPhaseData: mocks.aggregatedMetrics?.aiAdoptionPhaseData,
-    });
-  });
-
-  it('routes Copilot impact through one cohesive read model', () => {
-    mocks.currentView = VIEW_MODES.COPILOT_IMPACT;
-
-    renderToStaticMarkup(<ViewRouter />);
-
-    expect(mocks.copilotImpactView).toHaveBeenCalledOnce();
-    const props = mocks.copilotImpactView.mock.calls[0][0];
-    expect(Object.keys(props)).toEqual(['model']);
-    expect(props.model).toEqual({
-      agentImpactData: mocks.aggregatedMetrics?.agentImpactData,
-      codeCompletionImpactData: mocks.aggregatedMetrics?.codeCompletionImpactData,
-      editModeImpactData: mocks.aggregatedMetrics?.editModeImpactData,
-      inlineModeImpactData: mocks.aggregatedMetrics?.inlineModeImpactData,
-      askModeImpactData: mocks.aggregatedMetrics?.askModeImpactData,
-      cliImpactData: mocks.aggregatedMetrics?.cliImpactData,
-      joinedImpactData: mocks.aggregatedMetrics?.joinedImpactData,
-    });
-  });
-
-  it('routes languages through one cohesive read model', () => {
+  it('delegates a standard view with the shared route context', () => {
     mocks.currentView = VIEW_MODES.LANGUAGES;
-    const expectedModel = {
-      languageStats: mocks.aggregatedMetrics!.languageStats,
-      languageFeatureImpactData: mocks.aggregatedMetrics!.languageFeatureImpactData,
-      dailyLanguageGenerationsData: mocks.aggregatedMetrics!.dailyLanguageGenerationsData,
-      dailyLanguageLocData: mocks.aggregatedMetrics!.dailyLanguageLocData,
-    };
-    mocks.selectLanguagesReadModel.mockReturnValueOnce(expectedModel);
 
     renderToStaticMarkup(<ViewRouter />);
 
-    expect(mocks.selectLanguagesReadModel).toHaveBeenCalledWith(mocks.aggregatedMetrics);
-    expect(mocks.languagesView).toHaveBeenCalledOnce();
-    const props = mocks.languagesView.mock.calls[0][0];
-    expect(Object.keys(props)).toEqual(['model']);
-    expect(props.model).toBe(expectedModel);
+    expect(mocks.standardRouteOutlet).toHaveBeenCalledOnce();
+    const props = mocks.standardRouteOutlet.mock.calls[0][0];
+    expect(props.view).toBe(VIEW_MODES.LANGUAGES);
+    expect(props.aggregatedMetrics).toBe(mocks.aggregatedMetrics);
+    expect(props.enterpriseName).toBe('test-enterprise');
+
+    props.onUserSelect('octocat', 42);
+    expect(mocks.selectUser).toHaveBeenCalledWith({
+      login: 'octocat',
+      id: 42,
+    });
   });
 
-  it('routes clients through the selector and one cohesive read model', () => {
-    mocks.currentView = VIEW_MODES.CLIENT_ANALYSIS;
-    const expectedModel: ClientsReadModel = {
-      ideStats: mocks.aggregatedMetrics!.ideStats,
-      multiIDEUsersCount: 4,
-      totalUniqueIDEUsers: 5,
-      cliUsers: 6,
-      cliSessions: 7,
-      cliLocAdded: 8,
-      cliLocDeleted: 9,
-    };
-    mocks.selectClientsReadModel.mockReturnValueOnce(expectedModel);
-
+  it('keeps user details out of the standard route outlet', () => {
     renderToStaticMarkup(<ViewRouter />);
 
-    expect(mocks.selectClientsReadModel).toHaveBeenCalledWith(
-      mocks.aggregatedMetrics
-    );
-    expect(mocks.clientsView).toHaveBeenCalledOnce();
-    const props = mocks.clientsView.mock.calls[0][0];
-    expect(Object.keys(props)).toEqual(['model']);
-    expect(props.model).toBe(expectedModel);
-  });
-
-  it('routes client versions through the selector and one cohesive read model', () => {
-    mocks.currentView = VIEW_MODES.CLIENT_VERSIONS;
-    const expectedModel: ClientVersionsReadModel = {
-      pluginVersionData: mocks.aggregatedMetrics!.pluginVersionData,
-      reportStartDay: '2026-01-15',
-    };
-    mocks.selectClientVersionsReadModel.mockReturnValueOnce(expectedModel);
-
-    renderToStaticMarkup(<ViewRouter />);
-
-    expect(mocks.selectClientVersionsReadModel).toHaveBeenCalledWith(
-      mocks.aggregatedMetrics
-    );
-    expect(mocks.clientVersionsView).toHaveBeenCalledOnce();
-    const props = mocks.clientVersionsView.mock.calls[0][0];
-    expect(Object.keys(props)).toEqual(['model']);
-    expect(props.model).toBe(expectedModel);
-  });
-
-  it('routes model details through the selector and one cohesive read model', () => {
-    mocks.currentView = VIEW_MODES.MODEL_DETAILS;
-    const expectedModel: ModelDetailsReadModel = {
-      allModels: mocks.aggregatedMetrics!.modelBreakdownData.allModels,
-      modelCategories:
-        mocks.aggregatedMetrics!.modelBreakdownData.modelCategories,
-      autoModels: mocks.aggregatedMetrics!.modelBreakdownData.autoModels ?? [],
-      autoModeAdoptionTrend:
-        mocks.aggregatedMetrics!.modelBreakdownData.autoModeAdoptionTrend ?? [],
-      dates: mocks.aggregatedMetrics!.modelBreakdownData.dates,
-      modelTotal: 10,
-      autoTotal: 4,
-    };
-    mocks.selectModelDetailsReadModel.mockReturnValueOnce(expectedModel);
-
-    renderToStaticMarkup(<ViewRouter />);
-
-    expect(mocks.selectModelDetailsReadModel).toHaveBeenCalledWith(
-      mocks.aggregatedMetrics
-    );
-    expect(mocks.modelDetailsView).toHaveBeenCalledOnce();
-    const props = mocks.modelDetailsView.mock.calls[0][0];
-    expect(Object.keys(props)).toEqual(['model']);
-    expect(props.model).toBe(expectedModel);
-  });
-
-  it('routes CLI adoption through the selector and one cohesive read model', () => {
-    mocks.currentView = VIEW_MODES.CLI_ADOPTION;
-    const expectedModel: CliAdoptionReadModel = {
-      stats: mocks.aggregatedMetrics!.stats,
-      dailyCliSessionData: mocks.aggregatedMetrics!.dailyCliSessionData,
-      dailyCliTokenData: mocks.aggregatedMetrics!.dailyCliTokenData,
-      dailyCliAdoptionTrend: mocks.aggregatedMetrics!.dailyCliAdoptionTrend,
-      cliModelEntries:
-        mocks.aggregatedMetrics!.modelBreakdownData.cliModels ?? [],
-      cliModelDates: ['2026-01-15'],
-      cliModelTotal: 7,
-      cliShare: 12.5,
-    };
-    mocks.selectCliAdoptionReadModel.mockReturnValueOnce(expectedModel);
-
-    renderToStaticMarkup(<ViewRouter />);
-
-    expect(mocks.selectCliAdoptionReadModel).toHaveBeenCalledWith(
-      mocks.aggregatedMetrics
-    );
-    expect(mocks.cliAdoptionView).toHaveBeenCalledOnce();
-    const props = mocks.cliAdoptionView.mock.calls[0][0];
-    expect(Object.keys(props)).toEqual(['model']);
-    expect(props.model).toBe(expectedModel);
-  });
-
-  it('routes AI Credits through the selector and a sole model prop', () => {
-    mocks.currentView = VIEW_MODES.AI_CREDITS;
-    const expectedModel: AiCreditsReadModel = {
-      reportStartDay: '2026-01-15',
-      reportEndDay: '2026-01-31',
-      dailyAiCreditsData: mocks.aggregatedMetrics!.dailyAiCreditsData,
-      userSummaries: mocks.aggregatedMetrics!.userSummaries,
-      usageDistributionData: mocks.aggregatedMetrics!.usageDistributionData,
-      totalAiCreditsUsed: 17.25,
-      onUserClick: vi.fn(),
-    };
-    mocks.selectAiCreditsReadModel.mockReturnValueOnce(expectedModel);
-
-    renderToStaticMarkup(<ViewRouter />);
-
-    expect(mocks.selectAiCreditsReadModel).toHaveBeenCalledOnce();
-    const [metrics, onUserClick] = mocks.selectAiCreditsReadModel.mock.calls[0];
-    expect(metrics).toBe(mocks.aggregatedMetrics);
-    expect(onUserClick).toEqual(expect.any(Function));
-    expect(mocks.aiCreditsView).toHaveBeenCalledOnce();
-    const props = mocks.aiCreditsView.mock.calls[0][0];
-    expect(Object.keys(props)).toEqual(['model']);
-    expect(props.model).toBe(expectedModel);
+    expect(mocks.standardRouteOutlet).not.toHaveBeenCalled();
   });
 });

--- a/src/components/layout/routes/StandardRouteOutlet.tsx
+++ b/src/components/layout/routes/StandardRouteOutlet.tsx
@@ -1,0 +1,27 @@
+import type { AggregatedMetrics } from '../../../types/aggregatedMetrics';
+import type { ViewMode } from '../../../types/navigation';
+import { resolveStandardRouteAdapter } from './standardRouteRegistry';
+
+interface StandardRouteOutletProps {
+  view: ViewMode;
+  aggregatedMetrics: AggregatedMetrics;
+  enterpriseName: string | null;
+  onUserSelect: (userLogin: string, userId: number) => void;
+}
+
+export default function StandardRouteOutlet({
+  view,
+  aggregatedMetrics,
+  enterpriseName,
+  onUserSelect,
+}: StandardRouteOutletProps) {
+  const RouteAdapter = resolveStandardRouteAdapter(view);
+
+  return (
+    <RouteAdapter
+      aggregatedMetrics={aggregatedMetrics}
+      enterpriseName={enterpriseName}
+      onUserSelect={onUserSelect}
+    />
+  );
+}

--- a/src/components/layout/routes/__tests__/standardRouteRegistry.test.tsx
+++ b/src/components/layout/routes/__tests__/standardRouteRegistry.test.tsx
@@ -1,0 +1,243 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { makeMetric } from '../../../../__tests__/factories/metrics';
+import { aggregateMetrics } from '../../../../domain/metricsAggregator';
+import type { AiCreditsReadModel } from '../../../../read-models/aiCredits';
+import type {
+  ExecutiveSummaryReadModel,
+  OverviewReadModel,
+} from '../../../../read-models/overview';
+import type { UsersReadModel } from '../../../../read-models/users';
+import type { AggregatedMetrics } from '../../../../types/aggregatedMetrics';
+import { VIEW_MODES } from '../../../../types/navigation';
+import {
+  STANDARD_ROUTE_REGISTRY,
+  STANDARD_VIEW_MODES,
+  isStandardViewMode,
+  resolveStandardRouteAdapter,
+} from '../standardRouteRegistry';
+import {
+  AboutRouteAdapter,
+  AiAdoptionPhasesRouteAdapter,
+  AiCreditsRouteAdapter,
+  CliAdoptionRouteAdapter,
+  ClientVersionsRouteAdapter,
+  ClientsRouteAdapter,
+  CopilotAdoptionRouteAdapter,
+  CopilotImpactRouteAdapter,
+  ExecutiveSummaryRouteAdapter,
+  LanguagesRouteAdapter,
+  ModelDetailsRouteAdapter,
+  OverviewRouteAdapter,
+  UsersRouteAdapter,
+  type StandardRouteContext,
+} from '../standardRouteAdapters';
+
+const mocks = vi.hoisted(() => ({
+  selectOverviewReadModel:
+    vi.fn<(metrics: AggregatedMetrics) => OverviewReadModel>(),
+  selectExecutiveSummaryReadModel:
+    vi.fn<(metrics: AggregatedMetrics) => ExecutiveSummaryReadModel>(),
+  selectUsersReadModel:
+    vi.fn<(metrics: AggregatedMetrics) => UsersReadModel>(),
+  selectAiCreditsReadModel: vi.fn<
+    (
+      metrics: AggregatedMetrics,
+      onUserSelect: AiCreditsReadModel['onUserClick']
+    ) => AiCreditsReadModel
+  >(),
+  overviewView:
+    vi.fn<
+      (props: {
+        model: OverviewReadModel;
+        enterpriseName: string | null;
+      }) => void
+    >(),
+  usersView:
+    vi.fn<
+      (props: {
+        model: UsersReadModel;
+        onUserClick: StandardRouteContext['onUserSelect'];
+      }) => void
+    >(),
+  aiCreditsView: vi.fn<(props: { model: AiCreditsReadModel }) => void>(),
+  aboutView: vi.fn(),
+}));
+
+vi.mock('../../../../read-models/overview', () => ({
+  selectOverviewReadModel: mocks.selectOverviewReadModel,
+  selectExecutiveSummaryReadModel: mocks.selectExecutiveSummaryReadModel,
+}));
+
+vi.mock('../../../../read-models/users', () => ({
+  selectUsersReadModel: mocks.selectUsersReadModel,
+}));
+
+vi.mock('../../../../read-models/aiCredits', () => ({
+  selectAiCreditsReadModel: mocks.selectAiCreditsReadModel,
+}));
+
+vi.mock('../../../features/overview', () => ({
+  OverviewDashboard: (props: {
+    model: OverviewReadModel;
+    enterpriseName: string | null;
+  }) => {
+    mocks.overviewView(props);
+    return null;
+  },
+}));
+
+vi.mock('../../../UniqueUsersView', () => ({
+  default: (props: {
+    model: UsersReadModel;
+    onUserClick: StandardRouteContext['onUserSelect'];
+  }) => {
+    mocks.usersView(props);
+    return null;
+  },
+}));
+
+vi.mock('../../../AiCreditsView', () => ({
+  default: (props: { model: AiCreditsReadModel }) => {
+    mocks.aiCreditsView(props);
+    return null;
+  },
+}));
+
+vi.mock('../../../AboutView', () => ({
+  default: () => {
+    mocks.aboutView();
+    return null;
+  },
+}));
+
+describe('standard route registry', () => {
+  let context: StandardRouteContext;
+  let overviewModel: OverviewReadModel;
+  let usersModel: UsersReadModel;
+  let aiCreditsModel: AiCreditsReadModel;
+
+  beforeEach(() => {
+    const aggregatedMetrics = aggregateMetrics([makeMetric()]).aggregated;
+    const onUserSelect = vi.fn();
+
+    overviewModel = {
+      reportStartDay: aggregatedMetrics.stats.reportStartDay,
+      reportEndDay: aggregatedMetrics.stats.reportEndDay,
+      engagementData: aggregatedMetrics.engagementData,
+      chatUsersData: aggregatedMetrics.chatUsersData,
+      chatRequestsData: aggregatedMetrics.chatRequestsData,
+    };
+    usersModel = { users: aggregatedMetrics.userSummaries };
+    aiCreditsModel = {
+      reportStartDay: aggregatedMetrics.stats.reportStartDay,
+      reportEndDay: aggregatedMetrics.stats.reportEndDay,
+      dailyAiCreditsData: aggregatedMetrics.dailyAiCreditsData,
+      userSummaries: aggregatedMetrics.userSummaries,
+      usageDistributionData: aggregatedMetrics.usageDistributionData,
+      totalAiCreditsUsed: 0,
+      onUserClick: onUserSelect,
+    };
+    context = {
+      aggregatedMetrics,
+      enterpriseName: 'test-enterprise',
+      onUserSelect,
+    };
+
+    vi.clearAllMocks();
+    mocks.selectOverviewReadModel.mockReturnValue(overviewModel);
+    mocks.selectUsersReadModel.mockReturnValue(usersModel);
+    mocks.selectAiCreditsReadModel.mockReturnValue(aiCreditsModel);
+  });
+
+  it('covers every view mode except specialized user details', () => {
+    const expectedModes = Object.values(VIEW_MODES).filter(
+      (view) => view !== VIEW_MODES.USER_DETAILS
+    );
+
+    expect([...STANDARD_VIEW_MODES].sort()).toEqual(expectedModes.sort());
+    expect(Object.keys(STANDARD_ROUTE_REGISTRY).sort()).toEqual(
+      expectedModes.sort()
+    );
+    expect(STANDARD_ROUTE_REGISTRY).not.toHaveProperty(
+      VIEW_MODES.USER_DETAILS
+    );
+  });
+
+  it('maps each standard mode to its feature-owned adapter', () => {
+    expect(STANDARD_ROUTE_REGISTRY).toEqual({
+      [VIEW_MODES.OVERVIEW]: OverviewRouteAdapter,
+      [VIEW_MODES.AI_CREDITS]: AiCreditsRouteAdapter,
+      [VIEW_MODES.EXECUTIVE_SUMMARY]: ExecutiveSummaryRouteAdapter,
+      [VIEW_MODES.ABOUT]: AboutRouteAdapter,
+      [VIEW_MODES.CLIENT_VERSIONS]: ClientVersionsRouteAdapter,
+      [VIEW_MODES.USERS]: UsersRouteAdapter,
+      [VIEW_MODES.LANGUAGES]: LanguagesRouteAdapter,
+      [VIEW_MODES.CLIENT_ANALYSIS]: ClientsRouteAdapter,
+      [VIEW_MODES.COPILOT_IMPACT]: CopilotImpactRouteAdapter,
+      [VIEW_MODES.COPILOT_ADOPTION]: CopilotAdoptionRouteAdapter,
+      [VIEW_MODES.AI_ADOPTION_PHASES]: AiAdoptionPhasesRouteAdapter,
+      [VIEW_MODES.MODEL_DETAILS]: ModelDetailsRouteAdapter,
+      [VIEW_MODES.CLI_ADOPTION]: CliAdoptionRouteAdapter,
+    });
+  });
+
+  it('recognizes only registered standard view modes', () => {
+    expect(isStandardViewMode(VIEW_MODES.ABOUT)).toBe(true);
+    expect(isStandardViewMode(VIEW_MODES.USER_DETAILS)).toBe(false);
+    expect(isStandardViewMode('unknown')).toBe(false);
+  });
+
+  it('selects and renders only the requested overview adapter', () => {
+    const RouteAdapter = resolveStandardRouteAdapter(VIEW_MODES.OVERVIEW);
+
+    renderToStaticMarkup(<RouteAdapter {...context} />);
+
+    expect(mocks.selectOverviewReadModel).toHaveBeenCalledWith(
+      context.aggregatedMetrics
+    );
+    expect(mocks.overviewView).toHaveBeenCalledWith({
+      model: overviewModel,
+      enterpriseName: context.enterpriseName,
+    });
+    expect(mocks.selectUsersReadModel).not.toHaveBeenCalled();
+    expect(mocks.selectAiCreditsReadModel).not.toHaveBeenCalled();
+  });
+
+  it('forwards the same user-selection callback through user-aware adapters', () => {
+    const UsersAdapter = resolveStandardRouteAdapter(VIEW_MODES.USERS);
+    const AiCreditsAdapter = resolveStandardRouteAdapter(VIEW_MODES.AI_CREDITS);
+
+    renderToStaticMarkup(<UsersAdapter {...context} />);
+    renderToStaticMarkup(<AiCreditsAdapter {...context} />);
+
+    expect(mocks.usersView).toHaveBeenCalledWith({
+      model: usersModel,
+      onUserClick: context.onUserSelect,
+    });
+    expect(mocks.selectAiCreditsReadModel).toHaveBeenCalledWith(
+      context.aggregatedMetrics,
+      context.onUserSelect
+    );
+    expect(mocks.aiCreditsView).toHaveBeenCalledWith({
+      model: aiCreditsModel,
+    });
+  });
+
+  it('renders about without selecting aggregate-backed models', () => {
+    const AboutAdapter = resolveStandardRouteAdapter(VIEW_MODES.ABOUT);
+
+    renderToStaticMarkup(<AboutAdapter {...context} />);
+
+    expect(mocks.aboutView).toHaveBeenCalledOnce();
+    expect(mocks.selectOverviewReadModel).not.toHaveBeenCalled();
+    expect(mocks.selectUsersReadModel).not.toHaveBeenCalled();
+    expect(mocks.selectAiCreditsReadModel).not.toHaveBeenCalled();
+  });
+
+  it('falls back to overview for unknown modes', () => {
+    expect(resolveStandardRouteAdapter('unknown')).toBe(
+      STANDARD_ROUTE_REGISTRY[VIEW_MODES.OVERVIEW]
+    );
+  });
+});

--- a/src/components/layout/routes/index.ts
+++ b/src/components/layout/routes/index.ts
@@ -1,0 +1,12 @@
+export { default as StandardRouteOutlet } from './StandardRouteOutlet';
+export {
+  STANDARD_ROUTE_REGISTRY,
+  STANDARD_VIEW_MODES,
+  isStandardViewMode,
+  resolveStandardRouteAdapter,
+  type StandardViewMode,
+} from './standardRouteRegistry';
+export type {
+  StandardRouteAdapter,
+  StandardRouteContext,
+} from './standardRouteAdapters';

--- a/src/components/layout/routes/standardRouteAdapters.tsx
+++ b/src/components/layout/routes/standardRouteAdapters.tsx
@@ -1,0 +1,160 @@
+import type { ComponentType } from 'react';
+import type { AggregatedMetrics } from '../../../types/aggregatedMetrics';
+import { selectAiCreditsReadModel } from '../../../read-models/aiCredits';
+import { selectAiAdoptionPhaseReadModel } from '../../../read-models/aiAdoptionPhases';
+import { selectCopilotAdoptionReadModel } from '../../../read-models/adoption';
+import { selectCliAdoptionReadModel } from '../../../read-models/cliAdoption';
+import {
+  selectClientsReadModel,
+  selectClientVersionsReadModel,
+} from '../../../read-models/clients';
+import { selectCopilotImpactReadModel } from '../../../read-models/impact';
+import { selectLanguagesReadModel } from '../../../read-models/languages';
+import { selectModelDetailsReadModel } from '../../../read-models/models';
+import {
+  selectExecutiveSummaryReadModel,
+  selectOverviewReadModel,
+} from '../../../read-models/overview';
+import { selectUsersReadModel } from '../../../read-models/users';
+import AboutView from '../../AboutView';
+import AiAdoptionPhaseView from '../../AiAdoptionPhaseView';
+import AiCreditsView from '../../AiCreditsView';
+import CLIAdoptionView from '../../CLIAdoptionView';
+import ClientVersionsView from '../../ClientVersionsView';
+import ClientsView from '../../ClientsView';
+import CopilotAdoptionView from '../../CopilotAdoptionView';
+import CopilotImpactView from '../../CopilotImpactView';
+import ExecutiveSummaryView from '../../ExecutiveSummaryView';
+import LanguagesView from '../../LanguagesView';
+import ModelDetailsView from '../../ModelDetailsView';
+import UniqueUsersView from '../../UniqueUsersView';
+import { OverviewDashboard } from '../../features/overview';
+
+export interface StandardRouteContext {
+  aggregatedMetrics: AggregatedMetrics;
+  enterpriseName: string | null;
+  onUserSelect: (userLogin: string, userId: number) => void;
+}
+
+export type StandardRouteAdapter = ComponentType<StandardRouteContext>;
+
+export function OverviewRouteAdapter({
+  aggregatedMetrics,
+  enterpriseName,
+}: StandardRouteContext) {
+  return (
+    <OverviewDashboard
+      model={selectOverviewReadModel(aggregatedMetrics)}
+      enterpriseName={enterpriseName}
+    />
+  );
+}
+
+export function AiCreditsRouteAdapter({
+  aggregatedMetrics,
+  onUserSelect,
+}: StandardRouteContext) {
+  return (
+    <AiCreditsView
+      model={selectAiCreditsReadModel(aggregatedMetrics, onUserSelect)}
+    />
+  );
+}
+
+export function ExecutiveSummaryRouteAdapter({
+  aggregatedMetrics,
+  enterpriseName,
+}: StandardRouteContext) {
+  return (
+    <ExecutiveSummaryView
+      model={selectExecutiveSummaryReadModel(aggregatedMetrics)}
+      enterpriseName={enterpriseName}
+    />
+  );
+}
+
+export const AboutRouteAdapter: StandardRouteAdapter = () => <AboutView />;
+
+export function ClientVersionsRouteAdapter({
+  aggregatedMetrics,
+}: StandardRouteContext) {
+  return (
+    <ClientVersionsView
+      model={selectClientVersionsReadModel(aggregatedMetrics)}
+    />
+  );
+}
+
+export function UsersRouteAdapter({
+  aggregatedMetrics,
+  onUserSelect,
+}: StandardRouteContext) {
+  return (
+    <UniqueUsersView
+      model={selectUsersReadModel(aggregatedMetrics)}
+      onUserClick={onUserSelect}
+    />
+  );
+}
+
+export function LanguagesRouteAdapter({
+  aggregatedMetrics,
+}: StandardRouteContext) {
+  return <LanguagesView model={selectLanguagesReadModel(aggregatedMetrics)} />;
+}
+
+export function ClientsRouteAdapter({
+  aggregatedMetrics,
+}: StandardRouteContext) {
+  return <ClientsView model={selectClientsReadModel(aggregatedMetrics)} />;
+}
+
+export function CopilotImpactRouteAdapter({
+  aggregatedMetrics,
+}: StandardRouteContext) {
+  return (
+    <CopilotImpactView
+      model={selectCopilotImpactReadModel(aggregatedMetrics)}
+    />
+  );
+}
+
+export function CopilotAdoptionRouteAdapter({
+  aggregatedMetrics,
+}: StandardRouteContext) {
+  return (
+    <CopilotAdoptionView
+      model={selectCopilotAdoptionReadModel(aggregatedMetrics)}
+    />
+  );
+}
+
+export function AiAdoptionPhasesRouteAdapter({
+  aggregatedMetrics,
+}: StandardRouteContext) {
+  return (
+    <AiAdoptionPhaseView
+      model={selectAiAdoptionPhaseReadModel(aggregatedMetrics)}
+    />
+  );
+}
+
+export function ModelDetailsRouteAdapter({
+  aggregatedMetrics,
+}: StandardRouteContext) {
+  return (
+    <ModelDetailsView
+      model={selectModelDetailsReadModel(aggregatedMetrics)}
+    />
+  );
+}
+
+export function CliAdoptionRouteAdapter({
+  aggregatedMetrics,
+}: StandardRouteContext) {
+  return (
+    <CLIAdoptionView
+      model={selectCliAdoptionReadModel(aggregatedMetrics)}
+    />
+  );
+}

--- a/src/components/layout/routes/standardRouteRegistry.ts
+++ b/src/components/layout/routes/standardRouteRegistry.ts
@@ -1,0 +1,68 @@
+import { VIEW_MODES, type ViewMode } from '../../../types/navigation';
+import {
+  AboutRouteAdapter,
+  AiAdoptionPhasesRouteAdapter,
+  AiCreditsRouteAdapter,
+  CliAdoptionRouteAdapter,
+  ClientVersionsRouteAdapter,
+  ClientsRouteAdapter,
+  CopilotAdoptionRouteAdapter,
+  CopilotImpactRouteAdapter,
+  ExecutiveSummaryRouteAdapter,
+  LanguagesRouteAdapter,
+  ModelDetailsRouteAdapter,
+  OverviewRouteAdapter,
+  UsersRouteAdapter,
+  type StandardRouteAdapter,
+} from './standardRouteAdapters';
+
+export type StandardViewMode = Exclude<
+  ViewMode,
+  typeof VIEW_MODES.USER_DETAILS
+>;
+
+export const STANDARD_VIEW_MODES = [
+  VIEW_MODES.OVERVIEW,
+  VIEW_MODES.AI_CREDITS,
+  VIEW_MODES.EXECUTIVE_SUMMARY,
+  VIEW_MODES.ABOUT,
+  VIEW_MODES.CLIENT_VERSIONS,
+  VIEW_MODES.USERS,
+  VIEW_MODES.LANGUAGES,
+  VIEW_MODES.CLIENT_ANALYSIS,
+  VIEW_MODES.COPILOT_IMPACT,
+  VIEW_MODES.COPILOT_ADOPTION,
+  VIEW_MODES.AI_ADOPTION_PHASES,
+  VIEW_MODES.MODEL_DETAILS,
+  VIEW_MODES.CLI_ADOPTION,
+] as const satisfies readonly StandardViewMode[];
+
+export const STANDARD_ROUTE_REGISTRY = {
+  [VIEW_MODES.OVERVIEW]: OverviewRouteAdapter,
+  [VIEW_MODES.AI_CREDITS]: AiCreditsRouteAdapter,
+  [VIEW_MODES.EXECUTIVE_SUMMARY]: ExecutiveSummaryRouteAdapter,
+  [VIEW_MODES.ABOUT]: AboutRouteAdapter,
+  [VIEW_MODES.CLIENT_VERSIONS]: ClientVersionsRouteAdapter,
+  [VIEW_MODES.USERS]: UsersRouteAdapter,
+  [VIEW_MODES.LANGUAGES]: LanguagesRouteAdapter,
+  [VIEW_MODES.CLIENT_ANALYSIS]: ClientsRouteAdapter,
+  [VIEW_MODES.COPILOT_IMPACT]: CopilotImpactRouteAdapter,
+  [VIEW_MODES.COPILOT_ADOPTION]: CopilotAdoptionRouteAdapter,
+  [VIEW_MODES.AI_ADOPTION_PHASES]: AiAdoptionPhasesRouteAdapter,
+  [VIEW_MODES.MODEL_DETAILS]: ModelDetailsRouteAdapter,
+  [VIEW_MODES.CLI_ADOPTION]: CliAdoptionRouteAdapter,
+} satisfies Record<StandardViewMode, StandardRouteAdapter>;
+
+export function isStandardViewMode(view: string): view is StandardViewMode {
+  return STANDARD_VIEW_MODES.some((standardView) => standardView === view);
+}
+
+export function resolveStandardRouteAdapter(
+  view: string
+): StandardRouteAdapter {
+  if (isStandardViewMode(view)) {
+    return STANDARD_ROUTE_REGISTRY[view];
+  }
+
+  return STANDARD_ROUTE_REGISTRY[VIEW_MODES.OVERVIEW];
+}


### PR DESCRIPTION
## Why

Standard feature routing should not make `ViewRouter` know every feature selector and view or eagerly compute unselected read models. This introduces a typed layout-owned adapter registry while leaving specialized user-details orchestration unchanged.

| Commit | Change |
|--------|--------|
| `refactor: add typed standard route registry` | Add lazy feature-owned adapters, a complete typed registry, and thin `ViewRouter` delegation. |
| `test: cover standard route delegation` | Cover registry completeness, route mapping, laziness, callbacks, fallback, About, and router delegation. |
| `docs: describe standard view routing` | Document the standard-route boundary and remaining user-details specialization. |