### PR TITLE
chore: enforce final architecture boundaries

### DIFF
--- a/docs/project-overview.md
+++ b/docs/project-overview.md
@@ -37,9 +37,10 @@ Next.js App Router SPA, TypeScript, Tailwind CSS. All rendering is client-side.
 
 **Raw metrics never leave the worker.** The `parseAndAggregate` flow parses files and aggregates them into a compact, grouped `AggregatedMetrics` object entirely within the worker. Only this pre-aggregated result is transferred to the main thread. This significantly reduces memory footprint for large datasets.
 
-**Two React contexts for state:**
+**Three React contexts for main-thread state and worker access:**
 - `MetricsContext` (`src/components/MetricsContext.tsx`) — stores the `AggregatedMetrics` result, loading/error/warning state, and data actions
-- `NavigationContext` (`src/state/NavigationContext.tsx`) — manages current view, selected user/model, and navigation actions
+- `NavigationContext` (`src/state/NavigationContext.tsx`) — manages current view and selected user
+- `MetricsWorkerContext` (`src/state/MetricsWorkerContext.tsx`) — owns the main-thread worker client lifecycle and exposes parse, user-detail, and reset operations
 
 **All view components consume pre-aggregated data.** No component accesses raw `CopilotMetrics[]` directly. The canonical `AggregatedMetrics` worker/UI contract is declared in `src/types/aggregatedMetrics.ts` and groups every aggregate under one owning domain slice. Feature read-model selectors in `src/read-models/` navigate only the slices they need; overview, executive summary, users, user details, Copilot adoption, AI adoption phases, Copilot impact, languages, clients, client versions, model details, CLI adoption, and AI credits retain their narrow runtime projections. Standard route adapters in `src/components/layout/routes/` own the selector and existing view for each non-user-details route, so only the selected route computes its projection. The specialized `UserDetailsRoute` owns user selection, on-demand worker requests, stale-result protection, redirects, recovery, and delivery of the user-details view model. The worker retains a compact user-detail accumulator so it can serve those requests without moving raw records onto the main thread.
 
@@ -56,8 +57,8 @@ Next.js App Router SPA, TypeScript, Tailwind CSS. All rendering is client-side.
 | `src/infra/` | Streaming metrics file parser |
 | `src/domain/calculators/` | Individual metric calculators (stats, engagement, model usage, impact, etc.) |
 | `src/hooks/` | Reusable React hooks (file upload, sorting, search) |
-| `src/workers/` | Web Worker entry point, client API, message types |
-| `src/state/` | Navigation context |
+| `src/workers/` | Framework-free Web Worker entry point, client API, message types |
+| `src/state/` | Navigation context and main-thread worker provider |
 | `src/read-models/` | Pure feature projections over the aggregate contract |
 | `src/types/` | TypeScript type definitions |
 | `src/utils/` | Formatting and utility helpers |
@@ -68,7 +69,7 @@ Next.js App Router SPA, TypeScript, Tailwind CSS. All rendering is client-side.
 
 ### 3.4. Feature Read-Model Boundaries
 
