### PR TITLE
Group the worker aggregate contract

### DIFF
--- a/docs/project-overview.md
+++ b/docs/project-overview.md
@@ -35,13 +35,13 @@ Next.js App Router SPA, TypeScript, Tailwind CSS. All rendering is client-side.
 
 **Web Worker for parsing and aggregation.** All CPU-intensive work (file parsing, metrics aggregation) runs in a dedicated Web Worker (`src/workers/`). The worker is pre-bundled via esbuild into `public/workers/metricsWorker.js` as a self-contained IIFE — this is required for compatibility with Next.js static export (`output: 'export'`).
 
-**Raw metrics never leave the worker.** The `parseAndAggregate` flow parses files and aggregates them into a compact `AggregatedMetrics` object entirely within the worker. Only this pre-aggregated result is transferred to the main thread. This significantly reduces memory footprint for large datasets.
+**Raw metrics never leave the worker.** The `parseAndAggregate` flow parses files and aggregates them into a compact, grouped `AggregatedMetrics` object entirely within the worker. Only this pre-aggregated result is transferred to the main thread. This significantly reduces memory footprint for large datasets.
 
 **Two React contexts for state:**
 - `MetricsContext` (`src/components/MetricsContext.tsx`) — stores the `AggregatedMetrics` result, loading/error/warning state, and data actions
 - `NavigationContext` (`src/state/NavigationContext.tsx`) — manages current view, selected user/model, and navigation actions
 
-**All view components consume pre-aggregated data.** No component accesses raw `CopilotMetrics[]` directly. The flat `AggregatedMetrics` worker/UI contract is declared in `src/types/aggregatedMetrics.ts`. Feature read-model selectors in `src/read-models/` insulate aggregate-backed UI paths from that flat payload; overview, executive summary, users, user details, Copilot adoption, AI adoption phases, Copilot impact, languages, clients, client versions, model details, CLI adoption, and AI credits consume only their typed projections. Standard route adapters in `src/components/layout/routes/` own the selector and existing view for each non-user-details route, so only the selected route computes its projection. The specialized `UserDetailsRoute` owns user selection, on-demand worker requests, stale-result protection, redirects, recovery, and delivery of the user-details view model. The worker retains a compact user-detail accumulator so it can serve those requests without moving raw records onto the main thread.
+**All view components consume pre-aggregated data.** No component accesses raw `CopilotMetrics[]` directly. The canonical `AggregatedMetrics` worker/UI contract is declared in `src/types/aggregatedMetrics.ts` and groups every aggregate under one owning domain slice. Feature read-model selectors in `src/read-models/` navigate only the slices they need; overview, executive summary, users, user details, Copilot adoption, AI adoption phases, Copilot impact, languages, clients, client versions, model details, CLI adoption, and AI credits retain their narrow runtime projections. Standard route adapters in `src/components/layout/routes/` own the selector and existing view for each non-user-details route, so only the selected route computes its projection. The specialized `UserDetailsRoute` owns user selection, on-demand worker requests, stale-result protection, redirects, recovery, and delivery of the user-details view model. The worker retains a compact user-detail accumulator so it can serve those requests without moving raw records onto the main thread.
 
 ### 3.2. Code Organization
 
@@ -68,7 +68,22 @@ Next.js App Router SPA, TypeScript, Tailwind CSS. All rendering is client-side.
 
 ### 3.4. Feature Read-Model Boundaries
 
-The worker payload remains the flat, unchanged `AggregatedMetrics` object. Pure selectors under `src/read-models/` project stable references from that payload into narrow UI contracts without copying, sorting, filtering, or mutation. Selectors may contain only existing deterministic, feature-specific scalar or date derivations, such as client CLI totals, the model-details auto total, CLI model chart dates, and the AI credits user total.
+The successful worker payload is one grouped `AggregatedMetrics` object. Each former root field has exactly one owner:
+
+```text
+AggregatedMetrics
+├── overview  stats, engagementData, chatUsersData, chatRequestsData
+├── users     userSummaries
+├── adoption  featureAdoptionData, agentModeHeatmapData, adoption series
+├── impact    agent, completion, edit, inline, ask, CLI, and joined impact
+├── languages language stats, feature impact, generation and LOC series
+├── clients   IDE stats/counts and plugin versions
+├── models    daily model usage and model breakdown
+├── cli       session, token, and adoption series
+└── ai        adoption phases, usage distribution, and credits
+```
+
+Pure selectors under `src/read-models/` project stable nested references from those slices into unchanged UI contracts without copying, sorting, filtering, or mutation. Selectors may contain only existing deterministic, feature-specific scalar or date derivations, such as client CLI totals, the model-details auto total, CLI model chart dates, and the AI credits user total. Executive summary composes across `overview`, `impact`, and `adoption`; user-details routing preserves the complete grouped aggregate object as its dataset identity.
 
 Established boundaries cover:
 - overview and executive summary
@@ -81,7 +96,7 @@ Established boundaries cover:
 - model details and CLI adoption
 - AI credits
 
-Phase 4 feature read-model boundaries and Phase 7 thin view routing are complete. The worker payload remains flat and unchanged. The typed standard-route registry delegates all non-user-details routes, while `UserDetailsRoute` owns the complete specialized lifecycle. `ViewRouter` retains only metrics-wide gates and top-level route selection. Phase 6 feature-view organization remains deferred.
+Phase 4 feature read-model boundaries, Phase 7 thin view routing, and Phase 8 grouped aggregate contract migration are complete. The typed standard-route registry delegates all non-user-details routes, while `UserDetailsRoute` owns the complete specialized lifecycle. `ViewRouter` retains only metrics-wide gates and top-level route selection. Phase 6 feature-view organization remains deferred.
 
 ---
 
@@ -92,7 +107,7 @@ flowchart LR
   A[User uploads .ndjson file] --> B[useFileUpload hook]
   B --> C[MetricsWorkerProvider-owned client]
   C -->|postMessage: parseAndAggregate| W[Web Worker: parse + aggregate]
-  W -->|parseAndAggregateResult| D[MetricsContext stores AggregatedMetrics + warnings]
+  W -->|parseAndAggregateResult: grouped slices| D[MetricsContext stores AggregatedMetrics + warnings]
   D --> VR[ViewRouter resolves current route]
   VR --> SR[Selected standard route adapter]
   VR --> UR[Specialized UserDetailsRoute]
@@ -108,7 +123,7 @@ flowchart LR
 1. `useFileUpload` validates file extensions and requests parsing through the typed worker client exposed by `MetricsWorkerProvider`
 2. The worker streams each file through `src/infra/metricsFileParser.ts` using the `File.stream()` API, parses lines via `parseMetricsLine`, and applies string interning (`StringPool`) for memory efficiency
 3. Records using deprecated LOC fields or missing required fields are skipped
-4. The worker runs `aggregateMetrics()` on the parsed data, retains the compact user-detail accumulator for on-demand requests, and returns the `AggregatedMetrics` result, enterprise name, record count, and any per-file parse errors (surfaced as a non-fatal warning in the UI when partial failures occur). Raw records remain off the main thread.
+4. The worker runs `aggregateMetrics()` on the parsed data, retains the compact user-detail accumulator for on-demand requests, and returns the grouped `AggregatedMetrics` result, enterprise name, record count, and any per-file parse errors (surfaced as a non-fatal warning in the UI when partial failures occur). The request protocol and lifecycle are unchanged; raw records remain off the main thread.
 5. `MetricsWorkerProvider` is the application-level lifecycle owner. Its client creates the browser Worker lazily, correlates requests and progress responses, cancels pending work on reusable resets, and permanently disposes the Worker when the provider unmounts.
 
 ### 4.2. Aggregation
@@ -117,7 +132,7 @@ flowchart LR
 
 The coordinator resolves the Copilot Cloud Agent compatibility signal exactly once per raw record and passes that boolean to core stats, user summaries, user detail, and engagement/adoption. CLI usage is accumulated once by the CLI family, including zero-filled dates. Its narrow, read-only daily-session dependency is consumed by engagement/adoption finalization so engagement, chat, and adoption retain CLI users and sessions without duplicating accumulation or exposing token internals. Model aggregation retains ownership of agent heatmap state through an explicit feature-signal entry point while the engagement/adoption and impact families independently consume the feature fields required by their calculators.
 
-Phase 5 modular aggregation orchestration is complete. The top-level coordinator deliberately retains only accumulator wiring, one raw-record loop, shared-signal resolution, narrow cross-family dependencies, finalization, and ordered assembly. Every family result still maps into the same flat `AggregatedMetrics` object declared in `src/types/aggregatedMetrics.ts`, so the worker protocol and UI payload remain unchanged. The payload remains flat until the planned Phase 8 contract migration.
+Phase 5 modular aggregation orchestration and Phase 8 grouped contract assembly are complete. The top-level coordinator deliberately retains only accumulator wiring, one raw-record loop, shared-signal resolution, narrow cross-family dependencies, finalization, and grouped assembly. Concrete family results map directly into `overview`, `users`, `adoption`, `impact`, `languages`, `clients`, `models`, `cli`, and `ai` without recomputation, compatibility aliases, or duplicate ownership. The worker still returns the compact user-detail accumulator separately for retained on-demand use.
 
 ### 4.3. Views
 
@@ -150,6 +165,7 @@ flowchart TB
 		AGG[aggregation/]
 		CALC[calculators/]
 		MConf[modelConfig.ts]
+		GAM[Grouped AggregatedMetrics slices]
 	end
 
 	subgraph WorkerBridge
@@ -173,8 +189,11 @@ flowchart TB
 	WT --> MFP
 	WT --> MA
 	MA --> AGG
+	MA --> GAM
 	AGG --> CALC
 	CALC --> MConf
+	GAM -->|parseAndAggregateResult| WC
+	WC --> MC
 
 	MC --> VR
 	NC --> VR

--- a/src/__tests__/factories/aggregatedMetrics.ts
+++ b/src/__tests__/factories/aggregatedMetrics.ts
@@ -2,12 +2,81 @@ import { aggregateMetrics } from '../../domain/metricsAggregator';
 import type { AggregatedMetrics } from '../../types/aggregatedMetrics';
 import type { UserSummary } from '../../types/metrics';
 
