### PR TITLE
Fix worker error propagation lifecycle coverage

### DIFF
--- a/src/state/__tests__/MetricsWorkerContext.test.tsx
+++ b/src/state/__tests__/MetricsWorkerContext.test.tsx
@@ -1,0 +1,51 @@
+import { StrictMode } from 'react';
+import {
+  act,
+  create,
+  type ReactTestRenderer,
+} from 'react-test-renderer';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { MetricsWorkerProvider } from '../MetricsWorkerContext';
+import { MetricsWorkerClient } from '../../workers/metricsWorkerClient';
+
+let renderer: ReactTestRenderer | null = null;
+
+async function settleMicrotasks() {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+afterEach(() => {
+  renderer?.unmount();
+  renderer = null;
+  vi.restoreAllMocks();
+});
+
+describe('MetricsWorkerProvider', () => {
+  it('keeps the client alive during Strict Mode replay and disposes once on real unmount', async () => {
+    const dispose = vi.spyOn(MetricsWorkerClient.prototype, 'dispose');
+
+    await act(async () => {
+      renderer = create(
+        <StrictMode>
+          <MetricsWorkerProvider>
+            <div>ready</div>
+          </MetricsWorkerProvider>
+        </StrictMode>
+      );
+    });
+    await settleMicrotasks();
+
+    expect(dispose).not.toHaveBeenCalled();
+
+    await act(async () => {
+      renderer?.unmount();
+    });
+    renderer = null;
+    await settleMicrotasks();
+
+    expect(dispose).toHaveBeenCalledOnce();
+  });
+});

--- a/src/state/__tests__/MetricsWorkerContext.test.tsx
+++ b/src/state/__tests__/MetricsWorkerContext.test.tsx
@@ -17,9 +17,14 @@ async function settleMicrotasks() {
   });
 }
 