-The successful worker payload is one grouped `AggregatedMetrics` object. Each former root field has exactly one owner:
+The successful worker payload is one grouped `AggregatedMetrics` object. Each aggregate field has exactly one owning slice:
 
 ```text
 AggregatedMetrics
@@ -96,7 +97,35 @@ Established boundaries cover:
 - model details and CLI adoption
 - AI credits
 
-Phase 4 feature read-model boundaries, Phase 7 thin view routing, and Phase 8 grouped aggregate contract migration are complete. The typed standard-route registry delegates all non-user-details routes, while `UserDetailsRoute` owns the complete specialized lifecycle. `ViewRouter` retains only metrics-wide gates and top-level route selection. Phase 6 feature-view organization remains deferred.
+Phase 4 feature read-model boundaries, Phase 7 thin view routing, Phase 8 grouped aggregate contract migration, and Phase 10 boundary enforcement/cleanup are complete. The typed standard-route registry delegates all non-user-details routes, while `UserDetailsRoute` owns the complete specialized lifecycle. `ViewRouter` retains only metrics-wide gates and top-level route selection. Phase 6 feature-view organization remains deferred. Phase 9 input-validation work was removed from scope because metrics inputs are validated upstream before they reach this viewer.
+
+### 3.5. Enforced Dependency Direction
+
+Phase 10 adds targeted ESLint import restrictions that make the current layering difficult to regress without introducing a new architecture framework:
+
+```text
+app/providers
+  -> state contexts + UI contexts
+state + hooks + layout routes
+  -> worker client, navigation, metrics context, read models
+read-models
+  -> grouped aggregate contract and pure domain helpers
+components/views
+  -> read models, shared UI, charts, contract types
+components/ui + components/charts
+  -> shared types/utilities only; no layout routes or feature modules
+workers
+  -> infra parser, domain aggregation, worker message contracts
+domain
+  -> contracts, calculators, and pure domain helpers only
+```
+
+The automated boundaries are intentionally focused:
+- UI components, layout routes, and read models cannot import `src/domain/metricsAggregator.ts` or `src/domain/aggregation/**`
+- production `src/domain/**` and `src/workers/**` modules cannot import React, Next.js, component, or state-context modules
+- shared UI primitives and shared charts cannot import feature modules or layout route modules
+
+Tests may import lower-level helpers to build fixtures and characterize behavior, but production code must follow the directions above.
 
 ---
 
@@ -105,7 +134,7 @@ Phase 4 feature read-model boundaries, Phase 7 thin view routing, and Phase 8 gr
 ```mermaid
 flowchart LR
   A[User uploads .ndjson file] --> B[useFileUpload hook]
-  B --> C[MetricsWorkerProvider-owned client]
+  B --> C[state/MetricsWorkerContext-owned client]
   C -->|postMessage: parseAndAggregate| W[Web Worker: parse + aggregate]
   W -->|parseAndAggregateResult: grouped slices| D[MetricsContext stores AggregatedMetrics + warnings]
   D --> VR[ViewRouter resolves current route]
@@ -122,9 +151,9 @@ flowchart LR
 
 1. `useFileUpload` validates file extensions and requests parsing through the typed worker client exposed by `MetricsWorkerProvider`
 2. The worker streams each file through `src/infra/metricsFileParser.ts` using the `File.stream()` API, parses lines via `parseMetricsLine`, and applies string interning (`StringPool`) for memory efficiency
-3. Records using deprecated LOC fields or missing required fields are skipped
+3. Records using deprecated LOC fields or missing required fields are skipped; broader input validation is intentionally external to the app
 4. The worker runs `aggregateMetrics()` on the parsed data, retains the compact user-detail accumulator for on-demand requests, and returns the grouped `AggregatedMetrics` result, enterprise name, record count, and any per-file parse errors (surfaced as a non-fatal warning in the UI when partial failures occur). The request protocol and lifecycle are unchanged; raw records remain off the main thread.
-5. `MetricsWorkerProvider` is the application-level lifecycle owner. Its client creates the browser Worker lazily, correlates requests and progress responses, cancels pending work on reusable resets, and permanently disposes the Worker when the provider unmounts.
+5. `MetricsWorkerProvider` in `src/state/` is the application-level lifecycle owner. Its client creates the browser Worker lazily, correlates requests and progress responses, cancels pending work on reusable resets, and permanently disposes the Worker when the provider unmounts.
 
 ### 4.2. Aggregation
 
@@ -136,7 +165,7 @@ Phase 5 modular aggregation orchestration and Phase 8 grouped contract assembly 
 
 ### 4.3. Views
 
-`ViewRouter` (`src/components/layout/ViewRouter.tsx`) is the thin top-level coordinator for metrics-wide upload, fatal-error, and loading gates. It selects either the typed standard-route outlet or the specialized `UserDetailsRoute`. Each standard adapter invokes its feature selector lazily and renders the existing view with a narrow shared route context. `UserDetailsRoute` consumes metrics, navigation, and worker contexts directly and owns selection/summary resolution, request invalidation and retry, effect-only redirects, stale-result rejection, cleanup, recoverable errors, and final `UserDetailsView` model delivery. This completes Phase 7 thin view routing; Phase 6 feature-view moves and decomposition remain deferred.
+`ViewRouter` (`src/components/layout/ViewRouter.tsx`) is the thin top-level coordinator for metrics-wide upload, fatal-error, and loading gates. It selects either the typed standard-route outlet or the specialized `UserDetailsRoute`. Each standard adapter invokes its feature selector lazily and renders the existing view with a narrow shared route context. `UserDetailsRoute` consumes metrics, navigation, and worker contexts directly and owns selection/summary resolution, request invalidation and retry, effect-only redirects, stale-result rejection, cleanup, recoverable errors, and final `UserDetailsView` model delivery. This completes Phase 7 thin view routing. Phase 10 keeps these dependencies enforced; Phase 6 feature-view moves and decomposition remain deferred.
 
 Charts use **Chart.js** via **react-chartjs-2**, wrapped in a `ChartContainer` component for consistent styling.
 
@@ -157,6 +186,7 @@ flowchart TB
 	subgraph State
 		MC[MetricsContext]
 		NC[NavigationContext]
+		MWP[MetricsWorkerProvider]
 	end
 
 	subgraph WebWorker[Web Worker]
@@ -169,9 +199,14 @@ flowchart TB
 	end
 
 	subgraph WorkerBridge
-		MWC[MetricsWorkerContext.tsx]
 		WC[metricsWorkerClient.ts]
 		WT[metricsWorker.ts]
+	end
+
+	subgraph Boundaries[ESLint boundaries]
+		BR1[UI/read-models cannot import aggregation implementation]
+		BR2[domain/workers stay framework-free]
+		BR3[shared UI/charts avoid layout and feature routes]
 	end
 
 	VR --> SR[Standard route outlet + registry]
@@ -181,10 +216,9 @@ flowchart TB
 	UD --> UDV[UserDetailsView]
 	UD --> RM
 
-	MWP --> MWC
-	MWC --> WC
-	UFU[useFileUpload] --> MWC
-	UD -->|user detail requests| MWC
+	MWP --> WC
+	UFU[useFileUpload] --> MWP
+	UD -->|user detail requests| MWP
 	WC -->|postMessage| WT
 	WT --> MFP
 	WT --> MA
@@ -197,4 +231,9 @@ flowchart TB
 
 	MC --> VR
 	NC --> VR
+	BR1 -.enforces.-> SR
+	BR1 -.enforces.-> RM
+	BR2 -.enforces.-> WT
+	BR2 -.enforces.-> MA
+	BR3 -.enforces.-> Views
 ```

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,6 +1,11 @@
 import eslint from '@eslint/js'
 import tseslint from 'typescript-eslint'
 
+const productionSourceIgnores = [
+  'src/**/*.test.{ts,tsx}',
+  'src/**/__tests__/**',
+]
+
 export default tseslint.config(
   {
     ignores: [
@@ -15,4 +20,152 @@ export default tseslint.config(
   },
   eslint.configs.recommended,
   ...tseslint.configs.recommended,
+  {
+    files: [
+      'src/components/**/*.{ts,tsx}',
+      'src/read-models/**/*.{ts,tsx}',
+    ],
+    ignores: productionSourceIgnores,
+    rules: {
+      'no-restricted-imports': ['error', {
+        patterns: [
+          {
+            group: [
+              '@/domain/aggregation',
+              '@/domain/aggregation/*',
+              '@/domain/metricsAggregator',
+              '../domain/aggregation',
+              '../domain/aggregation/*',
+              '../domain/metricsAggregator',
+              '../../domain/aggregation',
+              '../../domain/aggregation/*',
+              '../../domain/metricsAggregator',
+              '../../../domain/aggregation',
+              '../../../domain/aggregation/*',
+              '../../../domain/metricsAggregator',
+              '../../../../domain/aggregation',
+              '../../../../domain/aggregation/*',
+              '../../../../domain/metricsAggregator',
+            ],
+            message: 'UI and read-model layers must consume aggregate contracts/read models, not aggregation implementation modules.',
+          },
+        ],
+      }],
+    },
+  },
+  {
+    files: [
+      'src/domain/**/*.{ts,tsx}',
+      'src/workers/**/*.{ts,tsx}',
+    ],
+    ignores: productionSourceIgnores,
+    rules: {
+      'no-restricted-imports': ['error', {
+        paths: [
+          {
+            name: 'react',
+            message: 'Domain and worker modules must stay framework-free.',
+          },
+          {
+            name: 'react-dom',
+            message: 'Domain and worker modules must stay framework-free.',
+          },
+          {
+            name: 'react-dom/server',
+            message: 'Domain and worker modules must stay framework-free.',
+          },
+          {
+            name: 'react/jsx-runtime',
+            message: 'Domain and worker modules must stay framework-free.',
+          },
+          {
+            name: 'react/jsx-dev-runtime',
+            message: 'Domain and worker modules must stay framework-free.',
+          },
+        ],
+        patterns: [
+          {
+            group: [
+              '@/components',
+              '@/components/*',
+              '../components',
+              '../components/*',
+              '../../components',
+              '../../components/*',
+              '@/state',
+              '@/state/*',
+              '../state',
+              '../state/*',
+              '../../state',
+              '../../state/*',
+              'next',
+              'next/*',
+            ],
+            message: 'Domain and worker modules may depend on contracts and domain helpers only, not UI/state layers.',
+          },
+        ],
+      }],
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector: 'JSXElement',
+          message: 'Domain and worker modules must stay framework-free.',
+        },
+        {
+          selector: 'JSXFragment',
+          message: 'Domain and worker modules must stay framework-free.',
+        },
+      ],
+    },
+  },
+  {
+    files: [
+      'src/components/ui/**/*.{ts,tsx}',
+      'src/components/charts/**/*.{ts,tsx}',
+    ],
+    ignores: productionSourceIgnores,
+    rules: {
+      'no-restricted-imports': ['error', {
+        patterns: [
+          {
+            group: [
+              '@/domain/aggregation',
+              '@/domain/aggregation/*',
+              '@/domain/metricsAggregator',
+              '../domain/aggregation',
+              '../domain/aggregation/*',
+              '../domain/metricsAggregator',
+              '../../domain/aggregation',
+              '../../domain/aggregation/*',
+              '../../domain/metricsAggregator',
+              '../../../domain/aggregation',
+              '../../../domain/aggregation/*',
+              '../../../domain/metricsAggregator',
+              '../../../../domain/aggregation',
+              '../../../../domain/aggregation/*',
+              '../../../../domain/metricsAggregator',
+            ],
+            message: 'UI and read-model layers must consume aggregate contracts/read models, not aggregation implementation modules.',
+          },
+          {
+            group: [
+              '@/components/layout',
+              '@/components/layout/*',
+              '@/components/features',
+              '@/components/features/*',
+              '../layout',
+              '../layout/*',
+              '../features',
+              '../features/*',
+              '../../layout',
+              '../../layout/*',
+              '../../features',
+              '../../features/*',
+            ],
+            message: 'Shared UI primitives and charts must not depend on feature or layout route modules.',
+          },
+        ],
+      }],
+    },
+  },
 )