-export function makeAggregatedMetrics(
-  overrides: Partial<AggregatedMetrics> = {}
-): AggregatedMetrics {
+type AggregatedMetricsOverrides = {
+  [Slice in keyof AggregatedMetrics]?: Partial<AggregatedMetrics[Slice]>;
+};
+
+export const AGGREGATED_METRICS_SLICE_KEYS = {
+  overview: ['stats', 'engagementData', 'chatUsersData', 'chatRequestsData'],
+  users: ['userSummaries'],
+  adoption: [
+    'featureAdoptionData',
+    'agentModeHeatmapData',
+    'dailyAdoptionTrend',
+    'dailyCloudAgentAdoptionData',
+    'dailyCodeReviewAdoptionData',
+  ],
+  impact: [
+    'agentImpactData',
+    'codeCompletionImpactData',
+    'editModeImpactData',
+    'inlineModeImpactData',
+    'askModeImpactData',
+    'cliImpactData',
+    'joinedImpactData',
+  ],
+  languages: [
+    'languageStats',
+    'languageFeatureImpactData',
+    'dailyLanguageGenerationsData',
+    'dailyLanguageLocData',
+  ],
+  clients: [
+    'ideStats',
+    'multiIDEUsersCount',
+    'totalUniqueIDEUsers',
+    'pluginVersionData',
+  ],
+  models: ['modelUsageData', 'modelBreakdownData'],
+  cli: ['dailyCliSessionData', 'dailyCliTokenData', 'dailyCliAdoptionTrend'],
+  ai: ['aiAdoptionPhaseData', 'usageDistributionData', 'dailyAiCreditsData'],
+} as const satisfies {
+  [Slice in keyof AggregatedMetrics]: readonly (keyof AggregatedMetrics[Slice])[];
+};
+
+export const FORMER_FLAT_AGGREGATE_KEYS = Object.values(
+  AGGREGATED_METRICS_SLICE_KEYS
+).flat();
+
+export function projectFormerFlatAggregate(metrics: AggregatedMetrics) {
   return {
-    ...aggregateMetrics([]).aggregated,
-    ...overrides,
+    ...metrics.overview,
+    ...metrics.users,
+    ...metrics.adoption,
+    ...metrics.impact,
+    ...metrics.languages,
+    ...metrics.clients,
+    ...metrics.models,
+    ...metrics.cli,
+    ...metrics.ai,
+  };
+}
+
+export function makeAggregatedMetrics(
+  overrides: AggregatedMetricsOverrides = {}
+): AggregatedMetrics {
+  const defaults = aggregateMetrics([]).aggregated;
+
+  return {
+    overview: { ...defaults.overview, ...overrides.overview },
+    users: { ...defaults.users, ...overrides.users },
+    adoption: { ...defaults.adoption, ...overrides.adoption },
+    impact: { ...defaults.impact, ...overrides.impact },
+    languages: { ...defaults.languages, ...overrides.languages },
+    clients: { ...defaults.clients, ...overrides.clients },
+    models: { ...defaults.models, ...overrides.models },
+    cli: { ...defaults.cli, ...overrides.cli },
+    ai: { ...defaults.ai, ...overrides.ai },
   };
 }
 

--- a/src/components/layout/DataInfoBar.tsx
+++ b/src/components/layout/DataInfoBar.tsx
@@ -8,7 +8,7 @@ const DataInfoBar: React.FC = () => {
 
   if (!aggregatedMetrics) return null;
 
-  const { reportStartDay, reportEndDay } = aggregatedMetrics.stats;
+  const { reportStartDay, reportEndDay } = aggregatedMetrics.overview.stats;
 
   return (
     <div className="fixed top-16 left-0 right-0 z-30 hidden h-9 items-center border-b border-[#d1d9e0] bg-[#f6f8fa] print:hidden lg:flex">

--- a/src/components/layout/routes/__tests__/UserDetailsRoute.test.tsx
+++ b/src/components/layout/routes/__tests__/UserDetailsRoute.test.tsx
@@ -238,7 +238,7 @@ describe('UserDetailsRoute', () => {
 
     expect(mocks.userDetailsView).toHaveBeenCalledWith({
       userDetails: details,
-      userSummary: mocks.aggregatedMetrics?.userSummaries[0],
+      userSummary: mocks.aggregatedMetrics?.users.userSummaries[0],
       userLogin: 'testuser',
       userId: 1,
     });

--- a/src/components/layout/routes/__tests__/standardRouteRegistry.test.tsx
+++ b/src/components/layout/routes/__tests__/standardRouteRegistry.test.tsx
@@ -122,19 +122,19 @@ describe('standard route registry', () => {
     const onUserSelect = vi.fn();
 
     overviewModel = {
-      reportStartDay: aggregatedMetrics.stats.reportStartDay,
-      reportEndDay: aggregatedMetrics.stats.reportEndDay,
-      engagementData: aggregatedMetrics.engagementData,
-      chatUsersData: aggregatedMetrics.chatUsersData,
-      chatRequestsData: aggregatedMetrics.chatRequestsData,
+      reportStartDay: aggregatedMetrics.overview.stats.reportStartDay,
+      reportEndDay: aggregatedMetrics.overview.stats.reportEndDay,
+      engagementData: aggregatedMetrics.overview.engagementData,
+      chatUsersData: aggregatedMetrics.overview.chatUsersData,
+      chatRequestsData: aggregatedMetrics.overview.chatRequestsData,
     };
-    usersModel = { users: aggregatedMetrics.userSummaries };
+    usersModel = { users: aggregatedMetrics.users.userSummaries };
     aiCreditsModel = {
-      reportStartDay: aggregatedMetrics.stats.reportStartDay,
-      reportEndDay: aggregatedMetrics.stats.reportEndDay,
-      dailyAiCreditsData: aggregatedMetrics.dailyAiCreditsData,
-      userSummaries: aggregatedMetrics.userSummaries,
-      usageDistributionData: aggregatedMetrics.usageDistributionData,
+      reportStartDay: aggregatedMetrics.overview.stats.reportStartDay,
+      reportEndDay: aggregatedMetrics.overview.stats.reportEndDay,
+      dailyAiCreditsData: aggregatedMetrics.ai.dailyAiCreditsData,
+      userSummaries: aggregatedMetrics.users.userSummaries,
+      usageDistributionData: aggregatedMetrics.ai.usageDistributionData,
       totalAiCreditsUsed: 0,
       onUserClick: onUserSelect,
     };

--- a/src/domain/__tests__/metricsAggregator.modularization.test.ts
+++ b/src/domain/__tests__/metricsAggregator.modularization.test.ts
@@ -82,7 +82,7 @@ describe('metrics aggregation modularization boundary', () => {
     const { aggregated } = aggregateMetrics(metrics);
 
     expect(metrics).toEqual(originalMetrics);
-    expect(aggregated.engagementData).toEqual([
+    expect(aggregated.overview.engagementData).toEqual([
       {
         date: '2024-01-15',
         activeUsers: 2,
@@ -96,7 +96,7 @@ describe('metrics aggregation modularization boundary', () => {
         engagementPercentage: 50,
       },
     ]);
-    expect(aggregated.chatUsersData).toEqual([
+    expect(aggregated.overview.chatUsersData).toEqual([
       {
         date: '2024-01-15',
         askModeUsers: 0,
@@ -116,7 +116,7 @@ describe('metrics aggregation modularization boundary', () => {
         cliUsers: 1,
       },
     ]);
-    expect(aggregated.chatRequestsData).toEqual([
+    expect(aggregated.overview.chatRequestsData).toEqual([
       {
         date: '2024-01-15',
         askModeRequests: 0,
@@ -136,7 +136,7 @@ describe('metrics aggregation modularization boundary', () => {
         cliSessions: 2,
       },
     ]);
-    expect(aggregated.featureAdoptionData).toEqual({
+    expect(aggregated.adoption.featureAdoptionData).toEqual({
       totalUsers: 2,
       completionUsers: 1,
       completionOnlyUsers: 0,
@@ -150,10 +150,10 @@ describe('metrics aggregation modularization boundary', () => {
       codeReviewUsers: 2,
       advancedUsers: 1,
     });
-    expect(aggregated.dailyCloudAgentAdoptionData).toEqual([
+    expect(aggregated.adoption.dailyCloudAgentAdoptionData).toEqual([
       { date: '2024-01-16', uniqueUsers: 1 },
     ]);
-    expect(aggregated.dailyCodeReviewAdoptionData).toEqual([
+    expect(aggregated.adoption.dailyCodeReviewAdoptionData).toEqual([
       {
         date: '2024-01-15',
         activeUsers: 1,
@@ -167,7 +167,7 @@ describe('metrics aggregation modularization boundary', () => {
         totalUsers: 1,
       },
     ]);
-    expect(aggregated.agentModeHeatmapData).toEqual([
+    expect(aggregated.adoption.agentModeHeatmapData).toEqual([
       {
         date: '2024-01-16',
         agentModeRequests: 4,
@@ -176,7 +176,7 @@ describe('metrics aggregation modularization boundary', () => {
       },
     ]);
 
-    expect(aggregated.agentImpactData).toEqual([
+    expect(aggregated.impact.agentImpactData).toEqual([
       {
         date: '2024-01-15',
         locAdded: 0,
@@ -194,17 +194,17 @@ describe('metrics aggregation modularization boundary', () => {
         totalUniqueUsers: 2,
       },
     ]);
-    expect(aggregated.codeCompletionImpactData.map(day => day.netChange)).toEqual([
+    expect(aggregated.impact.codeCompletionImpactData.map(day => day.netChange)).toEqual([
       3,
       15,
     ]);
-    expect(aggregated.editModeImpactData.map(day => day.netChange)).toEqual([0, 0]);
-    expect(aggregated.inlineModeImpactData.map(day => day.netChange)).toEqual([3, 0]);
-    expect(aggregated.askModeImpactData.map(day => day.netChange)).toEqual([0, 8]);
-    expect(aggregated.cliImpactData.map(day => day.netChange)).toEqual([0, 5]);
-    expect(aggregated.joinedImpactData.map(day => day.netChange)).toEqual([6, 35]);
+    expect(aggregated.impact.editModeImpactData.map(day => day.netChange)).toEqual([0, 0]);
+    expect(aggregated.impact.inlineModeImpactData.map(day => day.netChange)).toEqual([3, 0]);
+    expect(aggregated.impact.askModeImpactData.map(day => day.netChange)).toEqual([0, 8]);
+    expect(aggregated.impact.cliImpactData.map(day => day.netChange)).toEqual([0, 5]);
+    expect(aggregated.impact.joinedImpactData.map(day => day.netChange)).toEqual([6, 35]);
 
-    expect(aggregated.aiAdoptionPhaseData.map(data => ({
+    expect(aggregated.ai.aiAdoptionPhaseData.map(data => ({
       phase: data.phase.phase_number,
       users: data.userCount,
       credits: data.avgAiCreditsUsed,
@@ -212,19 +212,19 @@ describe('metrics aggregation modularization boundary', () => {
       { phase: 2, users: 1, credits: 12 },
       { phase: -1, users: 1, credits: 0 },
     ]);
-    expect(aggregated.usageDistributionData.map(bucket => bucket.id)).toEqual([
+    expect(aggregated.ai.usageDistributionData.map(bucket => bucket.id)).toEqual([
       'power',
       'heavy',
       'typical',
       'light',
     ]);
-    expect(aggregated.usageDistributionData.map(bucket => bucket.userCount)).toEqual([
+    expect(aggregated.ai.usageDistributionData.map(bucket => bucket.userCount)).toEqual([
       0,
       0,
       2,
       0,
     ]);
-    expect(aggregated.dailyAiCreditsData).toEqual([
+    expect(aggregated.ai.dailyAiCreditsData).toEqual([
       { date: '2024-01-15', aiCreditsUsed: 5, users: 1 },
       { date: '2024-01-16', aiCreditsUsed: 7, users: 1 },
     ]);

--- a/src/domain/__tests__/metricsAggregator.orchestration.test.ts
+++ b/src/domain/__tests__/metricsAggregator.orchestration.test.ts
@@ -1,5 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  AGGREGATED_METRICS_SLICE_KEYS,
+  FORMER_FLAT_AGGREGATE_KEYS,
+  projectFormerFlatAggregate,
+} from '../../__tests__/factories/aggregatedMetrics';
 import { makeMetric } from '../../__tests__/factories/metrics';
+import type { AggregatedMetrics } from '../../types/aggregatedMetrics';
 import type { CopilotMetrics } from '../../types/metrics';
 
 const { resolveCopilotCloudAgentUsage } = vi.hoisted(() => ({
@@ -20,43 +26,22 @@ vi.mock('../copilotCloudAgentUsage', () => ({
   resolveCopilotCloudAgentUsage,
 }));
 
-import { aggregateMetrics } from '../metricsAggregator';
+import {
+  aggregateMetrics,
+  assembleAggregatedMetrics,
+} from '../metricsAggregator';
 
-const aggregateKeys = [
-  'stats',
-  'userSummaries',
-  'engagementData',
-  'chatUsersData',
-  'chatRequestsData',
-  'languageStats',
-  'modelUsageData',
-  'featureAdoptionData',
-  'agentModeHeatmapData',
-  'agentImpactData',
-  'codeCompletionImpactData',
-  'editModeImpactData',
-  'inlineModeImpactData',
-  'askModeImpactData',
-  'cliImpactData',
-  'joinedImpactData',
-  'ideStats',
-  'multiIDEUsersCount',
-  'totalUniqueIDEUsers',
-  'pluginVersionData',
-  'languageFeatureImpactData',
-  'dailyLanguageGenerationsData',
-  'dailyLanguageLocData',
-  'modelBreakdownData',
-  'dailyCliSessionData',
-  'dailyCliTokenData',
-  'dailyCliAdoptionTrend',
-  'dailyAdoptionTrend',
-  'dailyCloudAgentAdoptionData',
-  'dailyCodeReviewAdoptionData',
-  'aiAdoptionPhaseData',
-  'usageDistributionData',
-  'dailyAiCreditsData',
-];
+const aggregateSliceKeys = [
+  'overview',
+  'users',
+  'adoption',
+  'impact',
+  'languages',
+  'clients',
+  'models',
+  'cli',
+  'ai',
+] as const satisfies readonly (keyof AggregatedMetrics)[];
 
 const ideTotal = (ide: string, interactions: number) => ({
   ide,
@@ -77,9 +62,9 @@ describe('metrics aggregation orchestration characterization', () => {
   it('preserves empty and first-record report metadata for stats and user details', () => {
     const empty = aggregateMetrics([]);
 
-    expect(empty.aggregated.stats.reportStartDay).toBe('');
-    expect(empty.aggregated.stats.reportEndDay).toBe('');
-    expect(empty.aggregated.userSummaries).toEqual([]);
+    expect(empty.aggregated.overview.stats.reportStartDay).toBe('');
+    expect(empty.aggregated.overview.stats.reportEndDay).toBe('');
+    expect(empty.aggregated.users.userSummaries).toEqual([]);
     expect(empty.userDetailAccumulator.reportStartDay).toBe('');
     expect(empty.userDetailAccumulator.reportEndDay).toBe('');
 
@@ -93,8 +78,8 @@ describe('metrics aggregation orchestration characterization', () => {
     });
     const populated = aggregateMetrics([first, second]);
 
-    expect(populated.aggregated.stats.reportStartDay).toBe('2024-02-01');
-    expect(populated.aggregated.stats.reportEndDay).toBe('2024-02-29');
+    expect(populated.aggregated.overview.stats.reportStartDay).toBe('2024-02-01');
+    expect(populated.aggregated.overview.stats.reportEndDay).toBe('2024-02-29');
     expect(populated.userDetailAccumulator.reportStartDay).toBe('2024-02-01');
     expect(populated.userDetailAccumulator.reportEndDay).toBe('2024-02-29');
   });
@@ -111,11 +96,11 @@ describe('metrics aggregation orchestration characterization', () => {
 
     expect(resolveCopilotCloudAgentUsage).toHaveBeenCalledOnce();
     expect(resolveCopilotCloudAgentUsage).toHaveBeenCalledWith(metric);
-    expect(aggregated.stats.codingAgentUsers).toBe(1);
-    expect(aggregated.userSummaries[0].used_copilot_coding_agent).toBe(true);
-    expect(aggregated.userSummaries[0].cloud_agent_days).toBe(1);
-    expect(aggregated.featureAdoptionData.codingAgentUsers).toBe(1);
-    expect(aggregated.dailyCloudAgentAdoptionData).toEqual([
+    expect(aggregated.overview.stats.codingAgentUsers).toBe(1);
+    expect(aggregated.users.userSummaries[0].used_copilot_coding_agent).toBe(true);
+    expect(aggregated.users.userSummaries[0].cloud_agent_days).toBe(1);
+    expect(aggregated.adoption.featureAdoptionData.codingAgentUsers).toBe(1);
+    expect(aggregated.adoption.dailyCloudAgentAdoptionData).toEqual([
       { date: '2024-01-17', uniqueUsers: 1 },
     ]);
   });
@@ -192,8 +177,8 @@ describe('metrics aggregation orchestration characterization', () => {
       secondUser,
     ]);
 
-    expect(aggregated.userSummaries.map(user => user.user_id)).toEqual([2, 1]);
-    expect(aggregated.userSummaries[1]).toEqual({
+    expect(aggregated.users.userSummaries.map(user => user.user_id)).toEqual([2, 1]);
+    expect(aggregated.users.userSummaries[1]).toEqual({
       user_login: 'alice',
       user_id: 1,
       total_user_initiated_interactions: 10,
@@ -218,7 +203,7 @@ describe('metrics aggregation orchestration characterization', () => {
       used_auto_mode: true,
       ai_adoption_phase: phase,
     });
-    expect(aggregated.userSummaries[1].ai_adoption_phase).not.toBe(phase);
+    expect(aggregated.users.userSummaries[1].ai_adoption_phase).not.toBe(phase);
   });
 
   it('preserves client positive guards, CLI fallback, and lexical tie-breaking', () => {
@@ -234,18 +219,163 @@ describe('metrics aggregation orchestration characterization', () => {
 
     const { aggregated } = aggregateMetrics([metric]);
 
-    expect(aggregated.userSummaries[0].top_client).toBe('alpha');
+    expect(aggregated.users.userSummaries[0].top_client).toBe('alpha');
   });
 
-  it('keeps the flat aggregate key order, does not mutate input, and owns one raw-record pass', () => {
+  it('assembles finalized family results without copying their values', () => {
+    const defaults = aggregateMetrics([]).aggregated;
+    const coreStatsAggregation = {
+      stats: { ...defaults.overview.stats, totalRecords: 11 },
+    };
+    const userSummaryAggregation = {
+      userSummaries: [...defaults.users.userSummaries],
+    };
+    const engagementAdoptionAggregation = {
+      engagementData: [...defaults.overview.engagementData],
+      chatUsersData: [...defaults.overview.chatUsersData],
+      chatRequestsData: [...defaults.overview.chatRequestsData],
+      featureAdoptionData: { ...defaults.adoption.featureAdoptionData },
+      dailyAdoptionTrend: [...defaults.adoption.dailyAdoptionTrend],
+      dailyCloudAgentAdoptionData: [
+        ...defaults.adoption.dailyCloudAgentAdoptionData,
+      ],
+      dailyCodeReviewAdoptionData: [
+        ...defaults.adoption.dailyCodeReviewAdoptionData,
+      ],
+    };
+    const impactAggregation = {
+      agentImpactData: [...defaults.impact.agentImpactData],
+      codeCompletionImpactData: [
+        ...defaults.impact.codeCompletionImpactData,
+      ],
+      editModeImpactData: [...defaults.impact.editModeImpactData],
+      inlineModeImpactData: [...defaults.impact.inlineModeImpactData],
+      askModeImpactData: [...defaults.impact.askModeImpactData],
+      cliImpactData: [...defaults.impact.cliImpactData],
+      joinedImpactData: [...defaults.impact.joinedImpactData],
+    };
+    const languageAggregation = {
+      languageStats: [...defaults.languages.languageStats],
+      languageFeatureImpactData: {
+        ...defaults.languages.languageFeatureImpactData,
+      },
+      dailyLanguageGenerationsData: {
+        ...defaults.languages.dailyLanguageGenerationsData,
+      },
+      dailyLanguageLocData: {
+        ...defaults.languages.dailyLanguageLocData,
+      },
+    };
+    const clientAggregation = {
+      ideStats: [...defaults.clients.ideStats],
+      multiIDEUsersCount: 12,
+      totalUniqueIDEUsers: 13,
+      pluginVersionData: { ...defaults.clients.pluginVersionData },
+    };
+    const modelAggregation = {
+      modelUsageData: [...defaults.models.modelUsageData],
+      agentModeHeatmapData: [...defaults.adoption.agentModeHeatmapData],
+      modelBreakdownData: { ...defaults.models.modelBreakdownData },
+    };
+    const cliAggregation = {
+      dailyCliSessionData: [...defaults.cli.dailyCliSessionData],
+      dailyCliTokenData: [...defaults.cli.dailyCliTokenData],
+      dailyCliAdoptionTrend: [...defaults.cli.dailyCliAdoptionTrend],
+    };
+    const aiAggregation = {
+      aiAdoptionPhaseData: [...defaults.ai.aiAdoptionPhaseData],
+      usageDistributionData: [...defaults.ai.usageDistributionData],
+      dailyAiCreditsData: [...defaults.ai.dailyAiCreditsData],
+    };
+    const aggregated = assembleAggregatedMetrics({
+      coreStatsAggregation,
+      userSummaryAggregation,
+      engagementAdoptionAggregation,
+      impactAggregation,
+      languageAggregation,
+      clientAggregation,
+      modelAggregation,
+      cliAggregation,
+      aiAggregation,
+    });
+    const expectedFormerFlat = {
+      ...coreStatsAggregation,
+      ...userSummaryAggregation,
+      ...engagementAdoptionAggregation,
+      ...impactAggregation,
+      ...languageAggregation,
+      ...clientAggregation,
+      ...modelAggregation,
+      ...cliAggregation,
+      ...aiAggregation,
+    };
+    const actualFormerFlat = projectFormerFlatAggregate(aggregated);
+
+    for (const key of FORMER_FLAT_AGGREGATE_KEYS) {
+      expect(actualFormerFlat[key]).toBe(expectedFormerFlat[key]);
+    }
+  });
+
+  it('owns every former field once and measures grouped serialization', () => {
     const source = [
       makeMetric({
         user_id: 1,
+        used_agent: true,
+        used_chat: true,
+        used_copilot_cloud_agent: true,
+        used_copilot_code_review_active: true,
+        ai_credits_used: 2.5,
         totals_by_ide: [ideTotal('vscode', 2)],
+        totals_by_feature: [{
+          feature: 'chat_panel_agent_mode',
+          user_initiated_interaction_count: 3,
+          code_generation_activity_count: 1,
+          code_acceptance_activity_count: 1,
+          loc_added_sum: 5,
+          loc_deleted_sum: 1,
+          loc_suggested_to_add_sum: 7,
+          loc_suggested_to_delete_sum: 2,
+        }],
+        totals_by_language_feature: [{
+          language: 'typescript',
+          feature: 'code_completion',
+          code_generation_activity_count: 4,
+          code_acceptance_activity_count: 2,
+          loc_added_sum: 6,
+          loc_deleted_sum: 1,
+          loc_suggested_to_add_sum: 8,
+          loc_suggested_to_delete_sum: 2,
+        }],
+        totals_by_model_feature: [{
+          model: 'gpt-5',
+          feature: 'chat_panel_agent_mode',
+          user_initiated_interaction_count: 3,
+          code_generation_activity_count: 1,
+          code_acceptance_activity_count: 1,
+          loc_added_sum: 5,
+          loc_deleted_sum: 1,
+          loc_suggested_to_add_sum: 7,
+          loc_suggested_to_delete_sum: 2,
+        }],
+        ai_adoption_phase: {
+          phase_number: 2,
+          phase: 'Accelerating',
+          version: 'v2',
+        },
       }),
       makeMetric({
         user_id: 2,
         used_cli: true,
+        totals_by_cli: {
+          session_count: 2,
+          request_count: 3,
+          prompt_count: 1,
+          token_usage: {
+            output_tokens_sum: 11,
+            prompt_tokens_sum: 7,
+            avg_tokens_per_request: 6,
+          },
+        },
       }),
     ];
     const original = structuredClone(source);
@@ -260,8 +390,58 @@ describe('metrics aggregation orchestration characterization', () => {
     });
 
     const { aggregated } = aggregateMetrics(metrics);
+    const flat = projectFormerFlatAggregate(aggregated);
+    const groupedBytes = new TextEncoder().encode(
+      JSON.stringify(aggregated)
+    ).byteLength;
+    const flatBytes = new TextEncoder().encode(JSON.stringify(flat)).byteLength;
+    const deltaBytes = groupedBytes - flatBytes;
+    const percentageDelta = (deltaBytes / flatBytes) * 100;
 
-    expect(Object.keys(aggregated)).toEqual(aggregateKeys);
+    expect(Object.keys(aggregated)).toEqual(aggregateSliceKeys);
+    expect(Object.keys(aggregated.overview)).toEqual(
+      AGGREGATED_METRICS_SLICE_KEYS.overview
+    );
+    expect(Object.keys(aggregated.users)).toEqual(
+      AGGREGATED_METRICS_SLICE_KEYS.users
+    );
+    expect(Object.keys(aggregated.adoption)).toEqual(
+      AGGREGATED_METRICS_SLICE_KEYS.adoption
+    );
+    expect(Object.keys(aggregated.impact)).toEqual(
+      AGGREGATED_METRICS_SLICE_KEYS.impact
+    );
+    expect(Object.keys(aggregated.languages)).toEqual(
+      AGGREGATED_METRICS_SLICE_KEYS.languages
+    );
+    expect(Object.keys(aggregated.clients)).toEqual(
+      AGGREGATED_METRICS_SLICE_KEYS.clients
+    );
+    expect(Object.keys(aggregated.models)).toEqual(
+      AGGREGATED_METRICS_SLICE_KEYS.models
+    );
+    expect(Object.keys(aggregated.cli)).toEqual(
+      AGGREGATED_METRICS_SLICE_KEYS.cli
+    );
+    expect(Object.keys(aggregated.ai)).toEqual(
+      AGGREGATED_METRICS_SLICE_KEYS.ai
+    );
+    expect(Object.keys(flat)).toEqual(FORMER_FLAT_AGGREGATE_KEYS);
+    expect(new Set(FORMER_FLAT_AGGREGATE_KEYS).size).toBe(
+      FORMER_FLAT_AGGREGATE_KEYS.length
+    );
+    for (const key of FORMER_FLAT_AGGREGATE_KEYS) {
+      expect(aggregated).not.toHaveProperty(key);
+    }
+    expect(aggregated).not.toHaveProperty('metrics');
+    expect(groupedBytes).toBeGreaterThan(0);
+    expect(flatBytes).toBeGreaterThan(0);
+    expect(groupedBytes).toBe(flatBytes + deltaBytes);
+    expect(Number.isFinite(percentageDelta)).toBe(true);
+    console.info(
+      `[aggregate-payload-size] grouped=${groupedBytes} flat=${flatBytes} `
+      + `delta=${deltaBytes} percentage=${percentageDelta.toFixed(2)}%`
+    );
     expect(iteratorRequests).toBe(1);
     expect(source).toEqual(original);
   });

--- a/src/domain/__tests__/metricsAggregator.test.ts
+++ b/src/domain/__tests__/metricsAggregator.test.ts
@@ -24,10 +24,10 @@ describe('metricsAggregator', () => {
       const { aggregated } = aggregateMetrics([]);
 
       expect(aggregated).toBeDefined();
-      expect(aggregated.stats.uniqueUsers).toBe(0);
-      expect(aggregated.stats.totalRecords).toBe(0);
-      expect(aggregated.userSummaries).toHaveLength(0);
-      expect(aggregated.engagementData).toHaveLength(0);
+      expect(aggregated.overview.stats.uniqueUsers).toBe(0);
+      expect(aggregated.overview.stats.totalRecords).toBe(0);
+      expect(aggregated.users.userSummaries).toHaveLength(0);
+      expect(aggregated.overview.engagementData).toHaveLength(0);
     });
 
     it('should count distinct cloud-agent and code-review days and net LOC per user', () => {
@@ -55,7 +55,7 @@ describe('metricsAggregator', () => {
       });
 
       const { aggregated } = aggregateMetrics([day1, day2, day3]);
-      const summary = aggregated.userSummaries[0];
+      const summary = aggregated.users.userSummaries[0];
 
       expect(summary.cloud_agent_days).toBe(2);
       expect(summary.code_review_days).toBe(2);
@@ -76,8 +76,8 @@ describe('metricsAggregator', () => {
       const { aggregated } = aggregateMetrics([metric1, metric2]);
 
       // Should use dates from first record
-      expect(aggregated.stats.reportStartDay).toBe('2024-01-01');
-      expect(aggregated.stats.reportEndDay).toBe('2024-01-31');
+      expect(aggregated.overview.stats.reportStartDay).toBe('2024-01-01');
+      expect(aggregated.overview.stats.reportEndDay).toBe('2024-01-31');
     });
 
     it('should aggregate multiple records for same user across days', () => {
@@ -101,10 +101,10 @@ describe('metricsAggregator', () => {
 
       const { aggregated } = aggregateMetrics([day1, day2]);
 
-      expect(aggregated.stats.uniqueUsers).toBe(1);
-      expect(aggregated.userSummaries).toHaveLength(1);
+      expect(aggregated.overview.stats.uniqueUsers).toBe(1);
+      expect(aggregated.users.userSummaries).toHaveLength(1);
 
-      const userSummary = aggregated.userSummaries[0];
+      const userSummary = aggregated.users.userSummaries[0];
       expect(userSummary.user_id).toBe(123);
       expect(userSummary.total_loc_added).toBe(150); // 100 + 50
       expect(userSummary.total_loc_deleted).toBe(30); // 20 + 10
@@ -163,7 +163,7 @@ describe('metricsAggregator', () => {
       });
 
       const { aggregated, userDetailAccumulator } = aggregateMetrics([userOneDayOne, userTwo, userOneDayTwo]);
-      const summary = aggregated.userSummaries.find(user => user.user_id === 123);
+      const summary = aggregated.users.userSummaries.find(user => user.user_id === 123);
       const details = computeSingleUserDetailedMetrics(userDetailAccumulator, 123);
 
       expect(summary?.total_user_initiated_interactions).toBe(15);
@@ -172,8 +172,8 @@ describe('metricsAggregator', () => {
       expect(details?.totalModelRequests).toBe(10);
       expect(details?.total_ai_credits_used).toBe(summary?.total_ai_credits_used);
       expect(details?.days.map(day => day.day)).toEqual(['2024-01-15', '2024-01-16']);
-      expect(details?.reportStartDay).toBe(aggregated.stats.reportStartDay);
-      expect(details?.reportEndDay).toBe(aggregated.stats.reportEndDay);
+      expect(details?.reportStartDay).toBe(aggregated.overview.stats.reportStartDay);
+      expect(details?.reportEndDay).toBe(aggregated.overview.stats.reportEndDay);
       expect(computeSingleUserDetailedMetrics(userDetailAccumulator, 999)).toBeNull();
     });
 
@@ -206,8 +206,8 @@ describe('metricsAggregator', () => {
 
       const { aggregated } = aggregateMetrics([day1, day2, inactiveClientDay]);
 
-      expect(aggregated.userSummaries.find(user => user.user_id === 123)?.top_client).toBe('vscode');
-      expect(aggregated.userSummaries.find(user => user.user_id === 456)?.top_client).toBeNull();
+      expect(aggregated.users.userSummaries.find(user => user.user_id === 123)?.top_client).toBe('vscode');
+      expect(aggregated.users.userSummaries.find(user => user.user_id === 456)?.top_client).toBeNull();
     });
 
     it('should include CLI activity when selecting the top user client', () => {
@@ -253,8 +253,8 @@ describe('metricsAggregator', () => {
 
       const { aggregated } = aggregateMetrics([cliOnly, cliTop]);
 
-      expect(aggregated.userSummaries.find(user => user.user_id === 123)?.top_client).toBe('copilot_cli');
-      expect(aggregated.userSummaries.find(user => user.user_id === 456)?.top_client).toBe('copilot_cli');
+      expect(aggregated.users.userSummaries.find(user => user.user_id === 123)?.top_client).toBe('copilot_cli');
+      expect(aggregated.users.userSummaries.find(user => user.user_id === 456)?.top_client).toBe('copilot_cli');
     });
 
     it('should aggregate AI credits per user across days', () => {
@@ -271,7 +271,7 @@ describe('metricsAggregator', () => {
 
       const { aggregated } = aggregateMetrics([day1, day2]);
 
-      expect(aggregated.userSummaries[0].total_ai_credits_used).toBeCloseTo(60);
+      expect(aggregated.users.userSummaries[0].total_ai_credits_used).toBeCloseTo(60);
     });
 
     it('should aggregate AI credits by day across users', () => {
@@ -293,11 +293,11 @@ describe('metricsAggregator', () => {
 
       const { aggregated } = aggregateMetrics([day2User1, day1User1, day1User2]);
 
-      expect(aggregated.dailyAiCreditsData).toHaveLength(2);
-      expect(aggregated.dailyAiCreditsData[0].date).toBe('2024-01-15');
-      expect(aggregated.dailyAiCreditsData[0].aiCreditsUsed).toBeCloseTo(60);
-      expect(aggregated.dailyAiCreditsData[0].users).toBe(2);
-      expect(aggregated.dailyAiCreditsData[1]).toEqual({ date: '2024-01-16', aiCreditsUsed: 10, users: 1 });
+      expect(aggregated.ai.dailyAiCreditsData).toHaveLength(2);
+      expect(aggregated.ai.dailyAiCreditsData[0].date).toBe('2024-01-15');
+      expect(aggregated.ai.dailyAiCreditsData[0].aiCreditsUsed).toBeCloseTo(60);
+      expect(aggregated.ai.dailyAiCreditsData[0].users).toBe(2);
+      expect(aggregated.ai.dailyAiCreditsData[1]).toEqual({ date: '2024-01-16', aiCreditsUsed: 10, users: 1 });
     });
 
     it('should track user feature flags correctly', () => {
@@ -344,12 +344,12 @@ describe('metricsAggregator', () => {
 
       const { aggregated } = aggregateMetrics([agentUser, chatUser, cliUser, autoUser]);
 
-      expect(aggregated.stats.uniqueUsers).toBe(4);
-      expect(aggregated.stats.agentUsers).toBe(1);
-      expect(aggregated.stats.chatUsers).toBe(2);
-      expect(aggregated.stats.cliUsers).toBe(1);
+      expect(aggregated.overview.stats.uniqueUsers).toBe(4);
+      expect(aggregated.overview.stats.agentUsers).toBe(1);
+      expect(aggregated.overview.stats.chatUsers).toBe(2);
+      expect(aggregated.overview.stats.cliUsers).toBe(1);
 
-      const summaries = aggregated.userSummaries;
+      const summaries = aggregated.users.userSummaries;
       expect(summaries.find(u => u.user_id === 1)?.used_agent).toBe(true);
       expect(summaries.find(u => u.user_id === 2)?.used_chat).toBe(true);
       expect(summaries.find(u => u.user_id === 3)?.used_cli).toBe(true);
@@ -378,7 +378,7 @@ describe('metricsAggregator', () => {
 
       const { aggregated } = aggregateMetrics([earlierPhase, laterPhase]);
 
-      expect(aggregated.userSummaries[0].ai_adoption_phase).toEqual({
+      expect(aggregated.users.userSummaries[0].ai_adoption_phase).toEqual({
         phase_number: 2,
         phase: 'Phase 2',
         version: 'v1',
@@ -469,9 +469,9 @@ describe('metricsAggregator', () => {
 
       const { aggregated } = aggregateMetrics([user1Day1, user1Day2, user2, user3]);
 
-      expect(aggregated.aiAdoptionPhaseData).toHaveLength(2);
+      expect(aggregated.ai.aiAdoptionPhaseData).toHaveLength(2);
 
-      const phase1 = aggregated.aiAdoptionPhaseData.find(phase => phase.phase.phase_number === 1)!;
+      const phase1 = aggregated.ai.aiAdoptionPhaseData.find(phase => phase.phase.phase_number === 1)!;
       expect(phase1.userCount).toBe(2);
       expect(phase1.avgUserInitiatedInteractions).toBe(20);
       expect(phase1.totalLocAdded).toBe(200);
@@ -492,7 +492,7 @@ describe('metricsAggregator', () => {
         { name: 'python', total: 10, uniqueUsers: 1 },
       ]);
 
-      const phase2 = aggregated.aiAdoptionPhaseData.find(phase => phase.phase.phase_number === 2)!;
+      const phase2 = aggregated.ai.aiAdoptionPhaseData.find(phase => phase.phase.phase_number === 2)!;
       expect(phase2.userCount).toBe(1);
       expect(phase2.avgUserInitiatedInteractions).toBe(5);
       expect(phase2.avgAiCreditsUsed).toBe(5);
@@ -520,7 +520,7 @@ describe('metricsAggregator', () => {
 
       const { aggregated } = aggregateMetrics([metric]);
 
-      expect(aggregated.aiAdoptionPhaseData[0].topClients).toEqual([]);
+      expect(aggregated.ai.aiAdoptionPhaseData[0].topClients).toEqual([]);
     });
 
     it('should accumulate user flags across multiple days (OR logic)', () => {
@@ -543,7 +543,7 @@ describe('metricsAggregator', () => {
 
       const { aggregated } = aggregateMetrics([day1, day2]);
 
-      const userSummary = aggregated.userSummaries[0];
+      const userSummary = aggregated.users.userSummaries[0];
       expect(userSummary.used_chat).toBe(true);
       expect(userSummary.used_agent).toBe(true);
       expect(userSummary.used_cli).toBe(false);
@@ -567,10 +567,10 @@ describe('metricsAggregator', () => {
 
       const { aggregated } = aggregateMetrics([user1Day1, user2Day1, user1Day2]);
 
-      expect(aggregated.engagementData).toHaveLength(2);
+      expect(aggregated.overview.engagementData).toHaveLength(2);
 
-      const day1Data = aggregated.engagementData.find(d => d.date === '2024-01-15');
-      const day2Data = aggregated.engagementData.find(d => d.date === '2024-01-16');
+      const day1Data = aggregated.overview.engagementData.find(d => d.date === '2024-01-15');
+      const day2Data = aggregated.overview.engagementData.find(d => d.date === '2024-01-16');
 
       expect(day1Data?.activeUsers).toBe(2);
       expect(day2Data?.activeUsers).toBe(1);
@@ -594,8 +594,8 @@ describe('metricsAggregator', () => {
 
       const { aggregated } = aggregateMetrics([metric]);
 
-      expect(aggregated.ideStats).toBeDefined();
-      expect(aggregated.ideStats.length).toBeGreaterThan(0);
+      expect(aggregated.clients.ideStats).toBeDefined();
+      expect(aggregated.clients.ideStats.length).toBeGreaterThan(0);
     });
 
     it('should process language stats when provided', () => {
@@ -616,8 +616,8 @@ describe('metricsAggregator', () => {
 
       const { aggregated } = aggregateMetrics([metric]);
 
-      expect(aggregated.languageStats).toBeDefined();
-      expect(aggregated.languageStats.length).toBeGreaterThan(0);
+      expect(aggregated.languages.languageStats).toBeDefined();
+      expect(aggregated.languages.languageStats.length).toBeGreaterThan(0);
     });
 
     it('should process model usage data when provided', () => {
@@ -639,10 +639,10 @@ describe('metricsAggregator', () => {
 
       const { aggregated } = aggregateMetrics([metric]);
 
-      expect(aggregated.modelUsageData).toBeDefined();
-      expect(aggregated.modelUsageData.length).toBeGreaterThan(0);
-      expect(aggregated.modelUsageData[0].modelInteractions).toBe(15);
-      expect(aggregated.modelUsageData[0].unknownModels).toBe(0);
+      expect(aggregated.models.modelUsageData).toBeDefined();
+      expect(aggregated.models.modelUsageData.length).toBeGreaterThan(0);
+      expect(aggregated.models.modelUsageData[0].modelInteractions).toBe(15);
+      expect(aggregated.models.modelUsageData[0].unknownModels).toBe(0);
     });
 
     it('should include assumed code completion interactions in aggregate model usage', () => {
@@ -665,22 +665,22 @@ describe('metricsAggregator', () => {
       const { aggregated, userDetailAccumulator } = aggregateMetrics([metric]);
       const userDetails = computeSingleUserDetailedMetrics(userDetailAccumulator, metric.user_id);
 
-      expect(aggregated.modelUsageData).toEqual([
+      expect(aggregated.models.modelUsageData).toEqual([
         {
           date: '2024-01-15',
           modelInteractions: 44,
           unknownModels: 0,
         },
       ]);
-      expect(aggregated.modelBreakdownData.modelTotal).toBe(44);
-      expect(aggregated.modelBreakdownData.allModels).toEqual([
+      expect(aggregated.models.modelBreakdownData.modelTotal).toBe(44);
+      expect(aggregated.models.modelBreakdownData.allModels).toEqual([
         {
           model: 'gpt-4o',
           total: 44,
           dailyData: { '2024-01-15': 44 },
         },
       ]);
-      expect(userDetails?.dailyModelUsage).toEqual(aggregated.modelUsageData);
+      expect(userDetails?.dailyModelUsage).toEqual(aggregated.models.modelUsageData);
       expect(userDetails?.totalModelRequests).toBe(44);
     });
 
@@ -724,7 +724,7 @@ describe('metricsAggregator', () => {
       });
 
       const { aggregated } = aggregateMetrics([metric]);
-      const { modelBreakdownData } = aggregated;
+      const { modelBreakdownData } = aggregated.models;
 
       expect(modelBreakdownData.modelTotal).toBe(20);
       expect(modelBreakdownData.unknownTotal).toBe(3);
@@ -762,7 +762,7 @@ describe('metricsAggregator', () => {
 
       const { aggregated } = aggregateMetrics([day1User1, day1User2, day2User1]);
 
-      expect(aggregated.modelBreakdownData.autoModeAdoptionTrend).toEqual([
+      expect(aggregated.models.modelBreakdownData.autoModeAdoptionTrend).toEqual([
         {
           date: '2024-01-15',
           newUsers: 2,
@@ -778,8 +778,8 @@ describe('metricsAggregator', () => {
           cumulativeUsers: 2,
         },
       ]);
-      expect(aggregated.modelBreakdownData.allModels.some(entry => entry.model === 'auto')).toBe(false);
-      expect(aggregated.modelBreakdownData.modelTotal).toBe(0);
+      expect(aggregated.models.modelBreakdownData.allModels.some(entry => entry.model === 'auto')).toBe(false);
+      expect(aggregated.models.modelBreakdownData.modelTotal).toBe(0);
     });
 
     it('should count Auto model activity even when user initiated interactions are zero', () => {
@@ -803,14 +803,14 @@ describe('metricsAggregator', () => {
 
       const { aggregated } = aggregateMetrics([metric]);
 
-      expect(aggregated.modelBreakdownData.autoModels).toEqual([
+      expect(aggregated.models.modelBreakdownData.autoModels).toEqual([
         {
           model: 'auto',
           total: 1,
           dailyData: { '2024-01-15': 1 },
         },
       ]);
-      expect(aggregated.modelBreakdownData.autoModeAdoptionTrend).toEqual([
+      expect(aggregated.models.modelBreakdownData.autoModeAdoptionTrend).toEqual([
         {
           date: '2024-01-15',
           newUsers: 1,
@@ -819,7 +819,7 @@ describe('metricsAggregator', () => {
           cumulativeUsers: 1,
         },
       ]);
-      expect(aggregated.userSummaries[0].used_auto_mode).toBe(true);
+      expect(aggregated.users.userSummaries[0].used_auto_mode).toBe(true);
     });
 
     it('should process feature adoption data when provided', () => {
@@ -840,8 +840,8 @@ describe('metricsAggregator', () => {
 
       const { aggregated } = aggregateMetrics([metric]);
 
-      expect(aggregated.featureAdoptionData).toBeDefined();
-      expect(aggregated.featureAdoptionData.totalUsers).toBeGreaterThan(0);
+      expect(aggregated.adoption.featureAdoptionData).toBeDefined();
+      expect(aggregated.adoption.featureAdoptionData.totalUsers).toBeGreaterThan(0);
     });
 
     it('should aggregate daily CLI model usage from model feature totals', () => {
@@ -915,8 +915,8 @@ describe('metricsAggregator', () => {
 
       const { aggregated } = aggregateMetrics([day1, day2]);
 
-      expect(aggregated.modelBreakdownData.cliTotal).toBe(23);
-      expect(aggregated.modelBreakdownData.cliModels).toEqual([
+      expect(aggregated.models.modelBreakdownData.cliTotal).toBe(23);
+      expect(aggregated.models.modelBreakdownData.cliModels).toEqual([
         {
           model: 'gpt-5.4',
           total: 18,
@@ -943,9 +943,9 @@ describe('metricsAggregator', () => {
 
       const { aggregated } = aggregateMetrics([metric]);
 
-      expect(aggregated.featureAdoptionData.totalUsers).toBe(1);
-      expect(aggregated.featureAdoptionData.cliUsers).toBe(1);
-      expect(aggregated.featureAdoptionData.advancedUsers).toBe(1);
+      expect(aggregated.adoption.featureAdoptionData.totalUsers).toBe(1);
+      expect(aggregated.adoption.featureAdoptionData.cliUsers).toBe(1);
+      expect(aggregated.adoption.featureAdoptionData.advancedUsers).toBe(1);
     });
 
     it('should count coding-agent-only users in feature adoption totals', () => {
@@ -959,10 +959,10 @@ describe('metricsAggregator', () => {
 
       const { aggregated } = aggregateMetrics([metric]);
 
-      expect(aggregated.stats.codingAgentUsers).toBe(1);
-      expect(aggregated.featureAdoptionData.totalUsers).toBe(1);
-      expect(aggregated.featureAdoptionData.codingAgentUsers).toBe(1);
-      expect(aggregated.featureAdoptionData.advancedUsers).toBe(1);
+      expect(aggregated.overview.stats.codingAgentUsers).toBe(1);
+      expect(aggregated.adoption.featureAdoptionData.totalUsers).toBe(1);
+      expect(aggregated.adoption.featureAdoptionData.codingAgentUsers).toBe(1);
+      expect(aggregated.adoption.featureAdoptionData.advancedUsers).toBe(1);
     });
 
     it('should count code-review users from combined active or passive flags', () => {
@@ -989,8 +989,8 @@ describe('metricsAggregator', () => {
 
       const { aggregated } = aggregateMetrics([activeOnly, passiveOnly]);
 
-      expect(aggregated.featureAdoptionData.codeReviewUsers).toBe(2);
-      expect(aggregated.featureAdoptionData.totalUsers).toBe(2);
+      expect(aggregated.adoption.featureAdoptionData.codeReviewUsers).toBe(2);
+      expect(aggregated.adoption.featureAdoptionData.totalUsers).toBe(2);
     });
 
     it('should count cloud-agent-only users from the new cloud-agent flag', () => {
@@ -1005,10 +1005,10 @@ describe('metricsAggregator', () => {
 
       const { aggregated } = aggregateMetrics([metric]);
 
-      expect(aggregated.stats.codingAgentUsers).toBe(1);
-      expect(aggregated.featureAdoptionData.codingAgentUsers).toBe(1);
-      expect(aggregated.featureAdoptionData.advancedUsers).toBe(1);
-      expect(aggregated.userSummaries[0].used_copilot_coding_agent).toBe(true);
+      expect(aggregated.overview.stats.codingAgentUsers).toBe(1);
+      expect(aggregated.adoption.featureAdoptionData.codingAgentUsers).toBe(1);
+      expect(aggregated.adoption.featureAdoptionData.advancedUsers).toBe(1);
+      expect(aggregated.users.userSummaries[0].used_copilot_coding_agent).toBe(true);
     });
 
     it('should aggregate daily Cloud Agent and Code Review adoption users', () => {
@@ -1044,10 +1044,10 @@ describe('metricsAggregator', () => {
         day2CodeReviewUser,
       ]);
 
-      expect(aggregated.dailyCloudAgentAdoptionData).toEqual([
+      expect(aggregated.adoption.dailyCloudAgentAdoptionData).toEqual([
         { date: '2024-01-15', uniqueUsers: 2 },
       ]);
-      expect(aggregated.dailyCodeReviewAdoptionData).toEqual([
+      expect(aggregated.adoption.dailyCodeReviewAdoptionData).toEqual([
         { date: '2024-01-15', activeUsers: 1, passiveUsers: 1, totalUsers: 2 },
         { date: '2024-01-16', activeUsers: 1, passiveUsers: 1, totalUsers: 1 },
       ]);
@@ -1065,10 +1065,10 @@ describe('metricsAggregator', () => {
 
       const { aggregated } = aggregateMetrics([metric]);
 
-      expect(aggregated.stats.codingAgentUsers).toBe(0);
-      expect(aggregated.stats.completionOnlyUsers).toBe(1);
-      expect(aggregated.featureAdoptionData.codingAgentUsers).toBe(0);
-      expect(aggregated.userSummaries[0].used_copilot_coding_agent).toBe(false);
+      expect(aggregated.overview.stats.codingAgentUsers).toBe(0);
+      expect(aggregated.overview.stats.completionOnlyUsers).toBe(1);
+      expect(aggregated.adoption.featureAdoptionData.codingAgentUsers).toBe(0);
+      expect(aggregated.users.userSummaries[0].used_copilot_coding_agent).toBe(false);
     });
 
     it('should exclude CLI users from completion-only counts when only used_cli marks CLI usage', () => {
@@ -1092,8 +1092,8 @@ describe('metricsAggregator', () => {
 
       const { aggregated } = aggregateMetrics([metric]);
 
-      expect(aggregated.featureAdoptionData.cliUsers).toBe(1);
-      expect(aggregated.featureAdoptionData.completionOnlyUsers).toBe(0);
+      expect(aggregated.adoption.featureAdoptionData.cliUsers).toBe(1);
+      expect(aggregated.adoption.featureAdoptionData.completionOnlyUsers).toBe(0);
     });
 
     it('should exclude coding-agent users from completion-only counts', () => {
@@ -1118,10 +1118,10 @@ describe('metricsAggregator', () => {
 
       const { aggregated } = aggregateMetrics([metric]);
 
-      expect(aggregated.stats.codingAgentUsers).toBe(1);
-      expect(aggregated.stats.completionOnlyUsers).toBe(0);
-      expect(aggregated.featureAdoptionData.codingAgentUsers).toBe(1);
-      expect(aggregated.featureAdoptionData.completionOnlyUsers).toBe(0);
+      expect(aggregated.overview.stats.codingAgentUsers).toBe(1);
+      expect(aggregated.overview.stats.completionOnlyUsers).toBe(0);
+      expect(aggregated.adoption.featureAdoptionData.codingAgentUsers).toBe(1);
+      expect(aggregated.adoption.featureAdoptionData.completionOnlyUsers).toBe(0);
     });
 
     it('should accumulate coding-agent usage across multiple days using OR logic', () => {
@@ -1140,9 +1140,9 @@ describe('metricsAggregator', () => {
 
       const { aggregated } = aggregateMetrics([day1, day2]);
 
-      const userSummary = aggregated.userSummaries[0];
+      const userSummary = aggregated.users.userSummaries[0];
       expect(userSummary.used_copilot_coding_agent).toBe(true);
-      expect(aggregated.stats.codingAgentUsers).toBe(1);
+      expect(aggregated.overview.stats.codingAgentUsers).toBe(1);
     });
 
     it('should process impact data when features have LOC', () => {
@@ -1163,9 +1163,9 @@ describe('metricsAggregator', () => {
 
       const { aggregated } = aggregateMetrics([metric]);
 
-      expect(aggregated.codeCompletionImpactData).toBeDefined();
-      expect(aggregated.agentImpactData).toBeDefined();
-      expect(aggregated.editModeImpactData).toBeDefined();
+      expect(aggregated.impact.codeCompletionImpactData).toBeDefined();
+      expect(aggregated.impact.agentImpactData).toBeDefined();
+      expect(aggregated.impact.editModeImpactData).toBeDefined();
     });
 
     it('should compute daily adoption trend with new and returning users across surfaces', () => {
@@ -1199,15 +1199,15 @@ describe('metricsAggregator', () => {
 
       const { aggregated } = aggregateMetrics([user1Day1, user2Day1, user1Day2, user3Day2]);
 
-      expect(aggregated.dailyAdoptionTrend).toHaveLength(2);
+      expect(aggregated.adoption.dailyAdoptionTrend).toHaveLength(2);
 
-      const day1 = aggregated.dailyAdoptionTrend.find(d => d.date === '2024-01-15')!;
+      const day1 = aggregated.adoption.dailyAdoptionTrend.find(d => d.date === '2024-01-15')!;
       expect(day1.newUsers).toBe(2);
       expect(day1.returningUsers).toBe(0);
       expect(day1.totalActiveUsers).toBe(2);
       expect(day1.cumulativeUsers).toBe(2);
 
-      const day2 = aggregated.dailyAdoptionTrend.find(d => d.date === '2024-01-16')!;
+      const day2 = aggregated.adoption.dailyAdoptionTrend.find(d => d.date === '2024-01-16')!;
       expect(day2.newUsers).toBe(1); // charlie is new
       expect(day2.returningUsers).toBe(1); // alice is returning
       expect(day2.totalActiveUsers).toBe(2);

--- a/src/domain/aggregation/aiAggregation.ts
+++ b/src/domain/aggregation/aiAggregation.ts
@@ -1,4 +1,4 @@
-import type { AggregatedMetrics } from '../../types/aggregatedMetrics';
+import type { AiMetricsSlice } from '../../types/aggregatedMetrics';
 import type { CopilotMetrics } from '../../types/metrics';
 import {
   accumulateAiAdoptionPhase,
@@ -21,10 +21,7 @@ export interface AiAggregationAccumulator {
   credits: AiCreditsAccumulator;
 }
 
-export type AiAggregationResult = Pick<
-  AggregatedMetrics,
-  'aiAdoptionPhaseData' | 'usageDistributionData' | 'dailyAiCreditsData'
->;
+export type AiAggregationResult = AiMetricsSlice;
 
 export function createAiAggregationAccumulator(): AiAggregationAccumulator {
   return {

--- a/src/domain/aggregation/cliAggregation.ts
+++ b/src/domain/aggregation/cliAggregation.ts
@@ -1,4 +1,4 @@
-import type { AggregatedMetrics } from '../../types/aggregatedMetrics';
+import type { CliMetricsSlice } from '../../types/aggregatedMetrics';
 import type { CopilotMetrics } from '../../types/metrics';
 import {
   accumulateCliUsage,
@@ -15,10 +15,7 @@ export interface CliAggregationAccumulator {
   usage: CliUsageAccumulator;
 }
 
-export type CliAggregationResult = Pick<
-  AggregatedMetrics,
-  'dailyCliSessionData' | 'dailyCliTokenData' | 'dailyCliAdoptionTrend'
->;
+export type CliAggregationResult = CliMetricsSlice;
 
 export function createCliAggregationAccumulator(): CliAggregationAccumulator {
   return {

--- a/src/domain/aggregation/clientAggregation.ts
+++ b/src/domain/aggregation/clientAggregation.ts
@@ -1,4 +1,4 @@
-import type { AggregatedMetrics } from '../../types/aggregatedMetrics';
+import type { ClientsMetricsSlice } from '../../types/aggregatedMetrics';
 import type { CopilotMetrics } from '../../types/metrics';
 import {
   accumulateIDEStats,
@@ -23,13 +23,7 @@ export interface ClientAggregationAccumulator {
   pluginVersions: PluginVersionAccumulator;
 }
 
-export type ClientAggregationResult = Pick<
-  AggregatedMetrics,
-  | 'ideStats'
-  | 'multiIDEUsersCount'
-  | 'totalUniqueIDEUsers'
-  | 'pluginVersionData'
->;
+export type ClientAggregationResult = ClientsMetricsSlice;
 
 export function createClientAggregationAccumulator(): ClientAggregationAccumulator {
   return {

--- a/src/domain/aggregation/coreStatsAggregation.ts
+++ b/src/domain/aggregation/coreStatsAggregation.ts
@@ -1,4 +1,4 @@
-import type { AggregatedMetrics } from '../../types/aggregatedMetrics';
+import type { OverviewMetricsSlice } from '../../types/aggregatedMetrics';
 import type { CopilotMetrics } from '../../types/metrics';
 import {
   accumulateUserUsage,
@@ -12,7 +12,7 @@ export interface CoreStatsAggregationAccumulator {
   filteredMetricsCount: number;
 }
 
-export type CoreStatsAggregationResult = Pick<AggregatedMetrics, 'stats'>;
+export type CoreStatsAggregationResult = Pick<OverviewMetricsSlice, 'stats'>;
 
 export function createCoreStatsAggregationAccumulator(
 ): CoreStatsAggregationAccumulator {

--- a/src/domain/aggregation/engagementAdoptionAggregation.ts
+++ b/src/domain/aggregation/engagementAdoptionAggregation.ts
@@ -1,4 +1,7 @@
-import type { AggregatedMetrics } from '../../types/aggregatedMetrics';
+import type {
+  AdoptionMetricsSlice,
+  OverviewMetricsSlice,
+} from '../../types/aggregatedMetrics';
 import type { CopilotMetrics } from '../../types/metrics';
 import {
   accumulateCloudAgentAdoption,
@@ -41,10 +44,12 @@ export interface EngagementAdoptionAggregationAccumulator {
 }
 
 export type EngagementAdoptionAggregationResult = Pick<
-  AggregatedMetrics,
+  OverviewMetricsSlice,
   | 'engagementData'
   | 'chatUsersData'
   | 'chatRequestsData'
+> & Pick<
+  AdoptionMetricsSlice,
   | 'featureAdoptionData'
   | 'dailyAdoptionTrend'
   | 'dailyCloudAgentAdoptionData'

--- a/src/domain/aggregation/impactAggregation.ts
+++ b/src/domain/aggregation/impactAggregation.ts
@@ -1,4 +1,4 @@
-import type { AggregatedMetrics } from '../../types/aggregatedMetrics';
+import type { ImpactMetricsSlice } from '../../types/aggregatedMetrics';
 import type { CopilotMetrics } from '../../types/metrics';
 import {
   accumulateFeatureImpactRecord,
@@ -18,16 +18,7 @@ export interface ImpactAggregationAccumulator {
   impact: ImpactAccumulator;
 }
 
-export type ImpactAggregationResult = Pick<
-  AggregatedMetrics,
-  | 'agentImpactData'
-  | 'codeCompletionImpactData'
-  | 'editModeImpactData'
-  | 'inlineModeImpactData'
-  | 'askModeImpactData'
-  | 'cliImpactData'
-  | 'joinedImpactData'
->;
+export type ImpactAggregationResult = ImpactMetricsSlice;
 
 export function createImpactAggregationAccumulator(
 ): ImpactAggregationAccumulator {

--- a/src/domain/aggregation/languageAggregation.ts
+++ b/src/domain/aggregation/languageAggregation.ts
@@ -1,4 +1,4 @@
-import type { AggregatedMetrics } from '../../types/aggregatedMetrics';
+import type { LanguagesMetricsSlice } from '../../types/aggregatedMetrics';
 import type { CopilotMetrics } from '../../types/metrics';
 import {
   accumulateLanguageFeatureImpact,
@@ -24,13 +24,7 @@ export interface LanguageAggregationAccumulator {
   featureImpact: LanguageFeatureImpactAccumulator;
 }
 
-export type LanguageAggregationResult = Pick<
-  AggregatedMetrics,
-  | 'languageStats'
-  | 'languageFeatureImpactData'
-  | 'dailyLanguageGenerationsData'
-  | 'dailyLanguageLocData'
->;
+export type LanguageAggregationResult = LanguagesMetricsSlice;
 
 export function createLanguageAggregationAccumulator(): LanguageAggregationAccumulator {
   return {

--- a/src/domain/aggregation/modelAggregation.ts
+++ b/src/domain/aggregation/modelAggregation.ts
@@ -1,4 +1,7 @@
-import type { AggregatedMetrics } from '../../types/aggregatedMetrics';
+import type {
+  AdoptionMetricsSlice,
+  ModelsMetricsSlice,
+} from '../../types/aggregatedMetrics';
 import type { CopilotMetrics } from '../../types/metrics';
 import { getCanonicalUserInitiatedInteractionCount } from '../assumedInteractions';
 import {
@@ -26,9 +29,9 @@ export interface ModelAggregationAccumulator {
 }
 
 export type ModelAggregationResult = Pick<
-  AggregatedMetrics,
-  'modelUsageData' | 'agentModeHeatmapData' | 'modelBreakdownData'
->;
+  AdoptionMetricsSlice,
+  'agentModeHeatmapData'
+> & ModelsMetricsSlice;
 
 export function createModelAggregationAccumulator(): ModelAggregationAccumulator {
   return {

--- a/src/domain/aggregation/userSummaryAggregation.ts
+++ b/src/domain/aggregation/userSummaryAggregation.ts
@@ -1,4 +1,4 @@
-import type { AggregatedMetrics } from '../../types/aggregatedMetrics';
+import type { UsersMetricsSlice } from '../../types/aggregatedMetrics';
 import type { CopilotMetrics, UserSummary } from '../../types/metrics';
 import { isActiveAutoModeFeature } from '../autoMode';
 
@@ -11,10 +11,7 @@ export interface UserSummaryAggregationAccumulator {
   userAiAdoptionPhaseDays: Map<number, string>;
 }
 
-export type UserSummaryAggregationResult = Pick<
-  AggregatedMetrics,
-  'userSummaries'
->;
+export type UserSummaryAggregationResult = UsersMetricsSlice;
 
 export function createUserSummaryAggregationAccumulator(
 ): UserSummaryAggregationAccumulator {

--- a/src/domain/metricsAggregator.ts
+++ b/src/domain/metricsAggregator.ts
@@ -6,11 +6,13 @@ import {
   createCoreStatsAggregationAccumulator,
   finalizeCoreStatsAggregation,
   getStatsAccumulatorForDimensions,
+  type CoreStatsAggregationResult,
 } from './aggregation/coreStatsAggregation';
 import {
   accumulateUserSummaryAggregation,
   createUserSummaryAggregationAccumulator,
   finalizeUserSummaryAggregation,
+  type UserSummaryAggregationResult,
 } from './aggregation/userSummaryAggregation';
 import {
   accumulateUserDetailAggregation,
@@ -22,39 +24,99 @@ import {
   accumulateClientAggregation,
   createClientAggregationAccumulator,
   finalizeClientAggregation,
+  type ClientAggregationResult,
 } from './aggregation/clientAggregation';
 import {
   accumulateCliAggregation,
   createCliAggregationAccumulator,
   finalizeCliAggregation,
   getCliUsageForDownstreamCalculations,
+  type CliAggregationResult,
 } from './aggregation/cliAggregation';
 import {
   accumulateLanguageAggregation,
   createLanguageAggregationAccumulator,
   finalizeLanguageAggregation,
+  type LanguageAggregationResult,
 } from './aggregation/languageAggregation';
 import {
   accumulateModelAggregation,
   accumulateModelFeatureSignals,
   createModelAggregationAccumulator,
   finalizeModelAggregation,
+  type ModelAggregationResult,
 } from './aggregation/modelAggregation';
 import {
   accumulateEngagementAdoptionAggregation,
   createEngagementAdoptionAggregationAccumulator,
   finalizeEngagementAdoptionAggregation,
+  type EngagementAdoptionAggregationResult,
 } from './aggregation/engagementAdoptionAggregation';
 import {
   accumulateImpactAggregation,
   createImpactAggregationAccumulator,
   finalizeImpactAggregation,
+  type ImpactAggregationResult,
 } from './aggregation/impactAggregation';
 import {
   accumulateAiAggregation,
   createAiAggregationAccumulator,
   finalizeAiAggregation,
+  type AiAggregationResult,
 } from './aggregation/aiAggregation';
+
+interface FinalizedAggregationResults {
+  coreStatsAggregation: CoreStatsAggregationResult;
+  userSummaryAggregation: UserSummaryAggregationResult;
+  engagementAdoptionAggregation: EngagementAdoptionAggregationResult;
+  impactAggregation: ImpactAggregationResult;
+  languageAggregation: LanguageAggregationResult;
+  clientAggregation: ClientAggregationResult;
+  modelAggregation: ModelAggregationResult;
+  cliAggregation: CliAggregationResult;
+  aiAggregation: AiAggregationResult;
+}
+
+export function assembleAggregatedMetrics({
+  coreStatsAggregation,
+  userSummaryAggregation,
+  engagementAdoptionAggregation,
+  impactAggregation,
+  languageAggregation,
+  clientAggregation,
+  modelAggregation,
+  cliAggregation,
+  aiAggregation,
+}: FinalizedAggregationResults): AggregatedMetrics {
+  return {
+    overview: {
+      stats: coreStatsAggregation.stats,
+      engagementData: engagementAdoptionAggregation.engagementData,
+      chatUsersData: engagementAdoptionAggregation.chatUsersData,
+      chatRequestsData: engagementAdoptionAggregation.chatRequestsData,
+    },
+    users: userSummaryAggregation,
+    adoption: {
+      featureAdoptionData: engagementAdoptionAggregation.featureAdoptionData,
+      agentModeHeatmapData: modelAggregation.agentModeHeatmapData,
+      dailyAdoptionTrend: engagementAdoptionAggregation.dailyAdoptionTrend,
+      dailyCloudAgentAdoptionData:
+        engagementAdoptionAggregation.dailyCloudAgentAdoptionData,
+      dailyCodeReviewAdoptionData:
+        engagementAdoptionAggregation.dailyCodeReviewAdoptionData,
+    },
+    impact: impactAggregation,
+    languages: languageAggregation,
+    clients: clientAggregation,
+    models: {
+      modelUsageData: modelAggregation.modelUsageData,
+      modelBreakdownData: modelAggregation.modelBreakdownData,
+    },
+    cli: cliAggregation,
+    ai: aiAggregation,
+  };
+}
+
 export function aggregateMetrics(
   metrics: CopilotMetrics[]
 ): { aggregated: AggregatedMetrics; userDetailAccumulator: UserDetailAccumulator } {
@@ -151,44 +213,17 @@ export function aggregateMetrics(
   const aiAggregation = finalizeAiAggregation(aiAggregationAccumulator);
 
   return {
-    aggregated: {
-      stats: coreStatsAggregation.stats,
-      userSummaries: userSummaryAggregation.userSummaries,
-      engagementData: engagementAdoptionAggregation.engagementData,
-      chatUsersData: engagementAdoptionAggregation.chatUsersData,
-      chatRequestsData: engagementAdoptionAggregation.chatRequestsData,
-      languageStats: languageAggregation.languageStats,
-      modelUsageData: modelAggregation.modelUsageData,
-      featureAdoptionData: engagementAdoptionAggregation.featureAdoptionData,
-      agentModeHeatmapData: modelAggregation.agentModeHeatmapData,
-      agentImpactData: impactAggregation.agentImpactData,
-      codeCompletionImpactData: impactAggregation.codeCompletionImpactData,
-      editModeImpactData: impactAggregation.editModeImpactData,
-      inlineModeImpactData: impactAggregation.inlineModeImpactData,
-      askModeImpactData: impactAggregation.askModeImpactData,
-      cliImpactData: impactAggregation.cliImpactData,
-      joinedImpactData: impactAggregation.joinedImpactData,
-      ideStats: clientAggregation.ideStats,
-      multiIDEUsersCount: clientAggregation.multiIDEUsersCount,
-      totalUniqueIDEUsers: clientAggregation.totalUniqueIDEUsers,
-      pluginVersionData: clientAggregation.pluginVersionData,
-      languageFeatureImpactData: languageAggregation.languageFeatureImpactData,
-      dailyLanguageGenerationsData:
-        languageAggregation.dailyLanguageGenerationsData,
-      dailyLanguageLocData: languageAggregation.dailyLanguageLocData,
-      modelBreakdownData: modelAggregation.modelBreakdownData,
-      dailyCliSessionData: cliAggregation.dailyCliSessionData,
-      dailyCliTokenData: cliAggregation.dailyCliTokenData,
-      dailyCliAdoptionTrend: cliAggregation.dailyCliAdoptionTrend,
-      dailyAdoptionTrend: engagementAdoptionAggregation.dailyAdoptionTrend,
-      dailyCloudAgentAdoptionData:
-        engagementAdoptionAggregation.dailyCloudAgentAdoptionData,
-      dailyCodeReviewAdoptionData:
-        engagementAdoptionAggregation.dailyCodeReviewAdoptionData,
-      aiAdoptionPhaseData: aiAggregation.aiAdoptionPhaseData,
-      usageDistributionData: aiAggregation.usageDistributionData,
-      dailyAiCreditsData: aiAggregation.dailyAiCreditsData,
-    },
+    aggregated: assembleAggregatedMetrics({
+      coreStatsAggregation,
+      userSummaryAggregation,
+      engagementAdoptionAggregation,
+      impactAggregation,
+      languageAggregation,
+      clientAggregation,
+      modelAggregation,
+      cliAggregation,
+      aiAggregation,
+    }),
     userDetailAccumulator,
   };
 }

--- a/src/read-models/__tests__/adoptionImpactReadModels.test.ts
+++ b/src/read-models/__tests__/adoptionImpactReadModels.test.ts
@@ -22,64 +22,72 @@ function makeFeatureMetrics(): AggregatedMetrics {
   const defaults = makeAggregatedMetrics();
 
   return makeAggregatedMetrics({
-    featureAdoptionData: {
-      ...defaults.featureAdoptionData,
-      totalUsers: 4,
-      agentModeUsers: 2,
-    },
-    agentModeHeatmapData: [{
-      date: '2026-01-15',
-      agentModeRequests: 8,
-      uniqueUsers: 2,
-      intensity: 4,
-    }],
-    stats: {
-      ...defaults.stats,
-      reportStartDay: '2026-01-15',
-      reportEndDay: '2026-01-16',
-    },
-    dailyAdoptionTrend: [{
-      date: '2026-01-15',
-      newUsers: 2,
-      returningUsers: 1,
-      totalActiveUsers: 3,
-      cumulativeUsers: 4,
-    }],
-    dailyCloudAgentAdoptionData: [{
-      date: '2026-01-15',
-      uniqueUsers: 1,
-    }],
-    dailyCodeReviewAdoptionData: [{
-      date: '2026-01-15',
-      activeUsers: 1,
-      passiveUsers: 1,
-      totalUsers: 2,
-    }],
-    aiAdoptionPhaseData: [{
-      phase: {
-        phase_number: 2,
-        phase: 'Phase 2',
-        version: 'v1',
+    overview: {
+      stats: {
+        ...defaults.overview.stats,
+        reportStartDay: '2026-01-15',
+        reportEndDay: '2026-01-16',
       },
-      userCount: 2,
-      avgUserInitiatedInteractions: 5,
-      totalLocAdded: 20,
-      totalLocDeleted: 4,
-      avgLocAdded: 10,
-      avgLocDeleted: 2,
-      avgAiCreditsUsed: 1.5,
-      avgDaysActive: 3,
-      topModels: [{ name: 'gpt-4.1', total: 8, uniqueUsers: 2 }],
-      topClients: [{ name: 'vscode', total: 7, uniqueUsers: 2 }],
-      topLanguages: [{ name: 'typescript', total: 6, uniqueUsers: 2 }],
-    }],
-    agentImpactData: [{ ...IMPACT_POINT, locAdded: 13, netChange: 10 }],
-    codeCompletionImpactData: [{ ...IMPACT_POINT, locAdded: 14, netChange: 11 }],
-    editModeImpactData: [{ ...IMPACT_POINT, locAdded: 15, netChange: 12 }],
-    inlineModeImpactData: [{ ...IMPACT_POINT, locAdded: 16, netChange: 13 }],
-    askModeImpactData: [{ ...IMPACT_POINT, locAdded: 17, netChange: 14 }],
-    cliImpactData: [{ ...IMPACT_POINT, locAdded: 18, netChange: 15 }],
-    joinedImpactData: [{ ...IMPACT_POINT, locAdded: 19, netChange: 16 }],
+    },
+    adoption: {
+      featureAdoptionData: {
+        ...defaults.adoption.featureAdoptionData,
+        totalUsers: 4,
+        agentModeUsers: 2,
+      },
+      agentModeHeatmapData: [{
+        date: '2026-01-15',
+        agentModeRequests: 8,
+        uniqueUsers: 2,
+        intensity: 4,
+      }],
+      dailyAdoptionTrend: [{
+        date: '2026-01-15',
+        newUsers: 2,
+        returningUsers: 1,
+        totalActiveUsers: 3,
+        cumulativeUsers: 4,
+      }],
+      dailyCloudAgentAdoptionData: [{
+        date: '2026-01-15',
+        uniqueUsers: 1,
+      }],
+      dailyCodeReviewAdoptionData: [{
+        date: '2026-01-15',
+        activeUsers: 1,
+        passiveUsers: 1,
+        totalUsers: 2,
+      }],
+    },
+    impact: {
+      agentImpactData: [{ ...IMPACT_POINT, locAdded: 13, netChange: 10 }],
+      codeCompletionImpactData: [{ ...IMPACT_POINT, locAdded: 14, netChange: 11 }],
+      editModeImpactData: [{ ...IMPACT_POINT, locAdded: 15, netChange: 12 }],
+      inlineModeImpactData: [{ ...IMPACT_POINT, locAdded: 16, netChange: 13 }],
+      askModeImpactData: [{ ...IMPACT_POINT, locAdded: 17, netChange: 14 }],
+      cliImpactData: [{ ...IMPACT_POINT, locAdded: 18, netChange: 15 }],
+      joinedImpactData: [{ ...IMPACT_POINT, locAdded: 19, netChange: 16 }],
+    },
+    ai: {
+      aiAdoptionPhaseData: [{
+        phase: {
+          phase_number: 2,
+          phase: 'Phase 2',
+          version: 'v1',
+        },
+        userCount: 2,
+        avgUserInitiatedInteractions: 5,
+        totalLocAdded: 20,
+        totalLocDeleted: 4,
+        avgLocAdded: 10,
+        avgLocDeleted: 2,
+        avgAiCreditsUsed: 1.5,
+        avgDaysActive: 3,
+        topModels: [{ name: 'gpt-4.1', total: 8, uniqueUsers: 2 }],
+        topClients: [{ name: 'vscode', total: 7, uniqueUsers: 2 }],
+        topLanguages: [{ name: 'typescript', total: 6, uniqueUsers: 2 }],
+      }],
+    },
   });
 }
 
@@ -90,19 +98,19 @@ describe('adoption and impact read models', () => {
     const model = selectCopilotAdoptionReadModel(metrics);
 
     expect(model).toEqual({
-      featureAdoptionData: metrics.featureAdoptionData,
-      agentModeHeatmapData: metrics.agentModeHeatmapData,
-      stats: metrics.stats,
-      dailyAdoptionTrend: metrics.dailyAdoptionTrend,
-      dailyCloudAgentAdoptionData: metrics.dailyCloudAgentAdoptionData,
-      dailyCodeReviewAdoptionData: metrics.dailyCodeReviewAdoptionData,
+      featureAdoptionData: metrics.adoption.featureAdoptionData,
+      agentModeHeatmapData: metrics.adoption.agentModeHeatmapData,
+      stats: metrics.overview.stats,
+      dailyAdoptionTrend: metrics.adoption.dailyAdoptionTrend,
+      dailyCloudAgentAdoptionData: metrics.adoption.dailyCloudAgentAdoptionData,
+      dailyCodeReviewAdoptionData: metrics.adoption.dailyCodeReviewAdoptionData,
     });
-    expect(model.featureAdoptionData).toBe(metrics.featureAdoptionData);
-    expect(model.agentModeHeatmapData).toBe(metrics.agentModeHeatmapData);
-    expect(model.stats).toBe(metrics.stats);
-    expect(model.dailyAdoptionTrend).toBe(metrics.dailyAdoptionTrend);
-    expect(model.dailyCloudAgentAdoptionData).toBe(metrics.dailyCloudAgentAdoptionData);
-    expect(model.dailyCodeReviewAdoptionData).toBe(metrics.dailyCodeReviewAdoptionData);
+    expect(model.featureAdoptionData).toBe(metrics.adoption.featureAdoptionData);
+    expect(model.agentModeHeatmapData).toBe(metrics.adoption.agentModeHeatmapData);
+    expect(model.stats).toBe(metrics.overview.stats);
+    expect(model.dailyAdoptionTrend).toBe(metrics.adoption.dailyAdoptionTrend);
+    expect(model.dailyCloudAgentAdoptionData).toBe(metrics.adoption.dailyCloudAgentAdoptionData);
+    expect(model.dailyCodeReviewAdoptionData).toBe(metrics.adoption.dailyCodeReviewAdoptionData);
     expect(Object.keys(model)).toEqual([
       'featureAdoptionData',
       'agentModeHeatmapData',
@@ -120,9 +128,9 @@ describe('adoption and impact read models', () => {
     const model = selectAiAdoptionPhaseReadModel(metrics);
 
     expect(model).toEqual({
-      aiAdoptionPhaseData: metrics.aiAdoptionPhaseData,
+      aiAdoptionPhaseData: metrics.ai.aiAdoptionPhaseData,
     });
-    expect(model.aiAdoptionPhaseData).toBe(metrics.aiAdoptionPhaseData);
+    expect(model.aiAdoptionPhaseData).toBe(metrics.ai.aiAdoptionPhaseData);
     expect(Object.keys(model)).toEqual(['aiAdoptionPhaseData']);
     expect(model).not.toHaveProperty('featureAdoptionData');
   });
@@ -133,21 +141,21 @@ describe('adoption and impact read models', () => {
     const model = selectCopilotImpactReadModel(metrics);
 
     expect(model).toEqual({
-      agentImpactData: metrics.agentImpactData,
-      codeCompletionImpactData: metrics.codeCompletionImpactData,
-      editModeImpactData: metrics.editModeImpactData,
-      inlineModeImpactData: metrics.inlineModeImpactData,
-      askModeImpactData: metrics.askModeImpactData,
-      cliImpactData: metrics.cliImpactData,
-      joinedImpactData: metrics.joinedImpactData,
+      agentImpactData: metrics.impact.agentImpactData,
+      codeCompletionImpactData: metrics.impact.codeCompletionImpactData,
+      editModeImpactData: metrics.impact.editModeImpactData,
+      inlineModeImpactData: metrics.impact.inlineModeImpactData,
+      askModeImpactData: metrics.impact.askModeImpactData,
+      cliImpactData: metrics.impact.cliImpactData,
+      joinedImpactData: metrics.impact.joinedImpactData,
     });
-    expect(model.agentImpactData).toBe(metrics.agentImpactData);
-    expect(model.codeCompletionImpactData).toBe(metrics.codeCompletionImpactData);
-    expect(model.editModeImpactData).toBe(metrics.editModeImpactData);
-    expect(model.inlineModeImpactData).toBe(metrics.inlineModeImpactData);
-    expect(model.askModeImpactData).toBe(metrics.askModeImpactData);
-    expect(model.cliImpactData).toBe(metrics.cliImpactData);
-    expect(model.joinedImpactData).toBe(metrics.joinedImpactData);
+    expect(model.agentImpactData).toBe(metrics.impact.agentImpactData);
+    expect(model.codeCompletionImpactData).toBe(metrics.impact.codeCompletionImpactData);
+    expect(model.editModeImpactData).toBe(metrics.impact.editModeImpactData);
+    expect(model.inlineModeImpactData).toBe(metrics.impact.inlineModeImpactData);
+    expect(model.askModeImpactData).toBe(metrics.impact.askModeImpactData);
+    expect(model.cliImpactData).toBe(metrics.impact.cliImpactData);
+    expect(model.joinedImpactData).toBe(metrics.impact.joinedImpactData);
     expect(Object.keys(model)).toEqual([
       'agentImpactData',
       'codeCompletionImpactData',
@@ -167,19 +175,19 @@ describe('adoption and impact read models', () => {
     const phases = selectAiAdoptionPhaseReadModel(metrics);
     const impact = selectCopilotImpactReadModel(metrics);
 
-    expect(adoption.agentModeHeatmapData).toBe(metrics.agentModeHeatmapData);
-    expect(adoption.dailyAdoptionTrend).toBe(metrics.dailyAdoptionTrend);
-    expect(adoption.dailyCloudAgentAdoptionData).toBe(metrics.dailyCloudAgentAdoptionData);
-    expect(adoption.dailyCodeReviewAdoptionData).toBe(metrics.dailyCodeReviewAdoptionData);
-    expect(phases.aiAdoptionPhaseData).toBe(metrics.aiAdoptionPhaseData);
+    expect(adoption.agentModeHeatmapData).toBe(metrics.adoption.agentModeHeatmapData);
+    expect(adoption.dailyAdoptionTrend).toBe(metrics.adoption.dailyAdoptionTrend);
+    expect(adoption.dailyCloudAgentAdoptionData).toBe(metrics.adoption.dailyCloudAgentAdoptionData);
+    expect(adoption.dailyCodeReviewAdoptionData).toBe(metrics.adoption.dailyCodeReviewAdoptionData);
+    expect(phases.aiAdoptionPhaseData).toBe(metrics.ai.aiAdoptionPhaseData);
     expect(Object.values(impact)).toEqual([
-      metrics.agentImpactData,
-      metrics.codeCompletionImpactData,
-      metrics.editModeImpactData,
-      metrics.inlineModeImpactData,
-      metrics.askModeImpactData,
-      metrics.cliImpactData,
-      metrics.joinedImpactData,
+      metrics.impact.agentImpactData,
+      metrics.impact.codeCompletionImpactData,
+      metrics.impact.editModeImpactData,
+      metrics.impact.inlineModeImpactData,
+      metrics.impact.askModeImpactData,
+      metrics.impact.cliImpactData,
+      metrics.impact.joinedImpactData,
     ]);
     expect([
       adoption.agentModeHeatmapData,

--- a/src/read-models/__tests__/aiCreditsReadModel.test.ts
+++ b/src/read-models/__tests__/aiCreditsReadModel.test.ts
@@ -10,40 +10,46 @@ function makeAiCreditsMetrics(): AggregatedMetrics {
   const defaults = makeAggregatedMetrics();
 
   return makeAggregatedMetrics({
-    stats: {
-      ...defaults.stats,
-      reportStartDay: '2026-01-15',
-      reportEndDay: '2026-01-17',
+    overview: {
+      stats: {
+        ...defaults.overview.stats,
+        reportStartDay: '2026-01-15',
+        reportEndDay: '2026-01-17',
+      },
     },
-    dailyAiCreditsData: [
-      { date: '2026-01-17', aiCreditsUsed: -0.25, users: 1 },
-      { date: '2026-01-15', aiCreditsUsed: 2.5, users: 2 },
-    ],
-    userSummaries: [
-      makeUserSummary({
-        user_login: 'fractional',
-        user_id: 1,
-        total_ai_credits_used: 2.5,
-      }),
-      makeUserSummary({
-        user_login: 'signed',
-        user_id: 2,
-        total_ai_credits_used: -0.25,
-      }),
-    ],
-    usageDistributionData: [{
-      id: 'power',
-      label: 'Power Users',
-      description: 'Top users',
-      userCount: 1,
-      totalAiCreditsUsed: 2.5,
-      avgAiCreditsUsed: 2.5,
-      avgDaysActive: 1.5,
-      totalLocAdded: 10,
-      totalLocDeleted: 2,
-      topModels: [{ name: 'gpt-5', total: 4, uniqueUsers: 1 }],
-      topClients: [{ name: 'vscode', total: 3, uniqueUsers: 1 }],
-    }],
+    users: {
+      userSummaries: [
+        makeUserSummary({
+          user_login: 'fractional',
+          user_id: 1,
+          total_ai_credits_used: 2.5,
+        }),
+        makeUserSummary({
+          user_login: 'signed',
+          user_id: 2,
+          total_ai_credits_used: -0.25,
+        }),
+      ],
+    },
+    ai: {
+      dailyAiCreditsData: [
+        { date: '2026-01-17', aiCreditsUsed: -0.25, users: 1 },
+        { date: '2026-01-15', aiCreditsUsed: 2.5, users: 2 },
+      ],
+      usageDistributionData: [{
+        id: 'power',
+        label: 'Power Users',
+        description: 'Top users',
+        userCount: 1,
+        totalAiCreditsUsed: 2.5,
+        avgAiCreditsUsed: 2.5,
+        avgDaysActive: 1.5,
+        totalLocAdded: 10,
+        totalLocDeleted: 2,
+        topModels: [{ name: 'gpt-5', total: 4, uniqueUsers: 1 }],
+        topClients: [{ name: 'vscode', total: 3, uniqueUsers: 1 }],
+      }],
+    },
   });
 }
 
@@ -57,31 +63,31 @@ describe('AI Credits read model', () => {
     expect(model).toEqual({
       reportStartDay: '2026-01-15',
       reportEndDay: '2026-01-17',
-      dailyAiCreditsData: metrics.dailyAiCreditsData,
-      userSummaries: metrics.userSummaries,
-      usageDistributionData: metrics.usageDistributionData,
+      dailyAiCreditsData: metrics.ai.dailyAiCreditsData,
+      userSummaries: metrics.users.userSummaries,
+      usageDistributionData: metrics.ai.usageDistributionData,
       totalAiCreditsUsed: 2.25,
       onUserClick,
     });
-    expect(model.dailyAiCreditsData).toBe(metrics.dailyAiCreditsData);
-    expect(model.dailyAiCreditsData[0]).toBe(metrics.dailyAiCreditsData[0]);
-    expect(model.userSummaries).toBe(metrics.userSummaries);
-    expect(model.userSummaries[0]).toBe(metrics.userSummaries[0]);
-    expect(model.usageDistributionData).toBe(metrics.usageDistributionData);
+    expect(model.dailyAiCreditsData).toBe(metrics.ai.dailyAiCreditsData);
+    expect(model.dailyAiCreditsData[0]).toBe(metrics.ai.dailyAiCreditsData[0]);
+    expect(model.userSummaries).toBe(metrics.users.userSummaries);
+    expect(model.userSummaries[0]).toBe(metrics.users.userSummaries[0]);
+    expect(model.usageDistributionData).toBe(metrics.ai.usageDistributionData);
     expect(model.usageDistributionData[0]).toBe(
-      metrics.usageDistributionData[0]
+      metrics.ai.usageDistributionData[0]
     );
     expect(model.usageDistributionData[0].topModels).toBe(
-      metrics.usageDistributionData[0].topModels
+      metrics.ai.usageDistributionData[0].topModels
     );
     expect(model.usageDistributionData[0].topModels[0]).toBe(
-      metrics.usageDistributionData[0].topModels[0]
+      metrics.ai.usageDistributionData[0].topModels[0]
     );
     expect(model.usageDistributionData[0].topClients).toBe(
-      metrics.usageDistributionData[0].topClients
+      metrics.ai.usageDistributionData[0].topClients
     );
     expect(model.usageDistributionData[0].topClients[0]).toBe(
-      metrics.usageDistributionData[0].topClients[0]
+      metrics.ai.usageDistributionData[0].topClients[0]
     );
     expect(model.onUserClick).toBe(onUserClick);
     expect(Object.keys(model)).toEqual([
@@ -109,25 +115,27 @@ describe('AI Credits read model', () => {
       reportEndDay: '',
       dailyAiCreditsData: [],
       userSummaries: [],
-      usageDistributionData: metrics.usageDistributionData,
+      usageDistributionData: metrics.ai.usageDistributionData,
       totalAiCreditsUsed: 0,
       onUserClick,
     });
-    expect(model.dailyAiCreditsData).toBe(metrics.dailyAiCreditsData);
-    expect(model.userSummaries).toBe(metrics.userSummaries);
-    expect(model.usageDistributionData).toBe(metrics.usageDistributionData);
+    expect(model.dailyAiCreditsData).toBe(metrics.ai.dailyAiCreditsData);
+    expect(model.userSummaries).toBe(metrics.users.userSummaries);
+    expect(model.usageDistributionData).toBe(metrics.ai.usageDistributionData);
   });
 
   it('keeps the existing runtime array fallbacks and date scalar semantics', () => {
     const metrics = makeAggregatedMetrics({
-      stats: {
-        ...makeAggregatedMetrics().stats,
-        reportStartDay: 'not-a-start-date',
-        reportEndDay: 'not-an-end-date',
+      overview: {
+        stats: {
+          ...makeAggregatedMetrics().overview.stats,
+          reportStartDay: 'not-a-start-date',
+          reportEndDay: 'not-an-end-date',
+        },
       },
     });
-    Reflect.set(metrics, 'dailyAiCreditsData', undefined);
-    Reflect.set(metrics, 'usageDistributionData', undefined);
+    Reflect.set(metrics.ai, 'dailyAiCreditsData', undefined);
+    Reflect.set(metrics.ai, 'usageDistributionData', undefined);
 
     const model = selectAiCreditsReadModel(metrics, vi.fn());
 
@@ -139,10 +147,12 @@ describe('AI Credits read model', () => {
 
   it('keeps signed and fractional totals without rounding or clamping', () => {
     const metrics = makeAggregatedMetrics({
-      userSummaries: [
-        makeUserSummary({ total_ai_credits_used: -4.75 }),
-        makeUserSummary({ total_ai_credits_used: 1.125 }),
-      ],
+      users: {
+        userSummaries: [
+          makeUserSummary({ total_ai_credits_used: -4.75 }),
+          makeUserSummary({ total_ai_credits_used: 1.125 }),
+        ],
+      },
     });
 
     const model = selectAiCreditsReadModel(metrics, vi.fn());

--- a/src/read-models/__tests__/clientsReadModels.test.ts
+++ b/src/read-models/__tests__/clientsReadModels.test.ts
@@ -10,72 +10,80 @@ function makeClientMetrics(): AggregatedMetrics {
   const defaults = makeAggregatedMetrics();
 
   return makeAggregatedMetrics({
-    stats: {
-      ...defaults.stats,
-      cliUsers: 7,
-      reportStartDay: '2026-01-15',
+    overview: {
+      stats: {
+        ...defaults.overview.stats,
+        cliUsers: 7,
+        reportStartDay: '2026-01-15',
+      },
     },
-    ideStats: [{
-      ide: 'vscode',
-      uniqueUsers: 4,
-      cliOverlapUsers: 1,
-      totalEngagements: 12,
-      totalGenerations: 8,
-      totalAcceptances: 5,
-      locAdded: 21,
-      locDeleted: 3,
-      locSuggestedToAdd: 30,
-      locSuggestedToDelete: 4,
-    }],
-    multiIDEUsersCount: 2,
-    totalUniqueIDEUsers: 5,
-    dailyCliSessionData: [
-      {
-        date: '2026-01-15',
-        sessionCount: 3,
-        requestCount: 4,
-        promptCount: 5,
-        uniqueUsers: 2,
-      },
-      {
-        date: '2026-01-16',
-        sessionCount: 8,
-        requestCount: 9,
-        promptCount: 10,
-        uniqueUsers: 3,
-      },
-    ],
-    cliImpactData: [
-      {
-        date: '2026-01-15',
-        locAdded: 13,
-        locDeleted: 2,
-        netChange: 11,
-        userCount: 2,
-        totalUniqueUsers: 7,
-      },
-      {
-        date: '2026-01-16',
-        locAdded: 17,
-        locDeleted: 5,
-        netChange: 12,
-        userCount: 3,
-        totalUniqueUsers: 7,
-      },
-    ],
-    pluginVersionData: {
-      jetbrains: [{
-        version: '1.5.0',
-        userCount: 2,
-        usernames: ['octocat', 'hubot'],
+    clients: {
+      ideStats: [{
+        ide: 'vscode',
+        uniqueUsers: 4,
+        cliOverlapUsers: 1,
+        totalEngagements: 12,
+        totalGenerations: 8,
+        totalAcceptances: 5,
+        locAdded: 21,
+        locDeleted: 3,
+        locSuggestedToAdd: 30,
+        locSuggestedToDelete: 4,
       }],
-      vscode: [{
-        version: '1.250.0',
-        userCount: 3,
-        usernames: ['octocat', 'hubot', 'monalisa'],
-      }],
-      totalUniqueIntellijUsers: 2,
-      totalUniqueVsCodeUsers: 3,
+      multiIDEUsersCount: 2,
+      totalUniqueIDEUsers: 5,
+      pluginVersionData: {
+        jetbrains: [{
+          version: '1.5.0',
+          userCount: 2,
+          usernames: ['octocat', 'hubot'],
+        }],
+        vscode: [{
+          version: '1.250.0',
+          userCount: 3,
+          usernames: ['octocat', 'hubot', 'monalisa'],
+        }],
+        totalUniqueIntellijUsers: 2,
+        totalUniqueVsCodeUsers: 3,
+      },
+    },
+    cli: {
+      dailyCliSessionData: [
+        {
+          date: '2026-01-15',
+          sessionCount: 3,
+          requestCount: 4,
+          promptCount: 5,
+          uniqueUsers: 2,
+        },
+        {
+          date: '2026-01-16',
+          sessionCount: 8,
+          requestCount: 9,
+          promptCount: 10,
+          uniqueUsers: 3,
+        },
+      ],
+    },
+    impact: {
+      cliImpactData: [
+        {
+          date: '2026-01-15',
+          locAdded: 13,
+          locDeleted: 2,
+          netChange: 11,
+          userCount: 2,
+          totalUniqueUsers: 7,
+        },
+        {
+          date: '2026-01-16',
+          locAdded: 17,
+          locDeleted: 5,
+          netChange: 12,
+          userCount: 3,
+          totalUniqueUsers: 7,
+        },
+      ],
     },
   });
 }
@@ -87,7 +95,7 @@ describe('client read models', () => {
     const model = selectClientsReadModel(metrics);
 
     expect(model).toEqual({
-      ideStats: metrics.ideStats,
+      ideStats: metrics.clients.ideStats,
       multiIDEUsersCount: 2,
       totalUniqueIDEUsers: 5,
       cliUsers: 7,
@@ -95,8 +103,8 @@ describe('client read models', () => {
       cliLocAdded: 30,
       cliLocDeleted: 7,
     });
-    expect(model.ideStats).toBe(metrics.ideStats);
-    expect(model.ideStats[0]).toBe(metrics.ideStats[0]);
+    expect(model.ideStats).toBe(metrics.clients.ideStats);
+    expect(model.ideStats[0]).toBe(metrics.clients.ideStats[0]);
     expect(Object.keys(model)).toEqual([
       'ideStats',
       'multiIDEUsersCount',
@@ -115,47 +123,55 @@ describe('client read models', () => {
   it('uses additive totals without filtering or changing signed values', () => {
     const defaults = makeAggregatedMetrics();
     const metrics = makeAggregatedMetrics({
-      stats: { ...defaults.stats, cliUsers: -1 },
-      multiIDEUsersCount: -2,
-      totalUniqueIDEUsers: -3,
-      dailyCliSessionData: [
-        {
-          date: 'invalid',
-          sessionCount: 4.5,
-          requestCount: 0,
-          promptCount: 0,
-          uniqueUsers: 0,
-        },
-        {
-          date: '',
-          sessionCount: -1.25,
-          requestCount: 0,
-          promptCount: 0,
-          uniqueUsers: 0,
-        },
-      ],
-      cliImpactData: [
-        {
-          date: 'invalid',
-          locAdded: 6.5,
-          locDeleted: -2,
-          netChange: 8.5,
-          userCount: 0,
-          totalUniqueUsers: 0,
-        },
-        {
-          date: '',
-          locAdded: -1.5,
-          locDeleted: 3,
-          netChange: -4.5,
-          userCount: 0,
-          totalUniqueUsers: 0,
-        },
-      ],
+      overview: {
+        stats: { ...defaults.overview.stats, cliUsers: -1 },
+      },
+      clients: {
+        multiIDEUsersCount: -2,
+        totalUniqueIDEUsers: -3,
+      },
+      cli: {
+        dailyCliSessionData: [
+          {
+            date: 'invalid',
+            sessionCount: 4.5,
+            requestCount: 0,
+            promptCount: 0,
+            uniqueUsers: 0,
+          },
+          {
+            date: '',
+            sessionCount: -1.25,
+            requestCount: 0,
+            promptCount: 0,
+            uniqueUsers: 0,
+          },
+        ],
+      },
+      impact: {
+        cliImpactData: [
+          {
+            date: 'invalid',
+            locAdded: 6.5,
+            locDeleted: -2,
+            netChange: 8.5,
+            userCount: 0,
+            totalUniqueUsers: 0,
+          },
+          {
+            date: '',
+            locAdded: -1.5,
+            locDeleted: 3,
+            netChange: -4.5,
+            userCount: 0,
+            totalUniqueUsers: 0,
+          },
+        ],
+      },
     });
 
     expect(selectClientsReadModel(metrics)).toEqual({
-      ideStats: metrics.ideStats,
+      ideStats: metrics.clients.ideStats,
       multiIDEUsersCount: -2,
       totalUniqueIDEUsers: -3,
       cliUsers: -1,
@@ -171,18 +187,18 @@ describe('client read models', () => {
     const model = selectClientVersionsReadModel(metrics);
 
     expect(model).toEqual({
-      pluginVersionData: metrics.pluginVersionData,
+      pluginVersionData: metrics.clients.pluginVersionData,
       reportStartDay: '2026-01-15',
     });
-    expect(model.pluginVersionData).toBe(metrics.pluginVersionData);
-    expect(model.pluginVersionData.jetbrains).toBe(metrics.pluginVersionData.jetbrains);
+    expect(model.pluginVersionData).toBe(metrics.clients.pluginVersionData);
+    expect(model.pluginVersionData.jetbrains).toBe(metrics.clients.pluginVersionData.jetbrains);
     expect(model.pluginVersionData.jetbrains[0]).toBe(
-      metrics.pluginVersionData.jetbrains[0]
+      metrics.clients.pluginVersionData.jetbrains[0]
     );
     expect(model.pluginVersionData.jetbrains[0].usernames).toBe(
-      metrics.pluginVersionData.jetbrains[0].usernames
+      metrics.clients.pluginVersionData.jetbrains[0].usernames
     );
-    expect(model.pluginVersionData.vscode).toBe(metrics.pluginVersionData.vscode);
+    expect(model.pluginVersionData.vscode).toBe(metrics.clients.pluginVersionData.vscode);
     expect(Object.keys(model)).toEqual(['pluginVersionData', 'reportStartDay']);
     expect(model).not.toHaveProperty('stats');
     expect(model).not.toHaveProperty('ideStats');
@@ -204,26 +220,28 @@ describe('client read models', () => {
       cliLocAdded: 0,
       cliLocDeleted: 0,
     });
-    expect(clients.ideStats).toBe(metrics.ideStats);
+    expect(clients.ideStats).toBe(metrics.clients.ideStats);
     expect(clientVersions).toEqual({
-      pluginVersionData: metrics.pluginVersionData,
+      pluginVersionData: metrics.clients.pluginVersionData,
       reportStartDay: '',
     });
-    expect(clientVersions.pluginVersionData).toBe(metrics.pluginVersionData);
+    expect(clientVersions.pluginVersionData).toBe(metrics.clients.pluginVersionData);
     expect(clientVersions.pluginVersionData.jetbrains).toBe(
-      metrics.pluginVersionData.jetbrains
+      metrics.clients.pluginVersionData.jetbrains
     );
     expect(clientVersions.pluginVersionData.vscode).toBe(
-      metrics.pluginVersionData.vscode
+      metrics.clients.pluginVersionData.vscode
     );
   });
 
   it('passes report dates through verbatim without adding fallback semantics', () => {
     const defaults = makeAggregatedMetrics();
     const metrics = makeAggregatedMetrics({
-      stats: {
-        ...defaults.stats,
-        reportStartDay: 'not-a-report-date',
+      overview: {
+        stats: {
+          ...defaults.overview.stats,
+          reportStartDay: 'not-a-report-date',
+        },
       },
     });
 

--- a/src/read-models/__tests__/featureReadModels.test.ts
+++ b/src/read-models/__tests__/featureReadModels.test.ts
@@ -16,15 +16,15 @@ describe('feature read models', () => {
     const model = selectOverviewReadModel(metrics);
 
     expect(model).toEqual({
-      reportStartDay: metrics.stats.reportStartDay,
-      reportEndDay: metrics.stats.reportEndDay,
-      engagementData: metrics.engagementData,
-      chatUsersData: metrics.chatUsersData,
-      chatRequestsData: metrics.chatRequestsData,
+      reportStartDay: metrics.overview.stats.reportStartDay,
+      reportEndDay: metrics.overview.stats.reportEndDay,
+      engagementData: metrics.overview.engagementData,
+      chatUsersData: metrics.overview.chatUsersData,
+      chatRequestsData: metrics.overview.chatRequestsData,
     });
-    expect(model.engagementData).toBe(metrics.engagementData);
-    expect(model.chatUsersData).toBe(metrics.chatUsersData);
-    expect(model.chatRequestsData).toBe(metrics.chatRequestsData);
+    expect(model.engagementData).toBe(metrics.overview.engagementData);
+    expect(model.chatUsersData).toBe(metrics.overview.chatUsersData);
+    expect(model.chatRequestsData).toBe(metrics.overview.chatRequestsData);
     expect(Object.keys(model)).toEqual([
       'reportStartDay',
       'reportEndDay',
@@ -39,17 +39,17 @@ describe('feature read models', () => {
     const model = selectExecutiveSummaryReadModel(metrics);
 
     expect(model).toEqual({
-      reportStartDay: metrics.stats.reportStartDay,
-      reportEndDay: metrics.stats.reportEndDay,
-      joinedImpactData: metrics.joinedImpactData,
-      agentImpactData: metrics.agentImpactData,
-      codeCompletionImpactData: metrics.codeCompletionImpactData,
-      featureAdoptionData: metrics.featureAdoptionData,
+      reportStartDay: metrics.overview.stats.reportStartDay,
+      reportEndDay: metrics.overview.stats.reportEndDay,
+      joinedImpactData: metrics.impact.joinedImpactData,
+      agentImpactData: metrics.impact.agentImpactData,
+      codeCompletionImpactData: metrics.impact.codeCompletionImpactData,
+      featureAdoptionData: metrics.adoption.featureAdoptionData,
     });
-    expect(model.joinedImpactData).toBe(metrics.joinedImpactData);
-    expect(model.agentImpactData).toBe(metrics.agentImpactData);
-    expect(model.codeCompletionImpactData).toBe(metrics.codeCompletionImpactData);
-    expect(model.featureAdoptionData).toBe(metrics.featureAdoptionData);
+    expect(model.joinedImpactData).toBe(metrics.impact.joinedImpactData);
+    expect(model.agentImpactData).toBe(metrics.impact.agentImpactData);
+    expect(model.codeCompletionImpactData).toBe(metrics.impact.codeCompletionImpactData);
+    expect(model.featureAdoptionData).toBe(metrics.adoption.featureAdoptionData);
     expect(Object.keys(model)).toEqual([
       'reportStartDay',
       'reportEndDay',
@@ -62,7 +62,7 @@ describe('feature read models', () => {
 
   it('projects the users list without copying it', () => {
     const users = [makeUserSummary()];
-    const metrics = makeAggregatedMetrics({ userSummaries: users });
+    const metrics = makeAggregatedMetrics({ users: { userSummaries: users } });
     const model = selectUsersReadModel(metrics);
 
     expect(model).toEqual({ users });
@@ -72,7 +72,9 @@ describe('feature read models', () => {
 
   it('resolves a selected user while preserving summary and dataset identity', () => {
     const userSummary = makeUserSummary();
-    const metrics = makeAggregatedMetrics({ userSummaries: [userSummary] });
+    const metrics = makeAggregatedMetrics({
+      users: { userSummaries: [userSummary] },
+    });
     const selectedUser = { id: userSummary.user_id, login: userSummary.user_login };
 
     const model = selectUserDetailsRouteReadModel(metrics, selectedUser);
@@ -115,7 +117,7 @@ describe('feature read models', () => {
 
   it('does not mutate the aggregate input', () => {
     const metrics = makeAggregatedMetrics({
-      userSummaries: [makeUserSummary()],
+      users: { userSummaries: [makeUserSummary()] },
     });
     const before = structuredClone(metrics);
 

--- a/src/read-models/__tests__/languagesReadModel.test.ts
+++ b/src/read-models/__tests__/languagesReadModel.test.ts
@@ -5,36 +5,38 @@ import { selectLanguagesReadModel } from '../languages';
 
 function makeLanguageMetrics(): AggregatedMetrics {
   return makeAggregatedMetrics({
-    languageStats: [{
-      language: 'typescript',
-      totalGenerations: 12,
-      totalAcceptances: 6,
-      totalEngagements: 18,
-      uniqueUsers: 2,
-      locAdded: 24,
-      locDeleted: 4,
-      locSuggestedToAdd: 30,
-      locSuggestedToDelete: 5,
-    }],
-    languageFeatureImpactData: {
-      features: ['code_completion'],
-      rows: [{
+    languages: {
+      languageStats: [{
         language: 'typescript',
-        total: 28,
-        features: { code_completion: 28 },
+        totalGenerations: 12,
+        totalAcceptances: 6,
+        totalEngagements: 18,
+        uniqueUsers: 2,
+        locAdded: 24,
+        locDeleted: 4,
+        locSuggestedToAdd: 30,
+        locSuggestedToDelete: 5,
       }],
-    },
-    dailyLanguageGenerationsData: {
-      dates: ['2026-01-15'],
-      languages: ['typescript'],
-      data: { '2026-01-15': { typescript: 12 } },
-      totals: { typescript: 12 },
-    },
-    dailyLanguageLocData: {
-      dates: ['2026-01-15'],
-      languages: ['typescript'],
-      data: { '2026-01-15': { typescript: 28 } },
-      totals: { typescript: 28 },
+      languageFeatureImpactData: {
+        features: ['code_completion'],
+        rows: [{
+          language: 'typescript',
+          total: 28,
+          features: { code_completion: 28 },
+        }],
+      },
+      dailyLanguageGenerationsData: {
+        dates: ['2026-01-15'],
+        languages: ['typescript'],
+        data: { '2026-01-15': { typescript: 12 } },
+        totals: { typescript: 12 },
+      },
+      dailyLanguageLocData: {
+        dates: ['2026-01-15'],
+        languages: ['typescript'],
+        data: { '2026-01-15': { typescript: 28 } },
+        totals: { typescript: 28 },
+      },
     },
   });
 }
@@ -46,57 +48,57 @@ describe('languages read model', () => {
     const model = selectLanguagesReadModel(metrics);
 
     expect(model).toEqual({
-      languageStats: metrics.languageStats,
-      languageFeatureImpactData: metrics.languageFeatureImpactData,
-      dailyLanguageGenerationsData: metrics.dailyLanguageGenerationsData,
-      dailyLanguageLocData: metrics.dailyLanguageLocData,
+      languageStats: metrics.languages.languageStats,
+      languageFeatureImpactData: metrics.languages.languageFeatureImpactData,
+      dailyLanguageGenerationsData: metrics.languages.dailyLanguageGenerationsData,
+      dailyLanguageLocData: metrics.languages.dailyLanguageLocData,
     });
-    expect(model.languageStats).toBe(metrics.languageStats);
-    expect(model.languageFeatureImpactData).toBe(metrics.languageFeatureImpactData);
-    expect(model.dailyLanguageGenerationsData).toBe(metrics.dailyLanguageGenerationsData);
-    expect(model.dailyLanguageLocData).toBe(metrics.dailyLanguageLocData);
-    expect(model.languageStats[0]).toBe(metrics.languageStats[0]);
+    expect(model.languageStats).toBe(metrics.languages.languageStats);
+    expect(model.languageFeatureImpactData).toBe(metrics.languages.languageFeatureImpactData);
+    expect(model.dailyLanguageGenerationsData).toBe(metrics.languages.dailyLanguageGenerationsData);
+    expect(model.dailyLanguageLocData).toBe(metrics.languages.dailyLanguageLocData);
+    expect(model.languageStats[0]).toBe(metrics.languages.languageStats[0]);
     expect(model.languageFeatureImpactData.features).toBe(
-      metrics.languageFeatureImpactData.features
+      metrics.languages.languageFeatureImpactData.features
     );
     expect(model.languageFeatureImpactData.rows).toBe(
-      metrics.languageFeatureImpactData.rows
+      metrics.languages.languageFeatureImpactData.rows
     );
     expect(model.languageFeatureImpactData.rows[0]).toBe(
-      metrics.languageFeatureImpactData.rows[0]
+      metrics.languages.languageFeatureImpactData.rows[0]
     );
     expect(model.languageFeatureImpactData.rows[0].features).toBe(
-      metrics.languageFeatureImpactData.rows[0].features
+      metrics.languages.languageFeatureImpactData.rows[0].features
     );
     expect(model.dailyLanguageGenerationsData.dates).toBe(
-      metrics.dailyLanguageGenerationsData.dates
+      metrics.languages.dailyLanguageGenerationsData.dates
     );
     expect(model.dailyLanguageGenerationsData.languages).toBe(
-      metrics.dailyLanguageGenerationsData.languages
+      metrics.languages.dailyLanguageGenerationsData.languages
     );
     expect(model.dailyLanguageGenerationsData.data).toBe(
-      metrics.dailyLanguageGenerationsData.data
+      metrics.languages.dailyLanguageGenerationsData.data
     );
     expect(model.dailyLanguageGenerationsData.data['2026-01-15']).toBe(
-      metrics.dailyLanguageGenerationsData.data['2026-01-15']
+      metrics.languages.dailyLanguageGenerationsData.data['2026-01-15']
     );
     expect(model.dailyLanguageGenerationsData.totals).toBe(
-      metrics.dailyLanguageGenerationsData.totals
+      metrics.languages.dailyLanguageGenerationsData.totals
     );
     expect(model.dailyLanguageLocData.dates).toBe(
-      metrics.dailyLanguageLocData.dates
+      metrics.languages.dailyLanguageLocData.dates
     );
     expect(model.dailyLanguageLocData.languages).toBe(
-      metrics.dailyLanguageLocData.languages
+      metrics.languages.dailyLanguageLocData.languages
     );
     expect(model.dailyLanguageLocData.data).toBe(
-      metrics.dailyLanguageLocData.data
+      metrics.languages.dailyLanguageLocData.data
     );
     expect(model.dailyLanguageLocData.data['2026-01-15']).toBe(
-      metrics.dailyLanguageLocData.data['2026-01-15']
+      metrics.languages.dailyLanguageLocData.data['2026-01-15']
     );
     expect(model.dailyLanguageLocData.totals).toBe(
-      metrics.dailyLanguageLocData.totals
+      metrics.languages.dailyLanguageLocData.totals
     );
     expect(Object.keys(model)).toEqual([
       'languageStats',
@@ -114,10 +116,10 @@ describe('languages read model', () => {
 
     const model = selectLanguagesReadModel(metrics);
 
-    expect(model.languageStats).toBe(metrics.languageStats);
-    expect(model.languageFeatureImpactData).toBe(metrics.languageFeatureImpactData);
-    expect(model.dailyLanguageGenerationsData).toBe(metrics.dailyLanguageGenerationsData);
-    expect(model.dailyLanguageLocData).toBe(metrics.dailyLanguageLocData);
+    expect(model.languageStats).toBe(metrics.languages.languageStats);
+    expect(model.languageFeatureImpactData).toBe(metrics.languages.languageFeatureImpactData);
+    expect(model.dailyLanguageGenerationsData).toBe(metrics.languages.dailyLanguageGenerationsData);
+    expect(model.dailyLanguageLocData).toBe(metrics.languages.dailyLanguageLocData);
     expect(model).toEqual({
       languageStats: [],
       languageFeatureImpactData: {

--- a/src/read-models/__tests__/modelsCliReadModels.test.ts
+++ b/src/read-models/__tests__/modelsCliReadModels.test.ts
@@ -6,45 +6,47 @@ import { selectModelDetailsReadModel } from '../models';
 
 function makeModelMetrics(): AggregatedMetrics {
   return makeAggregatedMetrics({
-    modelBreakdownData: {
-      allModels: [{
-        model: 'gpt-5',
-        total: 11,
-        dailyData: { '2026-01-15': 11 },
-      }],
-      modelCategories: [{
-        category: 'Powerful',
-        total: 11,
-        dailyData: { '2026-01-15': 11 },
-      }],
-      autoModels: [
-        {
-          model: 'auto',
-          total: 4.5,
-          dailyData: { '2026-01-15': 4.5 },
-        },
-        {
-          model: 'auto-secondary',
-          total: -1.25,
-          dailyData: { '2026-01-16': -1.25 },
-        },
-      ],
-      cliModels: [{
-        model: 'gpt-5',
-        total: 99,
-        dailyData: { '2026-01-15': 99 },
-      }],
-      autoModeAdoptionTrend: [{
-        date: '2026-01-15',
-        newUsers: 2,
-        returningUsers: 1,
-        totalActiveUsers: 3,
-        cumulativeUsers: 4,
-      }],
-      dates: ['2026-01-15', '2026-01-16'],
-      modelTotal: 11,
-      cliTotal: 99,
-      unknownTotal: 0,
+    models: {
+      modelBreakdownData: {
+        allModels: [{
+          model: 'gpt-5',
+          total: 11,
+          dailyData: { '2026-01-15': 11 },
+        }],
+        modelCategories: [{
+          category: 'Powerful',
+          total: 11,
+          dailyData: { '2026-01-15': 11 },
+        }],
+        autoModels: [
+          {
+            model: 'auto',
+            total: 4.5,
+            dailyData: { '2026-01-15': 4.5 },
+          },
+          {
+            model: 'auto-secondary',
+            total: -1.25,
+            dailyData: { '2026-01-16': -1.25 },
+          },
+        ],
+        cliModels: [{
+          model: 'gpt-5',
+          total: 99,
+          dailyData: { '2026-01-15': 99 },
+        }],
+        autoModeAdoptionTrend: [{
+          date: '2026-01-15',
+          newUsers: 2,
+          returningUsers: 1,
+          totalActiveUsers: 3,
+          cumulativeUsers: 4,
+        }],
+        dates: ['2026-01-15', '2026-01-16'],
+        modelTotal: 11,
+        cliTotal: 99,
+        unknownTotal: 0,
+      },
     },
   });
 }
@@ -53,51 +55,57 @@ function makeCliMetrics(): AggregatedMetrics {
   const defaults = makeAggregatedMetrics();
 
   return makeAggregatedMetrics({
-    stats: {
-      ...defaults.stats,
-      uniqueUsers: 9,
-      cliUsers: 3,
-      reportStartDay: '2026-01-01',
-      reportEndDay: '2026-01-31',
+    overview: {
+      stats: {
+        ...defaults.overview.stats,
+        uniqueUsers: 9,
+        cliUsers: 3,
+        reportStartDay: '2026-01-01',
+        reportEndDay: '2026-01-31',
+      },
     },
-    dailyCliSessionData: [
-      {
-        date: '2026-01-16',
-        sessionCount: 2,
-        requestCount: 4,
-        promptCount: 3,
-        uniqueUsers: 2,
-      },
-      {
+    cli: {
+      dailyCliSessionData: [
+        {
+          date: '2026-01-16',
+          sessionCount: 2,
+          requestCount: 4,
+          promptCount: 3,
+          uniqueUsers: 2,
+        },
+        {
+          date: '2026-01-15',
+          sessionCount: 1,
+          requestCount: 2,
+          promptCount: 1,
+          uniqueUsers: 1,
+        },
+      ],
+      dailyCliTokenData: [{
         date: '2026-01-15',
-        sessionCount: 1,
+        outputTokens: 100,
+        promptTokens: 50,
         requestCount: 2,
-        promptCount: 1,
-        uniqueUsers: 1,
-      },
-    ],
-    dailyCliTokenData: [{
-      date: '2026-01-15',
-      outputTokens: 100,
-      promptTokens: 50,
-      requestCount: 2,
-    }],
-    dailyCliAdoptionTrend: [{
-      date: '2026-01-15',
-      newUsers: 1,
-      returningUsers: 0,
-      totalActiveUsers: 1,
-      cumulativeUsers: 1,
-    }],
-    modelBreakdownData: {
-      ...defaults.modelBreakdownData,
-      cliModels: [{
-        model: 'gpt-5',
-        total: 6,
-        dailyData: { '2026-01-15': 6 },
       }],
-      dates: ['fallback-model-date'],
-      cliTotal: 6,
+      dailyCliAdoptionTrend: [{
+        date: '2026-01-15',
+        newUsers: 1,
+        returningUsers: 0,
+        totalActiveUsers: 1,
+        cumulativeUsers: 1,
+      }],
+    },
+    models: {
+      modelBreakdownData: {
+        ...defaults.models.modelBreakdownData,
+        cliModels: [{
+          model: 'gpt-5',
+          total: 6,
+          dailyData: { '2026-01-15': 6 },
+        }],
+        dates: ['fallback-model-date'],
+        cliTotal: 6,
+      },
     },
   });
 }
@@ -109,38 +117,38 @@ describe('model details read model', () => {
     const model = selectModelDetailsReadModel(metrics);
 
     expect(model).toEqual({
-      allModels: metrics.modelBreakdownData.allModels,
-      modelCategories: metrics.modelBreakdownData.modelCategories,
-      autoModels: metrics.modelBreakdownData.autoModels,
-      autoModeAdoptionTrend: metrics.modelBreakdownData.autoModeAdoptionTrend,
-      dates: metrics.modelBreakdownData.dates,
+      allModels: metrics.models.modelBreakdownData.allModels,
+      modelCategories: metrics.models.modelBreakdownData.modelCategories,
+      autoModels: metrics.models.modelBreakdownData.autoModels,
+      autoModeAdoptionTrend: metrics.models.modelBreakdownData.autoModeAdoptionTrend,
+      dates: metrics.models.modelBreakdownData.dates,
       modelTotal: 11,
       autoTotal: 3.25,
     });
-    expect(model.allModels).toBe(metrics.modelBreakdownData.allModels);
-    expect(model.allModels[0]).toBe(metrics.modelBreakdownData.allModels[0]);
+    expect(model.allModels).toBe(metrics.models.modelBreakdownData.allModels);
+    expect(model.allModels[0]).toBe(metrics.models.modelBreakdownData.allModels[0]);
     expect(model.allModels[0].dailyData).toBe(
-      metrics.modelBreakdownData.allModels[0].dailyData
+      metrics.models.modelBreakdownData.allModels[0].dailyData
     );
-    expect(model.modelCategories).toBe(metrics.modelBreakdownData.modelCategories);
+    expect(model.modelCategories).toBe(metrics.models.modelBreakdownData.modelCategories);
     expect(model.modelCategories[0]).toBe(
-      metrics.modelBreakdownData.modelCategories[0]
+      metrics.models.modelBreakdownData.modelCategories[0]
     );
     expect(model.modelCategories[0].dailyData).toBe(
-      metrics.modelBreakdownData.modelCategories[0].dailyData
+      metrics.models.modelBreakdownData.modelCategories[0].dailyData
     );
-    expect(model.autoModels).toBe(metrics.modelBreakdownData.autoModels);
-    expect(model.autoModels[0]).toBe(metrics.modelBreakdownData.autoModels?.[0]);
+    expect(model.autoModels).toBe(metrics.models.modelBreakdownData.autoModels);
+    expect(model.autoModels[0]).toBe(metrics.models.modelBreakdownData.autoModels?.[0]);
     expect(model.autoModels[0].dailyData).toBe(
-      metrics.modelBreakdownData.autoModels?.[0].dailyData
+      metrics.models.modelBreakdownData.autoModels?.[0].dailyData
     );
     expect(model.autoModeAdoptionTrend).toBe(
-      metrics.modelBreakdownData.autoModeAdoptionTrend
+      metrics.models.modelBreakdownData.autoModeAdoptionTrend
     );
     expect(model.autoModeAdoptionTrend[0]).toBe(
-      metrics.modelBreakdownData.autoModeAdoptionTrend?.[0]
+      metrics.models.modelBreakdownData.autoModeAdoptionTrend?.[0]
     );
-    expect(model.dates).toBe(metrics.modelBreakdownData.dates);
+    expect(model.dates).toBe(metrics.models.modelBreakdownData.dates);
     expect(Object.keys(model)).toEqual([
       'allModels',
       'modelCategories',
@@ -170,31 +178,33 @@ describe('model details read model', () => {
       modelTotal: 0,
       autoTotal: 0,
     });
-    expect(model.allModels).toBe(metrics.modelBreakdownData.allModels);
-    expect(model.modelCategories).toBe(metrics.modelBreakdownData.modelCategories);
-    expect(model.autoModels).toBe(metrics.modelBreakdownData.autoModels);
+    expect(model.allModels).toBe(metrics.models.modelBreakdownData.allModels);
+    expect(model.modelCategories).toBe(metrics.models.modelBreakdownData.modelCategories);
+    expect(model.autoModels).toBe(metrics.models.modelBreakdownData.autoModels);
     expect(model.autoModeAdoptionTrend).toBe(
-      metrics.modelBreakdownData.autoModeAdoptionTrend
+      metrics.models.modelBreakdownData.autoModeAdoptionTrend
     );
-    expect(model.dates).toBe(metrics.modelBreakdownData.dates);
+    expect(model.dates).toBe(metrics.models.modelBreakdownData.dates);
   });
 
   it('keeps the existing optional-array fallbacks', () => {
     const defaults = makeAggregatedMetrics();
     const metrics = makeAggregatedMetrics({
-      modelBreakdownData: {
-        ...defaults.modelBreakdownData,
-        autoModels: undefined,
-        autoModeAdoptionTrend: undefined,
+      models: {
+        modelBreakdownData: {
+          ...defaults.models.modelBreakdownData,
+          autoModels: undefined,
+          autoModeAdoptionTrend: undefined,
+        },
       },
     });
 
     expect(selectModelDetailsReadModel(metrics)).toEqual({
-      allModels: metrics.modelBreakdownData.allModels,
-      modelCategories: metrics.modelBreakdownData.modelCategories,
+      allModels: metrics.models.modelBreakdownData.allModels,
+      modelCategories: metrics.models.modelBreakdownData.modelCategories,
       autoModels: [],
       autoModeAdoptionTrend: [],
-      dates: metrics.modelBreakdownData.dates,
+      dates: metrics.models.modelBreakdownData.dates,
       modelTotal: 0,
       autoTotal: 0,
     });
@@ -217,34 +227,34 @@ describe('CLI adoption read model', () => {
     const model = selectCliAdoptionReadModel(metrics);
 
     expect(model).toEqual({
-      stats: metrics.stats,
-      dailyCliSessionData: metrics.dailyCliSessionData,
-      dailyCliTokenData: metrics.dailyCliTokenData,
-      dailyCliAdoptionTrend: metrics.dailyCliAdoptionTrend,
-      cliModelEntries: metrics.modelBreakdownData.cliModels,
+      stats: metrics.overview.stats,
+      dailyCliSessionData: metrics.cli.dailyCliSessionData,
+      dailyCliTokenData: metrics.cli.dailyCliTokenData,
+      dailyCliAdoptionTrend: metrics.cli.dailyCliAdoptionTrend,
+      cliModelEntries: metrics.models.modelBreakdownData.cliModels,
       cliModelDates: ['2026-01-16', '2026-01-15'],
       cliModelTotal: 6,
       cliShare: 33.3,
     });
-    expect(model.stats).toBe(metrics.stats);
+    expect(model.stats).toBe(metrics.overview.stats);
     expect(model.stats.reportStartDay).toBe('2026-01-01');
     expect(model.stats.reportEndDay).toBe('2026-01-31');
-    expect(model.dailyCliSessionData).toBe(metrics.dailyCliSessionData);
-    expect(model.dailyCliSessionData[0]).toBe(metrics.dailyCliSessionData[0]);
-    expect(model.dailyCliTokenData).toBe(metrics.dailyCliTokenData);
-    expect(model.dailyCliTokenData[0]).toBe(metrics.dailyCliTokenData[0]);
-    expect(model.dailyCliAdoptionTrend).toBe(metrics.dailyCliAdoptionTrend);
+    expect(model.dailyCliSessionData).toBe(metrics.cli.dailyCliSessionData);
+    expect(model.dailyCliSessionData[0]).toBe(metrics.cli.dailyCliSessionData[0]);
+    expect(model.dailyCliTokenData).toBe(metrics.cli.dailyCliTokenData);
+    expect(model.dailyCliTokenData[0]).toBe(metrics.cli.dailyCliTokenData[0]);
+    expect(model.dailyCliAdoptionTrend).toBe(metrics.cli.dailyCliAdoptionTrend);
     expect(model.dailyCliAdoptionTrend[0]).toBe(
-      metrics.dailyCliAdoptionTrend[0]
+      metrics.cli.dailyCliAdoptionTrend[0]
     );
-    expect(model.cliModelEntries).toBe(metrics.modelBreakdownData.cliModels);
+    expect(model.cliModelEntries).toBe(metrics.models.modelBreakdownData.cliModels);
     expect(model.cliModelEntries[0]).toBe(
-      metrics.modelBreakdownData.cliModels?.[0]
+      metrics.models.modelBreakdownData.cliModels?.[0]
     );
     expect(model.cliModelEntries[0].dailyData).toBe(
-      metrics.modelBreakdownData.cliModels?.[0].dailyData
+      metrics.models.modelBreakdownData.cliModels?.[0].dailyData
     );
-    expect(model.cliModelDates).not.toBe(metrics.modelBreakdownData.dates);
+    expect(model.cliModelDates).not.toBe(metrics.models.modelBreakdownData.dates);
     expect(Object.keys(model)).toEqual([
       'stats',
       'dailyCliSessionData',
@@ -263,40 +273,46 @@ describe('CLI adoption read model', () => {
   it('falls back to the model date reference only when CLI sessions are empty', () => {
     const defaults = makeAggregatedMetrics();
     const metrics = makeAggregatedMetrics({
-      dailyCliSessionData: [],
-      modelBreakdownData: {
-        ...defaults.modelBreakdownData,
-        dates: ['2026-02-01', '2026-02-02'],
+      cli: { dailyCliSessionData: [] },
+      models: {
+        modelBreakdownData: {
+          ...defaults.models.modelBreakdownData,
+          dates: ['2026-02-01', '2026-02-02'],
+        },
       },
     });
 
     const model = selectCliAdoptionReadModel(metrics);
 
-    expect(model.cliModelDates).toBe(metrics.modelBreakdownData.dates);
+    expect(model.cliModelDates).toBe(metrics.models.modelBreakdownData.dates);
     expect(model.cliModelDates).toEqual(['2026-02-01', '2026-02-02']);
   });
 
   it('keeps CLI model entry, total, and share fallback semantics', () => {
     const defaults = makeAggregatedMetrics();
     const metrics = makeAggregatedMetrics({
-      stats: {
-        ...defaults.stats,
-        uniqueUsers: 0,
-        cliUsers: 8,
-        reportStartDay: 'not-a-start-date',
-        reportEndDay: 'not-an-end-date',
+      overview: {
+        stats: {
+          ...defaults.overview.stats,
+          uniqueUsers: 0,
+          cliUsers: 8,
+          reportStartDay: 'not-a-start-date',
+          reportEndDay: 'not-an-end-date',
+        },
       },
-      modelBreakdownData: {
-        ...defaults.modelBreakdownData,
-        cliModels: undefined,
-        cliTotal: undefined,
+      models: {
+        modelBreakdownData: {
+          ...defaults.models.modelBreakdownData,
+          cliModels: undefined,
+          cliTotal: undefined,
+        },
       },
     });
 
     const model = selectCliAdoptionReadModel(metrics);
 
     expect(model.cliModelEntries).toEqual([]);
-    expect(model.cliModelDates).toBe(metrics.modelBreakdownData.dates);
+    expect(model.cliModelDates).toBe(metrics.models.modelBreakdownData.dates);
     expect(model.cliModelTotal).toBe(0);
     expect(model.cliShare).toBe(0);
     expect(model.stats.reportStartDay).toBe('not-a-start-date');
@@ -306,14 +322,18 @@ describe('CLI adoption read model', () => {
   it('does not replace defined signed totals or alter the share calculation', () => {
     const defaults = makeAggregatedMetrics();
     const metrics = makeAggregatedMetrics({
-      stats: {
-        ...defaults.stats,
-        uniqueUsers: 3,
-        cliUsers: -1,
+      overview: {
+        stats: {
+          ...defaults.overview.stats,
+          uniqueUsers: 3,
+          cliUsers: -1,
+        },
       },
-      modelBreakdownData: {
-        ...defaults.modelBreakdownData,
-        cliTotal: -4.5,
+      models: {
+        modelBreakdownData: {
+          ...defaults.models.modelBreakdownData,
+          cliTotal: -4.5,
+        },
       },
     });
 
@@ -329,7 +349,7 @@ describe('CLI adoption read model', () => {
     const model = selectCliAdoptionReadModel(metrics);
 
     expect(model).toEqual({
-      stats: metrics.stats,
+      stats: metrics.overview.stats,
       dailyCliSessionData: [],
       dailyCliTokenData: [],
       dailyCliAdoptionTrend: [],
@@ -338,12 +358,12 @@ describe('CLI adoption read model', () => {
       cliModelTotal: 0,
       cliShare: 0,
     });
-    expect(model.stats).toBe(metrics.stats);
-    expect(model.dailyCliSessionData).toBe(metrics.dailyCliSessionData);
-    expect(model.dailyCliTokenData).toBe(metrics.dailyCliTokenData);
-    expect(model.dailyCliAdoptionTrend).toBe(metrics.dailyCliAdoptionTrend);
-    expect(model.cliModelEntries).toBe(metrics.modelBreakdownData.cliModels);
-    expect(model.cliModelDates).toBe(metrics.modelBreakdownData.dates);
+    expect(model.stats).toBe(metrics.overview.stats);
+    expect(model.dailyCliSessionData).toBe(metrics.cli.dailyCliSessionData);
+    expect(model.dailyCliTokenData).toBe(metrics.cli.dailyCliTokenData);
+    expect(model.dailyCliAdoptionTrend).toBe(metrics.cli.dailyCliAdoptionTrend);
+    expect(model.cliModelEntries).toBe(metrics.models.modelBreakdownData.cliModels);
+    expect(model.cliModelDates).toBe(metrics.models.modelBreakdownData.dates);
   });
 
   it('does not mutate the aggregate input', () => {

--- a/src/read-models/adoption.ts
+++ b/src/read-models/adoption.ts
@@ -1,23 +1,23 @@
 import type { AggregatedMetrics } from '../types/aggregatedMetrics';
 
 export interface CopilotAdoptionReadModel {
-  featureAdoptionData: AggregatedMetrics['featureAdoptionData'];
-  agentModeHeatmapData: AggregatedMetrics['agentModeHeatmapData'];
-  stats: AggregatedMetrics['stats'];
-  dailyAdoptionTrend: AggregatedMetrics['dailyAdoptionTrend'];
-  dailyCloudAgentAdoptionData: AggregatedMetrics['dailyCloudAgentAdoptionData'];
-  dailyCodeReviewAdoptionData: AggregatedMetrics['dailyCodeReviewAdoptionData'];
+  featureAdoptionData: AggregatedMetrics['adoption']['featureAdoptionData'];
+  agentModeHeatmapData: AggregatedMetrics['adoption']['agentModeHeatmapData'];
+  stats: AggregatedMetrics['overview']['stats'];
+  dailyAdoptionTrend: AggregatedMetrics['adoption']['dailyAdoptionTrend'];
+  dailyCloudAgentAdoptionData: AggregatedMetrics['adoption']['dailyCloudAgentAdoptionData'];
+  dailyCodeReviewAdoptionData: AggregatedMetrics['adoption']['dailyCodeReviewAdoptionData'];
 }
 
 export function selectCopilotAdoptionReadModel(
   metrics: AggregatedMetrics
 ): CopilotAdoptionReadModel {
   return {
-    featureAdoptionData: metrics.featureAdoptionData,
-    agentModeHeatmapData: metrics.agentModeHeatmapData,
-    stats: metrics.stats,
-    dailyAdoptionTrend: metrics.dailyAdoptionTrend,
-    dailyCloudAgentAdoptionData: metrics.dailyCloudAgentAdoptionData,
-    dailyCodeReviewAdoptionData: metrics.dailyCodeReviewAdoptionData,
+    featureAdoptionData: metrics.adoption.featureAdoptionData,
+    agentModeHeatmapData: metrics.adoption.agentModeHeatmapData,
+    stats: metrics.overview.stats,
+    dailyAdoptionTrend: metrics.adoption.dailyAdoptionTrend,
+    dailyCloudAgentAdoptionData: metrics.adoption.dailyCloudAgentAdoptionData,
+    dailyCodeReviewAdoptionData: metrics.adoption.dailyCodeReviewAdoptionData,
   };
 }

--- a/src/read-models/aiAdoptionPhases.ts
+++ b/src/read-models/aiAdoptionPhases.ts
@@ -1,13 +1,13 @@
 import type { AggregatedMetrics } from '../types/aggregatedMetrics';
 
 export interface AiAdoptionPhaseReadModel {
-  aiAdoptionPhaseData: AggregatedMetrics['aiAdoptionPhaseData'];
+  aiAdoptionPhaseData: AggregatedMetrics['ai']['aiAdoptionPhaseData'];
 }
 
 export function selectAiAdoptionPhaseReadModel(
   metrics: AggregatedMetrics
 ): AiAdoptionPhaseReadModel {
   return {
-    aiAdoptionPhaseData: metrics.aiAdoptionPhaseData,
+    aiAdoptionPhaseData: metrics.ai.aiAdoptionPhaseData,
   };
 }

--- a/src/read-models/aiCredits.ts
+++ b/src/read-models/aiCredits.ts
@@ -1,11 +1,11 @@
 import type { AggregatedMetrics } from '../types/aggregatedMetrics';
 
 export interface AiCreditsReadModel {
-  reportStartDay: AggregatedMetrics['stats']['reportStartDay'];
-  reportEndDay: AggregatedMetrics['stats']['reportEndDay'];
-  dailyAiCreditsData: AggregatedMetrics['dailyAiCreditsData'];
-  userSummaries: AggregatedMetrics['userSummaries'];
-  usageDistributionData: AggregatedMetrics['usageDistributionData'];
+  reportStartDay: AggregatedMetrics['overview']['stats']['reportStartDay'];
+  reportEndDay: AggregatedMetrics['overview']['stats']['reportEndDay'];
+  dailyAiCreditsData: AggregatedMetrics['ai']['dailyAiCreditsData'];
+  userSummaries: AggregatedMetrics['users']['userSummaries'];
+  usageDistributionData: AggregatedMetrics['ai']['usageDistributionData'];
   totalAiCreditsUsed: number;
   onUserClick: (userLogin: string, userId: number) => void;
 }
@@ -16,10 +16,9 @@ export function selectAiCreditsReadModel(
 ): AiCreditsReadModel {
   const {
     stats: { reportStartDay, reportEndDay },
-    dailyAiCreditsData = [],
-    userSummaries,
-    usageDistributionData = [],
-  } = metrics;
+  } = metrics.overview;
+  const { userSummaries } = metrics.users;
+  const { dailyAiCreditsData = [], usageDistributionData = [] } = metrics.ai;
 
   return {
     reportStartDay,

--- a/src/read-models/cliAdoption.ts
+++ b/src/read-models/cliAdoption.ts
@@ -1,12 +1,12 @@
 import type { AggregatedMetrics } from '../types/aggregatedMetrics';
 
 export interface CliAdoptionReadModel {
-  stats: AggregatedMetrics['stats'];
-  dailyCliSessionData: AggregatedMetrics['dailyCliSessionData'];
-  dailyCliTokenData: AggregatedMetrics['dailyCliTokenData'];
-  dailyCliAdoptionTrend: AggregatedMetrics['dailyCliAdoptionTrend'];
+  stats: AggregatedMetrics['overview']['stats'];
+  dailyCliSessionData: AggregatedMetrics['cli']['dailyCliSessionData'];
+  dailyCliTokenData: AggregatedMetrics['cli']['dailyCliTokenData'];
+  dailyCliAdoptionTrend: AggregatedMetrics['cli']['dailyCliAdoptionTrend'];
   cliModelEntries: NonNullable<
-    AggregatedMetrics['modelBreakdownData']['cliModels']
+    AggregatedMetrics['models']['modelBreakdownData']['cliModels']
   >;
   cliModelDates: string[];
   cliModelTotal: number;
@@ -16,9 +16,11 @@ export interface CliAdoptionReadModel {
 export function selectCliAdoptionReadModel(
   metrics: AggregatedMetrics
 ): CliAdoptionReadModel {
-  const { stats, dailyCliSessionData, dailyCliTokenData, dailyCliAdoptionTrend } =
-    metrics;
-  const { cliModels = [], dates, cliTotal = 0 } = metrics.modelBreakdownData;
+  const { stats } = metrics.overview;
+  const { dailyCliSessionData, dailyCliTokenData, dailyCliAdoptionTrend } =
+    metrics.cli;
+  const { cliModels = [], dates, cliTotal = 0 } =
+    metrics.models.modelBreakdownData;
 
   return {
     stats,

--- a/src/read-models/clients.ts
+++ b/src/read-models/clients.ts
@@ -1,7 +1,7 @@
 import type { AggregatedMetrics } from '../types/aggregatedMetrics';
 
 export interface ClientsReadModel {
-  ideStats: AggregatedMetrics['ideStats'];
+  ideStats: AggregatedMetrics['clients']['ideStats'];
   multiIDEUsersCount: number;
   totalUniqueIDEUsers: number;
   cliUsers: number;
@@ -11,7 +11,7 @@ export interface ClientsReadModel {
 }
 
 export interface ClientVersionsReadModel {
-  pluginVersionData: AggregatedMetrics['pluginVersionData'];
+  pluginVersionData: AggregatedMetrics['clients']['pluginVersionData'];
   reportStartDay: string;
 }
 
@@ -19,19 +19,19 @@ export function selectClientsReadModel(
   metrics: AggregatedMetrics
 ): ClientsReadModel {
   return {
-    ideStats: metrics.ideStats,
-    multiIDEUsersCount: metrics.multiIDEUsersCount,
-    totalUniqueIDEUsers: metrics.totalUniqueIDEUsers,
-    cliUsers: metrics.stats.cliUsers,
-    cliSessions: metrics.dailyCliSessionData.reduce(
+    ideStats: metrics.clients.ideStats,
+    multiIDEUsersCount: metrics.clients.multiIDEUsersCount,
+    totalUniqueIDEUsers: metrics.clients.totalUniqueIDEUsers,
+    cliUsers: metrics.overview.stats.cliUsers,
+    cliSessions: metrics.cli.dailyCliSessionData.reduce(
       (sum, day) => sum + day.sessionCount,
       0
     ),
-    cliLocAdded: metrics.cliImpactData.reduce(
+    cliLocAdded: metrics.impact.cliImpactData.reduce(
       (sum, day) => sum + day.locAdded,
       0
     ),
-    cliLocDeleted: metrics.cliImpactData.reduce(
+    cliLocDeleted: metrics.impact.cliImpactData.reduce(
       (sum, day) => sum + day.locDeleted,
       0
     ),
@@ -42,7 +42,7 @@ export function selectClientVersionsReadModel(
   metrics: AggregatedMetrics
 ): ClientVersionsReadModel {
   return {
-    pluginVersionData: metrics.pluginVersionData,
-    reportStartDay: metrics.stats.reportStartDay,
+    pluginVersionData: metrics.clients.pluginVersionData,
+    reportStartDay: metrics.overview.stats.reportStartDay,
   };
 }

--- a/src/read-models/impact.ts
+++ b/src/read-models/impact.ts
@@ -1,25 +1,25 @@
 import type { AggregatedMetrics } from '../types/aggregatedMetrics';
 
 export interface CopilotImpactReadModel {
-  agentImpactData: AggregatedMetrics['agentImpactData'];
-  codeCompletionImpactData: AggregatedMetrics['codeCompletionImpactData'];
-  editModeImpactData: AggregatedMetrics['editModeImpactData'];
-  inlineModeImpactData: AggregatedMetrics['inlineModeImpactData'];
-  askModeImpactData: AggregatedMetrics['askModeImpactData'];
-  cliImpactData: AggregatedMetrics['cliImpactData'];
-  joinedImpactData: AggregatedMetrics['joinedImpactData'];
+  agentImpactData: AggregatedMetrics['impact']['agentImpactData'];
+  codeCompletionImpactData: AggregatedMetrics['impact']['codeCompletionImpactData'];
+  editModeImpactData: AggregatedMetrics['impact']['editModeImpactData'];
+  inlineModeImpactData: AggregatedMetrics['impact']['inlineModeImpactData'];
+  askModeImpactData: AggregatedMetrics['impact']['askModeImpactData'];
+  cliImpactData: AggregatedMetrics['impact']['cliImpactData'];
+  joinedImpactData: AggregatedMetrics['impact']['joinedImpactData'];
 }
 
 export function selectCopilotImpactReadModel(
   metrics: AggregatedMetrics
 ): CopilotImpactReadModel {
   return {
-    agentImpactData: metrics.agentImpactData,
-    codeCompletionImpactData: metrics.codeCompletionImpactData,
-    editModeImpactData: metrics.editModeImpactData,
-    inlineModeImpactData: metrics.inlineModeImpactData,
-    askModeImpactData: metrics.askModeImpactData,
-    cliImpactData: metrics.cliImpactData,
-    joinedImpactData: metrics.joinedImpactData,
+    agentImpactData: metrics.impact.agentImpactData,
+    codeCompletionImpactData: metrics.impact.codeCompletionImpactData,
+    editModeImpactData: metrics.impact.editModeImpactData,
+    inlineModeImpactData: metrics.impact.inlineModeImpactData,
+    askModeImpactData: metrics.impact.askModeImpactData,
+    cliImpactData: metrics.impact.cliImpactData,
+    joinedImpactData: metrics.impact.joinedImpactData,
   };
 }

--- a/src/read-models/languages.ts
+++ b/src/read-models/languages.ts
@@ -1,19 +1,19 @@
 import type { AggregatedMetrics } from '../types/aggregatedMetrics';
 
 export interface LanguagesReadModel {
-  languageStats: AggregatedMetrics['languageStats'];
-  languageFeatureImpactData: AggregatedMetrics['languageFeatureImpactData'];
-  dailyLanguageGenerationsData: AggregatedMetrics['dailyLanguageGenerationsData'];
-  dailyLanguageLocData: AggregatedMetrics['dailyLanguageLocData'];
+  languageStats: AggregatedMetrics['languages']['languageStats'];
+  languageFeatureImpactData: AggregatedMetrics['languages']['languageFeatureImpactData'];
+  dailyLanguageGenerationsData: AggregatedMetrics['languages']['dailyLanguageGenerationsData'];
+  dailyLanguageLocData: AggregatedMetrics['languages']['dailyLanguageLocData'];
 }
 
 export function selectLanguagesReadModel(
   metrics: AggregatedMetrics
 ): LanguagesReadModel {
   return {
-    languageStats: metrics.languageStats,
-    languageFeatureImpactData: metrics.languageFeatureImpactData,
-    dailyLanguageGenerationsData: metrics.dailyLanguageGenerationsData,
-    dailyLanguageLocData: metrics.dailyLanguageLocData,
+    languageStats: metrics.languages.languageStats,
+    languageFeatureImpactData: metrics.languages.languageFeatureImpactData,
+    dailyLanguageGenerationsData: metrics.languages.dailyLanguageGenerationsData,
+    dailyLanguageLocData: metrics.languages.dailyLanguageLocData,
   };
 }

--- a/src/read-models/models.ts
+++ b/src/read-models/models.ts
@@ -1,13 +1,13 @@
 import type { AggregatedMetrics } from '../types/aggregatedMetrics';
 
 export interface ModelDetailsReadModel {
-  allModels: AggregatedMetrics['modelBreakdownData']['allModels'];
-  modelCategories: AggregatedMetrics['modelBreakdownData']['modelCategories'];
-  autoModels: NonNullable<AggregatedMetrics['modelBreakdownData']['autoModels']>;
+  allModels: AggregatedMetrics['models']['modelBreakdownData']['allModels'];
+  modelCategories: AggregatedMetrics['models']['modelBreakdownData']['modelCategories'];
+  autoModels: NonNullable<AggregatedMetrics['models']['modelBreakdownData']['autoModels']>;
   autoModeAdoptionTrend: NonNullable<
-    AggregatedMetrics['modelBreakdownData']['autoModeAdoptionTrend']
+    AggregatedMetrics['models']['modelBreakdownData']['autoModeAdoptionTrend']
   >;
-  dates: AggregatedMetrics['modelBreakdownData']['dates'];
+  dates: AggregatedMetrics['models']['modelBreakdownData']['dates'];
   modelTotal: number;
   autoTotal: number;
 }
@@ -22,7 +22,7 @@ export function selectModelDetailsReadModel(
     autoModeAdoptionTrend = [],
     dates,
     modelTotal,
-  } = metrics.modelBreakdownData;
+  } = metrics.models.modelBreakdownData;
 
   return {
     allModels,

--- a/src/read-models/overview.ts
+++ b/src/read-models/overview.ts
@@ -3,27 +3,27 @@ import type { AggregatedMetrics } from '../types/aggregatedMetrics';
 export interface OverviewReadModel {
   reportStartDay: string;
   reportEndDay: string;
-  engagementData: AggregatedMetrics['engagementData'];
-  chatUsersData: AggregatedMetrics['chatUsersData'];
-  chatRequestsData: AggregatedMetrics['chatRequestsData'];
+  engagementData: AggregatedMetrics['overview']['engagementData'];
+  chatUsersData: AggregatedMetrics['overview']['chatUsersData'];
+  chatRequestsData: AggregatedMetrics['overview']['chatRequestsData'];
 }
 
 export interface ExecutiveSummaryReadModel {
   reportStartDay: string;
   reportEndDay: string;
-  joinedImpactData: AggregatedMetrics['joinedImpactData'];
-  agentImpactData: AggregatedMetrics['agentImpactData'];
-  codeCompletionImpactData: AggregatedMetrics['codeCompletionImpactData'];
-  featureAdoptionData: AggregatedMetrics['featureAdoptionData'];
+  joinedImpactData: AggregatedMetrics['impact']['joinedImpactData'];
+  agentImpactData: AggregatedMetrics['impact']['agentImpactData'];
+  codeCompletionImpactData: AggregatedMetrics['impact']['codeCompletionImpactData'];
+  featureAdoptionData: AggregatedMetrics['adoption']['featureAdoptionData'];
 }
 
 export function selectOverviewReadModel(metrics: AggregatedMetrics): OverviewReadModel {
   return {
-    reportStartDay: metrics.stats.reportStartDay,
-    reportEndDay: metrics.stats.reportEndDay,
-    engagementData: metrics.engagementData,
-    chatUsersData: metrics.chatUsersData,
-    chatRequestsData: metrics.chatRequestsData,
+    reportStartDay: metrics.overview.stats.reportStartDay,
+    reportEndDay: metrics.overview.stats.reportEndDay,
+    engagementData: metrics.overview.engagementData,
+    chatUsersData: metrics.overview.chatUsersData,
+    chatRequestsData: metrics.overview.chatRequestsData,
   };
 }
 
@@ -31,11 +31,11 @@ export function selectExecutiveSummaryReadModel(
   metrics: AggregatedMetrics
 ): ExecutiveSummaryReadModel {
   return {
-    reportStartDay: metrics.stats.reportStartDay,
-    reportEndDay: metrics.stats.reportEndDay,
-    joinedImpactData: metrics.joinedImpactData,
-    agentImpactData: metrics.agentImpactData,
-    codeCompletionImpactData: metrics.codeCompletionImpactData,
-    featureAdoptionData: metrics.featureAdoptionData,
+    reportStartDay: metrics.overview.stats.reportStartDay,
+    reportEndDay: metrics.overview.stats.reportEndDay,
+    joinedImpactData: metrics.impact.joinedImpactData,
+    agentImpactData: metrics.impact.agentImpactData,
+    codeCompletionImpactData: metrics.impact.codeCompletionImpactData,
+    featureAdoptionData: metrics.adoption.featureAdoptionData,
   };
 }

--- a/src/read-models/userDetails.ts
+++ b/src/read-models/userDetails.ts
@@ -36,7 +36,7 @@ export function selectUserDetailsRouteReadModel(
     return { status: 'pending', selectedUser };
   }
 
-  const userSummary = metrics.userSummaries.find(
+  const userSummary = metrics.users.userSummaries.find(
     (summary) => summary.user_id === selectedUser.id
   );
   if (!userSummary) {

--- a/src/read-models/users.ts
+++ b/src/read-models/users.ts
@@ -1,11 +1,11 @@
 import type { AggregatedMetrics } from '../types/aggregatedMetrics';
 
 export interface UsersReadModel {
-  users: AggregatedMetrics['userSummaries'];
+  users: AggregatedMetrics['users']['userSummaries'];
 }
 
 export function selectUsersReadModel(metrics: AggregatedMetrics): UsersReadModel {
   return {
-    users: metrics.userSummaries,
+    users: metrics.users.userSummaries,
   };
 }

--- a/src/types/aggregatedMetrics.ts
+++ b/src/types/aggregatedMetrics.ts
@@ -30,16 +30,26 @@ import type {
   DailyAiCreditsData,
 } from '../domain/calculators';
 
-export interface AggregatedMetrics {
+export interface OverviewMetricsSlice {
   stats: MetricsStats;
-  userSummaries: UserSummary[];
   engagementData: DailyEngagementData[];
   chatUsersData: DailyChatUsersData[];
   chatRequestsData: DailyChatRequestsData[];
-  languageStats: LanguageStats[];
-  modelUsageData: DailyModelUsageData[];
+}
+
+export interface UsersMetricsSlice {
+  userSummaries: UserSummary[];
+}
+
+export interface AdoptionMetricsSlice {
   featureAdoptionData: FeatureAdoptionData;
   agentModeHeatmapData: AgentModeHeatmapData[];
+  dailyAdoptionTrend: DailyAdoptionTrend[];
+  dailyCloudAgentAdoptionData: DailyCloudAgentAdoptionData[];
+  dailyCodeReviewAdoptionData: DailyCodeReviewAdoptionData[];
+}
+
+export interface ImpactMetricsSlice {
   agentImpactData: AgentImpactData[];
   codeCompletionImpactData: CodeCompletionImpactData[];
   editModeImpactData: ModeImpactData[];
@@ -47,23 +57,49 @@ export interface AggregatedMetrics {
   askModeImpactData: ModeImpactData[];
   cliImpactData: ModeImpactData[];
   joinedImpactData: ModeImpactData[];
+}
+
+export interface LanguagesMetricsSlice {
+  languageStats: LanguageStats[];
+  languageFeatureImpactData: LanguageFeatureImpactData;
+  dailyLanguageGenerationsData: DailyLanguageChartData;
+  dailyLanguageLocData: DailyLanguageChartData;
+}
+
+export interface ClientsMetricsSlice {
   ideStats: IDEStatsData[];
   multiIDEUsersCount: number;
   totalUniqueIDEUsers: number;
   pluginVersionData: PluginVersionAnalysisData;
-  languageFeatureImpactData: LanguageFeatureImpactData;
-  dailyLanguageGenerationsData: DailyLanguageChartData;
-  dailyLanguageLocData: DailyLanguageChartData;
+}
+
+export interface ModelsMetricsSlice {
+  modelUsageData: DailyModelUsageData[];
   modelBreakdownData: ModelBreakdownData;
+}
+
+export interface CliMetricsSlice {
   dailyCliSessionData: DailyCliSessionData[];
   dailyCliTokenData: DailyCliTokenData[];
   dailyCliAdoptionTrend: DailyCliAdoptionTrend[];
-  dailyAdoptionTrend: DailyAdoptionTrend[];
-  dailyCloudAgentAdoptionData: DailyCloudAgentAdoptionData[];
-  dailyCodeReviewAdoptionData: DailyCodeReviewAdoptionData[];
+}
+
+export interface AiMetricsSlice {
   aiAdoptionPhaseData: AiAdoptionPhaseData[];
   usageDistributionData: UsageDistributionBucket[];
   dailyAiCreditsData: DailyAiCreditsData[];
+}
+
+export interface AggregatedMetrics {
+  overview: OverviewMetricsSlice;
+  users: UsersMetricsSlice;
+  adoption: AdoptionMetricsSlice;
+  impact: ImpactMetricsSlice;
+  languages: LanguagesMetricsSlice;
+  clients: ClientsMetricsSlice;
+  models: ModelsMetricsSlice;
+  cli: CliMetricsSlice;
+  ai: AiMetricsSlice;
 }
 
 export interface UserDetailedMetrics {

--- a/src/workers/__tests__/metricsWorker.test.ts
+++ b/src/workers/__tests__/metricsWorker.test.ts
@@ -1,4 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  AGGREGATED_METRICS_SLICE_KEYS,
+  FORMER_FLAT_AGGREGATE_KEYS,
+} from '../../__tests__/factories/aggregatedMetrics';
 import { makeMetric } from '../../__tests__/factories/metrics';
 import type { WorkerRequest, WorkerResponse } from '../types';
 
@@ -141,7 +145,14 @@ describe('metricsWorker protocol', () => {
     expect(parseResult!.errors).toEqual([
       { fileIndex: 2, fileName: 'bad.ndjson', error: 'bad file stream' },
     ]);
-    expect(parseResult!.result.stats.totalRecords).toBe(1);
+    expect(Object.keys(parseResult!.result)).toEqual(
+      Object.keys(AGGREGATED_METRICS_SLICE_KEYS)
+    );
+    for (const key of FORMER_FLAT_AGGREGATE_KEYS) {
+      expect(parseResult!.result).not.toHaveProperty(key);
+    }
+    expect(parseResult!.result).not.toHaveProperty('metrics');
+    expect(parseResult!.result.overview.stats.totalRecords).toBe(1);
 
     responses.length = 0;
 

--- a/src/workers/__tests__/metricsWorkerClient.test.ts
+++ b/src/workers/__tests__/metricsWorkerClient.test.ts
@@ -80,7 +80,7 @@ describe('MetricsWorkerClient', () => {
 
     await expect(detailsPromise).resolves.toBeNull();
     await expect(parsePromise).resolves.toEqual({
-      result: expect.objectContaining({ stats: expect.any(Object) }),
+      result: expect.objectContaining({ overview: expect.any(Object) }),
       enterpriseName: 'acme',
       recordCount: 1,
       errors: [],


### PR DESCRIPTION
## Why

The worker/UI boundary was a flat collection of unrelated aggregate fields, making ownership and evolution harder to reason about. This groups every metric under one canonical domain slice while preserving worker isolation, values, references, and existing UI projections.

| Commit | Change |
|--------|--------|
| `refactor: group the aggregate contract` | Define the nine-slice contract, assemble finalized family results directly, and migrate every production selector and consumer. |
| `test: characterize the grouped aggregate payload` | Cover exact ownership, finalizer identity, worker protocol shape, former-root absence, and payload-size measurement. |
| `docs: document the grouped aggregate contract` | Update architecture, data flow, schema ownership, and Phase 8 status. |