### PR TITLE
Fix review note follow-ups

### DIFF
--- a/src/components/features/user-details/__tests__/userDetailsRequest.test.ts
+++ b/src/components/features/user-details/__tests__/userDetailsRequest.test.ts
@@ -37,6 +37,34 @@ describe('runUserDetailsRequest', () => {
     expect(onError).toHaveBeenCalledWith('Worker accumulator unavailable');
   });
 
+  it('uses the default error message when an Error has no message', async () => {
+    const onError = vi.fn();
+
+    await runUserDetailsRequest({
+      userId: 42,
+      load: vi.fn().mockRejectedValue(new Error()),
+      isCurrent: () => true,
+      onSuccess: vi.fn(),
+      onError,
+    });
+
+    expect(onError).toHaveBeenCalledWith('Failed to load user details.');
+  });
+
+  it('reports missing user details', async () => {
+    const onError = vi.fn();
+
+    await runUserDetailsRequest({
+      userId: 42,
+      load: vi.fn().mockResolvedValue(null),
+      isCurrent: () => true,
+      onSuccess: vi.fn(),
+      onError,
+    });
+
+    expect(onError).toHaveBeenCalledWith('No user details were returned for this user.');
+  });
+
   it('ignores late results from an obsolete request', async () => {
     let resolveRequest: (value: UserDetailedMetrics | null) => void = () => undefined;
     const load = vi.fn(() => new Promise<UserDetailedMetrics | null>((resolve) => {

--- a/src/components/features/user-details/userDetailsRequest.ts
+++ b/src/components/features/user-details/userDetailsRequest.ts
@@ -8,6 +8,8 @@ interface RunUserDetailsRequestOptions {
   onError: (message: string) => void;
 }
 
+const DEFAULT_USER_DETAILS_ERROR_MESSAGE = 'Failed to load user details.';
+
 export async function runUserDetailsRequest({
   userId,
   load,
@@ -32,6 +34,10 @@ export async function runUserDetailsRequest({
       return;
     }
 
-    onError(error instanceof Error ? error.message : 'Failed to load user details.');
+    onError(
+      error instanceof Error && error.message
+        ? error.message
+        : DEFAULT_USER_DETAILS_ERROR_MESSAGE
+    );
   }
 }

--- a/src/components/layout/__tests__/ViewRouter.test.tsx
+++ b/src/components/layout/__tests__/ViewRouter.test.tsx
@@ -4,10 +4,11 @@ import { makeMetric } from '../../../__tests__/factories/metrics';
 import { aggregateMetrics } from '../../../domain/metricsAggregator';
 import type { AggregatedMetrics } from '../../../types/aggregatedMetrics';
 import { VIEW_MODES, type ViewMode } from '../../../types/navigation';
+import type { StandardViewMode } from '../routes';
 import ViewRouter from '../ViewRouter';
 
 interface StandardRouteOutletProps {
-  view: ViewMode;
+  view: StandardViewMode;
   aggregatedMetrics: AggregatedMetrics;
   enterpriseName: string | null;
   onUserSelect: (userLogin: string, userId: number) => void;

--- a/src/components/layout/routes/StandardRouteOutlet.tsx
+++ b/src/components/layout/routes/StandardRouteOutlet.tsx
@@ -1,9 +1,11 @@
 import type { AggregatedMetrics } from '../../../types/aggregatedMetrics';
-import type { ViewMode } from '../../../types/navigation';
-import { resolveStandardRouteAdapter } from './standardRouteRegistry';
+import {
+  resolveStandardRouteAdapter,
+  type StandardViewMode,
+} from './standardRouteRegistry';
 
 interface StandardRouteOutletProps {
-  view: ViewMode;
+  view: StandardViewMode;
   aggregatedMetrics: AggregatedMetrics;
   enterpriseName: string | null;
   onUserSelect: (userLogin: string, userId: number) => void;

--- a/src/infra/__tests__/metricsFileParser.test.ts
+++ b/src/infra/__tests__/metricsFileParser.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { makeMetric } from '../../__tests__/factories/metrics';
 import { parseMetricsFile } from '../../domain/metricsParser';
+import type { MultiFileProgress } from '../metricsFileParser';
 import { parseMultipleMetricsStreams } from '../metricsFileParser';
 
 const encoder = new TextEncoder();
@@ -86,7 +87,7 @@ describe('parseMultipleMetricsStreams', () => {
     const lastFile = createChunkedFile([
       `${JSON.stringify(makeMetric({ user_id: 333, user_login: 'last_user' }))}\n`,
     ], 'last.ndjson');
-    const progress: Array<{ currentFile: number; totalFiles: number; fileName: string; recordsProcessed: number }> = [];
+    const progress: MultiFileProgress[] = [];
 
     const result = await parseMultipleMetricsStreams(
       [firstFile, failingFile, lastFile],


### PR DESCRIPTION
## Why

This change resolves three actionable Copilot Code Review follow-ups from merged PRs while keeping the static export, worker-first parsing flow, grouped aggregate contracts, route/read-model boundaries, and dependency enforcement intact.

Source discussions:
- PR #555 parser progress test type: https://github.com/asizikov-demos/copilot-user-level-statistics-viewer/pull/555#discussion_r3652798852
- PR #556 blank user details error message: https://github.com/asizikov-demos/copilot-user-level-statistics-viewer/pull/556#discussion_r3652830827
- PR #568 standard route outlet seam: https://github.com/asizikov-demos/copilot-user-level-statistics-viewer/pull/568#discussion_r3653357383

| Commit | Change |
|--------|--------|
| `test: reuse parser progress contract` | Reuses the exported `MultiFileProgress` contract in the parser stream test instead of duplicating its structural shape. |
| `fix: default blank user details errors` | Falls back to the default user-details error message when `Error.message` is empty and covers `new Error()` plus null details. |
| `fix: narrow standard route outlet view` | Narrows `StandardRouteOutlet` to `StandardViewMode` and updates the ViewRouter test helper to use the same seam type. |

## Validation and review

- Read-only code-review sub-agent: no significant issues found.
- `npm run build && npm run lint && npm run test:run` passed.
- `git diff --check` passed.
- Final test count: 77 test files / 694 tests.

## Out of scope / already superseded

- PR #563 lazy AI Credits selector note is superseded by lazy standard route adapters.
- PR #570 console.info/noisy payload test note is already addressed; the current test contains no `console.info`.