--- a/src/__tests__/architectureBoundaries.test.ts
+++ b/src/__tests__/architectureBoundaries.test.ts
@@ -1,0 +1,101 @@
+import { ESLint } from 'eslint';
+import { describe, expect, it } from 'vitest';
+
+const eslint = new ESLint({ cwd: process.cwd() });
+
+async function lintSource(filePath: string, source: string) {
+  const [result] = await eslint.lintText(source, { filePath });
+  return result.messages.map((message) => ({
+    ruleId: message.ruleId,
+    message: message.message,
+  }));
+}
+
+describe('architecture import boundaries', () => {
+  it('prevents UI routes from importing aggregation implementation modules', async () => {
+    const messages = await lintSource(
+      'src/components/layout/routes/ExampleRoute.tsx',
+      "import { aggregateMetrics } from '../../../domain/metricsAggregator';\nexport const value = aggregateMetrics;\n"
+    );
+
+    expect(messages).toContainEqual(expect.objectContaining({
+      ruleId: 'no-restricted-imports',
+      message: expect.stringContaining('aggregation implementation modules'),
+    }));
+  });
+
+  it('prevents read models from importing aggregation family modules', async () => {
+    const messages = await lintSource(
+      'src/read-models/example.ts',
+      "import { createCliAccumulator } from '../domain/aggregation/cliAggregation';\nexport const value = createCliAccumulator;\n"
+    );
+
+    expect(messages).toContainEqual(expect.objectContaining({
+      ruleId: 'no-restricted-imports',
+      message: expect.stringContaining('aggregation implementation modules'),
+    }));
+  });
+
+  it('keeps domain and worker modules free of React and UI state dependencies', async () => {
+    const messages = await lintSource(
+      'src/domain/example.ts',
+      "import type { ReactNode } from 'react';\nimport { useNavigation } from '../state/NavigationContext';\nexport type Value = ReactNode;\nexport const value = useNavigation;\n"
+    );
+
+    expect(messages).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        ruleId: 'no-restricted-imports',
+        message: expect.stringContaining('framework-free'),
+      }),
+      expect.objectContaining({
+        ruleId: 'no-restricted-imports',
+        message: expect.stringContaining('not UI/state layers'),
+      }),
+    ]));
+  });
+
+  it('prevents JSX from reintroducing framework coupling in domain modules', async () => {
+    const messages = await lintSource(
+      'src/domain/example.tsx',
+      'export const value = <span />;\n'
+    );
+
+    expect(messages).toContainEqual(expect.objectContaining({
+      ruleId: 'no-restricted-syntax',
+      message: expect.stringContaining('framework-free'),
+    }));
+  });
+
+  it('prevents shared chart modules from importing layout routes', async () => {
+    const messages = await lintSource(
+      'src/components/charts/ExampleChart.tsx',
+      "import ViewRouter from '../layout/ViewRouter';\nexport const value = ViewRouter;\n"
+    );
+
+    expect(messages).toContainEqual(expect.objectContaining({
+      ruleId: 'no-restricted-imports',
+      message: expect.stringContaining('Shared UI primitives and charts'),
+    }));
+  });
+
+  it('prevents shared chart modules from importing aggregation implementation modules', async () => {
+    const messages = await lintSource(
+      'src/components/charts/utils/example.ts',
+      "import { aggregateMetrics } from '../../../domain/metricsAggregator';\nexport const value = aggregateMetrics;\n"
+    );
+
+    expect(messages).toContainEqual(expect.objectContaining({
+      ruleId: 'no-restricted-imports',
+      message: expect.stringContaining('aggregation implementation modules'),
+    }));
+  });
+
+  it('allows contract imports across view and read-model layers', async () => {
+    const messages = await lintSource(
+      'src/read-models/example.ts',
+      "import type { AggregatedMetrics } from '../types/aggregatedMetrics';\nexport type Value = AggregatedMetrics;\n"
+    );
+
+    expect(messages).toEqual([]);
+  });
+});