-afterEach(() => {
-  renderer?.unmount();
-  renderer = null;
+afterEach(async () => {
+  if (renderer) {
+    await act(async () => {
+      renderer?.unmount();
+    });
+    renderer = null;
+    await settleMicrotasks();
+  }
   vi.restoreAllMocks();
 });
 

--- a/src/workers/__tests__/metricsWorkerClient.test.ts
+++ b/src/workers/__tests__/metricsWorkerClient.test.ts
@@ -176,7 +176,7 @@ describe('MetricsWorkerClient', () => {
     workers[0].fail({
       error: {
         name: 'TypeError',
-        message: 'cross-realm worker failed',
+        message: '  cross-realm worker failed  ',
         stack: 'TypeError: cross-realm worker failed\n    at metricsWorker.js:20:8',
         cause: rootCause,
       },

--- a/src/workers/__tests__/metricsWorkerClient.test.ts
+++ b/src/workers/__tests__/metricsWorkerClient.test.ts
@@ -18,8 +18,11 @@ class MockWorker {
     this.onmessage?.({ data: message } as MessageEvent<WorkerResponse>);
   }
 
-  fail(message: string): void {
-    this.onerror?.({ message } as ErrorEvent);
+  fail(event: string | Partial<ErrorEvent>): void {
+    const errorEvent = typeof event === 'string'
+      ? { message: event, filename: '', lineno: 0, colno: 0 }
+      : { message: '', filename: '', lineno: 0, colno: 0, ...event };
+    this.onerror?.(errorEvent as ErrorEvent);
   }
 }
 
@@ -136,6 +139,73 @@ describe('MetricsWorkerClient', () => {
     expect(workers[0].terminate).toHaveBeenCalledTimes(1);
     expect(workers[0].onmessage).toBeNull();
     expect(workers[0].onerror).toBeNull();
+  });
+
+  it('preserves the Error from ErrorEvent.error when a worker fails', async () => {
+    const { client, workers } = createHarness();
+    const rootCause = new Error('parse failure root cause');
+    const workerError = new Error('worker parse failed', { cause: rootCause });
+    workerError.stack = 'Error: worker parse failed\n    at metricsWorker.js:10:2';
+    const parsePromise = client.parseAndAggregate([new File([''], 'metrics.ndjson')]);
+    const detailsPromise = client.computeUserDetails(42);
+
+    workers[0].fail({
+      message: 'ignored browser event message',
+      error: workerError,
+      filename: 'metricsWorker.js',
+      lineno: 10,
+      colno: 2,
+    });
+
+    const [parseError, detailsError] = await Promise.all([
+      parsePromise.catch((error: unknown) => error),
+      detailsPromise.catch((error: unknown) => error),
+    ]);
+    expect(parseError).toBe(workerError);
+    expect(detailsError).toBe(workerError);
+    expect(workerError.cause).toBe(rootCause);
+    expect(workerError.stack).toContain('metricsWorker.js:10:2');
+    expect(workers[0].terminate).toHaveBeenCalledTimes(1);
+  });
+
+  it('preserves Error-like event.error details from another worker realm', async () => {
+    const { client, workers } = createHarness();
+    const rootCause = new Error('cross-realm root cause');
+    const request = client.computeUserDetails(42);
+
+    workers[0].fail({
+      error: {
+        name: 'TypeError',
+        message: 'cross-realm worker failed',
+        stack: 'TypeError: cross-realm worker failed\n    at metricsWorker.js:20:8',
+        cause: rootCause,
+      },
+      message: 'ignored fallback message',
+    });
+
+    const error = await request.catch((reason: unknown) => reason);
+    expect(error).toBeInstanceOf(Error);
+    expect(error).toMatchObject({
+      name: 'TypeError',
+      message: 'cross-realm worker failed',
+      cause: rootCause,
+      stack: expect.stringContaining('metricsWorker.js:20:8'),
+    });
+  });
+
+  it('builds a useful worker error from ErrorEvent fields when no Error exists', async () => {
+    const { client, workers } = createHarness();
+    const request = client.computeUserDetails(42);
+
+    workers[0].fail({
+      message: '',
+      filename: 'metricsWorker.js',
+      lineno: 12,
+      colno: 4,
+    });
+
+    await expect(request).rejects.toThrow('Worker error: metricsWorker.js:12:4');
+    expect(workers[0].terminate).toHaveBeenCalledTimes(1);
   });
 
   it('rejects pending work exactly once on reset and recreates the worker', async () => {

--- a/src/workers/metricsWorkerClient.ts
+++ b/src/workers/metricsWorkerClient.ts
@@ -199,11 +199,16 @@ export class MetricsWorkerClient {
     }
 
     const record = value as Record<string, unknown>;
-    if (typeof record.message !== 'string' || record.message.trim() === '') {
+    if (typeof record.message !== 'string') {
       return null;
     }
 
-    const error = new Error(record.message, { cause: record.cause });
+    const message = record.message.trim();
+    if (message === '') {
+      return null;
+    }
+
+    const error = new Error(message, { cause: record.cause });
     if (typeof record.name === 'string' && record.name.trim() !== '') {
       error.name = record.name;
     }

--- a/src/workers/metricsWorkerClient.ts
+++ b/src/workers/metricsWorkerClient.ts
@@ -105,7 +105,7 @@ export class MetricsWorkerClient {
       this.handleMessage(event.data);
     };
     worker.onerror = (event) => {
-      this.handleWorkerError(worker, event.message);
+      this.handleWorkerError(worker, this.errorFromErrorEvent(event));
     };
     this.worker = worker;
     return worker;
@@ -172,10 +172,52 @@ export class MetricsWorkerClient {
     return new Error(`Unexpected response type '${responseType}' for '${requestKind}' request`);
   }
 
-  private handleWorkerError(failedWorker: MetricsWorkerPort, message: string): void {
+  private errorFromErrorEvent(event: ErrorEvent): Error {
+    if (event.error instanceof Error) {
+      return event.error;
+    }
+
+    const errorLike = this.errorLikeFromUnknown(event.error);
+    if (errorLike) {
+      return errorLike;
+    }
+
+    const message = event.message.trim();
+    const location = [
+      event.filename,
+      event.lineno > 0 ? event.lineno : null,
+      event.colno > 0 ? event.colno : null,
+    ].filter((value) => value !== null && value !== '').join(':');
+    const details = [message, location].filter((value) => value !== '').join(' at ');
+
+    return new Error(`Worker error: ${details || 'Unknown worker error'}`);
+  }
+
+  private errorLikeFromUnknown(value: unknown): Error | null {
+    if (typeof value !== 'object' || value === null) {
+      return null;
+    }
+
+    const record = value as Record<string, unknown>;
+    if (typeof record.message !== 'string' || record.message.trim() === '') {
+      return null;
+    }
+
+    const error = new Error(record.message, { cause: record.cause });
+    if (typeof record.name === 'string' && record.name.trim() !== '') {
+      error.name = record.name;
+    }
+    if (typeof record.stack === 'string' && record.stack.trim() !== '') {
+      error.stack = record.stack;
+    }
+
+    return error;
+  }
+
+  private handleWorkerError(failedWorker: MetricsWorkerPort, error: Error): void {
     if (this.worker !== failedWorker) return;
 
-    this.releaseWorker(new Error(`Worker error: ${message}`));
+    this.releaseWorker(error);
   }
 
   private releaseWorker(error: Error): void {


### PR DESCRIPTION
## Why

This change addresses unresolved Copilot Code Review notes from merged PR #557 so worker failures preserve useful debugging context and the delayed-dispose provider lifecycle is covered directly. Source discussions: https://github.com/asizikov-demos/copilot-user-level-statistics-viewer/pull/557#discussion_r3652851600 and https://github.com/asizikov-demos/copilot-user-level-statistics-viewer/pull/557#discussion_r3652851608.

| Commit | Change |
|--------|--------|
| `fix: preserve worker error context` | Preserves same-realm `ErrorEvent.error`, normalizes Error-like cross-realm worker errors with message/name/stack/cause, and falls back to useful event field messages without changing stale-worker or pending-request fanout behavior. |
| `test: cover worker provider lifecycle` | Adds direct React coverage that `MetricsWorkerProvider` is not disposed during Strict Mode effect replay and disposes exactly once on real unmount. |
| `fix: address worker lifecycle review feedback` | Makes renderer cleanup deterministic inside `act()` and trims validated cross-realm worker error messages before surfacing them. |

## Validation

| Command | Result |
|---------|--------|
| `npm run test:run -- src/workers/__tests__/metricsWorkerClient.test.ts src/state/__tests__/MetricsWorkerContext.test.tsx` | Passed: 2 files / 12 tests |
| `npm run build && npm run lint && npm run test:run` | Passed: 78 files / 696 tests |
| `git diff --check` | Passed |

## Review

Read-only code review was run on the full diff. The first pass found a cross-realm worker error preservation gap; that was fixed, covered with a regression test, and subsequent reviews reported no significant issues. Follow-up inline feedback was addressed with deterministic React cleanup and normalized Error-like messages.

## Deliberately not included

The separate `queueMicrotask` fallback suggestion (`discussion_r3652851594`) is intentionally out of scope because this app targets Node >=20.19 and modern Next 16 browser output, where `queueMicrotask` is available; adding a fallback would add compatibility complexity without a supported-runtime benefit.