--- a/src/__tests__/factories/aggregatedMetrics.ts
+++ b/src/__tests__/factories/aggregatedMetrics.ts
@@ -44,23 +44,9 @@ export const AGGREGATED_METRICS_SLICE_KEYS = {
   [Slice in keyof AggregatedMetrics]: readonly (keyof AggregatedMetrics[Slice])[];
 };
 
-export const FORMER_FLAT_AGGREGATE_KEYS = Object.values(
+export const AGGREGATED_METRICS_FIELD_KEYS = Object.values(
   AGGREGATED_METRICS_SLICE_KEYS
 ).flat();
-
-export function projectFormerFlatAggregate(metrics: AggregatedMetrics) {
-  return {
-    ...metrics.overview,
-    ...metrics.users,
-    ...metrics.adoption,
-    ...metrics.impact,
-    ...metrics.languages,
-    ...metrics.clients,
-    ...metrics.models,
-    ...metrics.cli,
-    ...metrics.ai,
-  };
-}
 
 export function makeAggregatedMetrics(
   overrides: AggregatedMetricsOverrides = {}

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -1,17 +1,17 @@
 "use client";
 
 import React from 'react';
-import { MetricsProvider } from '../components/MetricsContext';
+import { MetricsContextProvider } from '../components/MetricsContext';
 import { NavigationProvider } from '../state/NavigationContext';
-import { MetricsWorkerProvider } from '../workers/MetricsWorkerContext';
+import { MetricsWorkerProvider } from '../state/MetricsWorkerContext';
 
 const Providers: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   return (
     <MetricsWorkerProvider>
       <NavigationProvider>
-        <MetricsProvider>
+        <MetricsContextProvider>
           {children}
-        </MetricsProvider>
+        </MetricsContextProvider>
       </NavigationProvider>
     </MetricsWorkerProvider>
   );

--- a/src/components/MetricsContext.tsx
+++ b/src/components/MetricsContext.tsx
@@ -103,12 +103,10 @@ export const MetricsContextProvider: React.FC<{ children: React.ReactNode }> = (
   );
 };
 
-export const MetricsProvider = MetricsContextProvider;
-
 export function useMetrics(): MetricsContextValue {
   const ctx = useContext(MetricsContext);
   if (!ctx) {
-    throw new Error('useMetrics must be used within a MetricsProvider');
+    throw new Error('useMetrics must be used within a MetricsContextProvider');
   }
   return ctx;
 }

--- a/src/components/charts/CLIAdoptionTrendChart.tsx
+++ b/src/components/charts/CLIAdoptionTrendChart.tsx
@@ -4,7 +4,7 @@ import { Chart } from 'react-chartjs-2';
 import { useMemo } from 'react';
 import { registerChartJS } from './utils/chartSetup';
 import { createAdoptionTrendChartConfig, createAdoptionTrendSummaryStats, getAdoptionTrendMetrics, padAdoptionTrendData } from './utils/adoptionTrendChart';
-import { computeCliInsights } from '../../domain/cliAdoptionInsights';
+import { computeCliInsights } from './utils/cliAdoptionInsights';
 import type { DailyCliAdoptionTrend } from '../../domain/calculators/metricCalculators';
 import ChartContainer from '../ui/ChartContainer';
 import InsightsCard from '../ui/InsightsCard';

--- a/src/components/charts/utils/cliAdoptionInsights.test.ts
+++ b/src/components/charts/utils/cliAdoptionInsights.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
-import { computeCliInsights } from '../cliAdoptionInsights';
-import type { MetricsStats } from '../../types/metrics';
-import type { DailyCliAdoptionTrend } from '../calculators/metricCalculators';
+import { computeCliInsights } from './cliAdoptionInsights';
+import type { MetricsStats } from '../../../types/metrics';
+import type { DailyCliAdoptionTrend } from '../../../domain/calculators/metricCalculators';
 
 function makeStats(overrides: Partial<MetricsStats> = {}): MetricsStats {
   return {

--- a/src/components/charts/utils/cliAdoptionInsights.tsx
+++ b/src/components/charts/utils/cliAdoptionInsights.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from 'react';
-import type { DailyCliAdoptionTrend } from './calculators/metricCalculators';
-import type { MetricsStats } from '../types/metrics';
+import type { DailyCliAdoptionTrend } from '../../../domain/calculators/metricCalculators';
+import type { MetricsStats } from '../../../types/metrics';
 
 export interface CliInsight {
   title: string;

--- a/src/components/layout/routes/UserDetailsRoute.tsx
+++ b/src/components/layout/routes/UserDetailsRoute.tsx
@@ -3,8 +3,8 @@
 import { useEffect, useRef, useState } from 'react';
 import { selectUserDetailsRouteReadModel } from '../../../read-models/userDetails';
 import { useNavigation } from '../../../state/NavigationContext';
+import { useMetricsWorker } from '../../../state/MetricsWorkerContext';
 import { VIEW_MODES } from '../../../types/navigation';
-import { useMetricsWorker } from '../../../workers/MetricsWorkerContext';
 import UserDetailsView from '../../UserDetailsView';
 import { useMetrics } from '../../MetricsContext';
 import { runUserDetailsRequest } from '../userDetailsRequest';

--- a/src/components/layout/routes/__tests__/UserDetailsRoute.test.tsx
+++ b/src/components/layout/routes/__tests__/UserDetailsRoute.test.tsx
@@ -61,7 +61,7 @@ vi.mock('../../../../state/NavigationContext', () => ({
   }),
 }));
 
-vi.mock('../../../../workers/MetricsWorkerContext', () => ({
+vi.mock('../../../../state/MetricsWorkerContext', () => ({
   useMetricsWorker: () => mocks.workerOperations,
 }));
 

--- a/src/domain/__tests__/metricsAggregator.orchestration.test.ts
+++ b/src/domain/__tests__/metricsAggregator.orchestration.test.ts
@@ -1,8 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
+  AGGREGATED_METRICS_FIELD_KEYS,
   AGGREGATED_METRICS_SLICE_KEYS,
-  FORMER_FLAT_AGGREGATE_KEYS,
-  projectFormerFlatAggregate,
 } from '../../__tests__/factories/aggregatedMetrics';
 import { makeMetric } from '../../__tests__/factories/metrics';
 import type { AggregatedMetrics } from '../../types/aggregatedMetrics';
@@ -298,25 +297,104 @@ describe('metrics aggregation orchestration characterization', () => {
       cliAggregation,
       aiAggregation,
     });
-    const expectedFormerFlat = {
-      ...coreStatsAggregation,
-      ...userSummaryAggregation,
-      ...engagementAdoptionAggregation,
-      ...impactAggregation,
-      ...languageAggregation,
-      ...clientAggregation,
-      ...modelAggregation,
-      ...cliAggregation,
-      ...aiAggregation,
-    };
-    const actualFormerFlat = projectFormerFlatAggregate(aggregated);
-
-    for (const key of FORMER_FLAT_AGGREGATE_KEYS) {
-      expect(actualFormerFlat[key]).toBe(expectedFormerFlat[key]);
-    }
+    expect(aggregated.overview.stats).toBe(coreStatsAggregation.stats);
+    expect(aggregated.overview.engagementData).toBe(
+      engagementAdoptionAggregation.engagementData
+    );
+    expect(aggregated.overview.chatUsersData).toBe(
+      engagementAdoptionAggregation.chatUsersData
+    );
+    expect(aggregated.overview.chatRequestsData).toBe(
+      engagementAdoptionAggregation.chatRequestsData
+    );
+    expect(aggregated.users.userSummaries).toBe(
+      userSummaryAggregation.userSummaries
+    );
+    expect(aggregated.adoption.featureAdoptionData).toBe(
+      engagementAdoptionAggregation.featureAdoptionData
+    );
+    expect(aggregated.adoption.agentModeHeatmapData).toBe(
+      modelAggregation.agentModeHeatmapData
+    );
+    expect(aggregated.adoption.dailyAdoptionTrend).toBe(
+      engagementAdoptionAggregation.dailyAdoptionTrend
+    );
+    expect(aggregated.adoption.dailyCloudAgentAdoptionData).toBe(
+      engagementAdoptionAggregation.dailyCloudAgentAdoptionData
+    );
+    expect(aggregated.adoption.dailyCodeReviewAdoptionData).toBe(
+      engagementAdoptionAggregation.dailyCodeReviewAdoptionData
+    );
+    expect(aggregated.impact.agentImpactData).toBe(
+      impactAggregation.agentImpactData
+    );
+    expect(aggregated.impact.codeCompletionImpactData).toBe(
+      impactAggregation.codeCompletionImpactData
+    );
+    expect(aggregated.impact.editModeImpactData).toBe(
+      impactAggregation.editModeImpactData
+    );
+    expect(aggregated.impact.inlineModeImpactData).toBe(
+      impactAggregation.inlineModeImpactData
+    );
+    expect(aggregated.impact.askModeImpactData).toBe(
+      impactAggregation.askModeImpactData
+    );
+    expect(aggregated.impact.cliImpactData).toBe(
+      impactAggregation.cliImpactData
+    );
+    expect(aggregated.impact.joinedImpactData).toBe(
+      impactAggregation.joinedImpactData
+    );
+    expect(aggregated.languages.languageStats).toBe(
+      languageAggregation.languageStats
+    );
+    expect(aggregated.languages.languageFeatureImpactData).toBe(
+      languageAggregation.languageFeatureImpactData
+    );
+    expect(aggregated.languages.dailyLanguageGenerationsData).toBe(
+      languageAggregation.dailyLanguageGenerationsData
+    );
+    expect(aggregated.languages.dailyLanguageLocData).toBe(
+      languageAggregation.dailyLanguageLocData
+    );
+    expect(aggregated.clients.ideStats).toBe(clientAggregation.ideStats);
+    expect(aggregated.clients.multiIDEUsersCount).toBe(
+      clientAggregation.multiIDEUsersCount
+    );
+    expect(aggregated.clients.totalUniqueIDEUsers).toBe(
+      clientAggregation.totalUniqueIDEUsers
+    );
+    expect(aggregated.clients.pluginVersionData).toBe(
+      clientAggregation.pluginVersionData
+    );
+    expect(aggregated.models.modelUsageData).toBe(
+      modelAggregation.modelUsageData
+    );
+    expect(aggregated.models.modelBreakdownData).toBe(
+      modelAggregation.modelBreakdownData
+    );
+    expect(aggregated.cli.dailyCliSessionData).toBe(
+      cliAggregation.dailyCliSessionData
+    );
+    expect(aggregated.cli.dailyCliTokenData).toBe(
+      cliAggregation.dailyCliTokenData
+    );
+    expect(aggregated.cli.dailyCliAdoptionTrend).toBe(
+      cliAggregation.dailyCliAdoptionTrend
+    );
+    expect(aggregated.ai.aiAdoptionPhaseData).toBe(
+      aiAggregation.aiAdoptionPhaseData
+    );
+    expect(aggregated.ai.usageDistributionData).toBe(
+      aiAggregation.usageDistributionData
+    );
+    expect(aggregated.ai.dailyAiCreditsData).toBe(
+      aiAggregation.dailyAiCreditsData
+    );
   });
 
-  it('owns every former field once and measures grouped serialization', () => {
+  it('owns every aggregate field once and uses a single raw-record pass', () => {
     const source = [
       makeMetric({
         user_id: 1,
@@ -390,13 +468,9 @@ describe('metrics aggregation orchestration characterization', () => {
     });
 
     const { aggregated } = aggregateMetrics(metrics);
-    const flat = projectFormerFlatAggregate(aggregated);
     const groupedBytes = new TextEncoder().encode(
       JSON.stringify(aggregated)
     ).byteLength;
-    const flatBytes = new TextEncoder().encode(JSON.stringify(flat)).byteLength;
-    const deltaBytes = groupedBytes - flatBytes;
-    const percentageDelta = (deltaBytes / flatBytes) * 100;
 
     expect(Object.keys(aggregated)).toEqual(aggregateSliceKeys);
     expect(Object.keys(aggregated.overview)).toEqual(
@@ -426,22 +500,14 @@ describe('metrics aggregation orchestration characterization', () => {
     expect(Object.keys(aggregated.ai)).toEqual(
       AGGREGATED_METRICS_SLICE_KEYS.ai
     );
-    expect(Object.keys(flat)).toEqual(FORMER_FLAT_AGGREGATE_KEYS);
-    expect(new Set(FORMER_FLAT_AGGREGATE_KEYS).size).toBe(
-      FORMER_FLAT_AGGREGATE_KEYS.length
+    expect(new Set(AGGREGATED_METRICS_FIELD_KEYS).size).toBe(
+      AGGREGATED_METRICS_FIELD_KEYS.length
     );
-    for (const key of FORMER_FLAT_AGGREGATE_KEYS) {
+    for (const key of AGGREGATED_METRICS_FIELD_KEYS) {
       expect(aggregated).not.toHaveProperty(key);
     }
     expect(aggregated).not.toHaveProperty('metrics');
     expect(groupedBytes).toBeGreaterThan(0);
-    expect(flatBytes).toBeGreaterThan(0);
-    expect(groupedBytes).toBe(flatBytes + deltaBytes);
-    expect(Number.isFinite(percentageDelta)).toBe(true);
-    console.info(
-      `[aggregate-payload-size] grouped=${groupedBytes} flat=${flatBytes} `
-      + `delta=${deltaBytes} percentage=${percentageDelta.toFixed(2)}%`
-    );
     expect(iteratorRequests).toBe(1);
     expect(source).toEqual(original);
   });

--- a/src/hooks/useFileUpload.ts
+++ b/src/hooks/useFileUpload.ts
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { MultiFileProgress } from '../infra/metricsFileParser';
-import { useMetricsWorker } from '../workers/MetricsWorkerContext';
+import { useMetricsWorker } from '../state/MetricsWorkerContext';
 import { useMetrics } from '../components/MetricsContext';
 import { getBasePath } from '../utils/basePath';
 

--- a/src/hooks/useResetAppState.ts
+++ b/src/hooks/useResetAppState.ts
@@ -3,7 +3,7 @@
 import { useCallback } from 'react';
 import { useMetrics } from '../components/MetricsContext';
 import { useNavigation } from '../state/NavigationContext';
-import { useMetricsWorker } from '../workers/MetricsWorkerContext';
+import { useMetricsWorker } from '../state/MetricsWorkerContext';
 
 export function useResetAppState() {
   const { resetMetrics } = useMetrics();

--- a/src/state/MetricsWorkerContext.tsx
+++ b/src/state/MetricsWorkerContext.tsx
@@ -12,7 +12,7 @@ import type { UserDetailedMetrics } from '../types/aggregatedMetrics';
 import {
   MetricsWorkerClient,
   type ParseAndAggregateResult,
-} from './metricsWorkerClient';
+} from '../workers/metricsWorkerClient';
 
 interface MetricsWorkerOperations {
   parseAndAggregate: (

--- a/src/workers/__tests__/metricsWorker.test.ts
+++ b/src/workers/__tests__/metricsWorker.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
+  AGGREGATED_METRICS_FIELD_KEYS,
   AGGREGATED_METRICS_SLICE_KEYS,
-  FORMER_FLAT_AGGREGATE_KEYS,
 } from '../../__tests__/factories/aggregatedMetrics';
 import { makeMetric } from '../../__tests__/factories/metrics';
 import type { WorkerRequest, WorkerResponse } from '../types';
@@ -148,7 +148,7 @@ describe('metricsWorker protocol', () => {
     expect(Object.keys(parseResult!.result)).toEqual(
       Object.keys(AGGREGATED_METRICS_SLICE_KEYS)
     );
-    for (const key of FORMER_FLAT_AGGREGATE_KEYS) {
+    for (const key of AGGREGATED_METRICS_FIELD_KEYS) {
       expect(parseResult!.result).not.toHaveProperty(key);
     }
     expect(parseResult!.result).not.toHaveProperty('metrics');


### PR DESCRIPTION
## Why

Phase 10 makes the completed maintainability architecture difficult to regress by enforcing key dependency directions, removing demonstrably obsolete migration residue, and aligning the project overview with the final grouped-aggregate implementation.

| Commit | Change |
|--------|--------|
| `chore: enforce architecture import boundaries` | Adds focused ESLint `no-restricted-imports` / `no-restricted-syntax` rules and characterization tests for UI/read-model aggregation boundaries, framework-free domain/worker modules, and shared UI/chart isolation. |
| `refactor: keep React helpers out of domain boundaries` | Moves React-only worker context and CLI insight rendering into main-thread/UI-owned areas, removes the unused `MetricsProvider` alias, and replaces test-only former-flat aggregate projection residue with grouped-contract assertions. |
| `docs: document final architecture boundaries` | Updates project overview text and diagrams for the final worker data flow, grouped aggregate ownership, enforced dependency direction, and phase status. |

## Validation and review

- Read-only code review sub-agent completed clean after two significant enforcement gaps were fixed.
- `npm run build && npm run lint && npm run test:run && git diff --check`
- Final test baseline: 71 test files / 671 tests.

## Audit outcomes

- Added three focused production boundary rule groups: UI/read-models cannot import aggregation internals; domain/workers are framework-free and JSX-free; shared UI/charts cannot import feature/layout route modules.
- Removed migration residue: test-only former-flat projection helper/keys, `MetricsProvider` alias, domain-owned JSX CLI insight helper, and React worker provider under `src/workers`.
- Preserved worker-first flow, grouped `AggregatedMetrics` slice ownership, user-detail worker lifecycle, and existing UI behavior.
