### PR TITLE
Improve Users summary with adoption rail

### DIFF
--- a/src/components/features/users/__tests__/UsersSections.test.tsx
+++ b/src/components/features/users/__tests__/UsersSections.test.tsx
@@ -43,7 +43,7 @@ function makeUser(overrides: Partial<UserSummary> = {}): UserSummary {
 }
 
 describe('Users feature sections', () => {
-  it('renders summary cards with the same feature-user counts', () => {
+  it('renders the total population and feature adoption rails', () => {
     const users = [
       makeUser(),
       makeUser({
@@ -63,13 +63,17 @@ describe('Users feature sections', () => {
     );
 
     expect(markup).toContain('Total Users');
-    expect(markup).toContain('Chat Users');
-    expect(markup).toContain('Agent Users');
-    expect(markup).toContain('Code Review Users');
-    expect(markup).toContain('CLI Users');
-    expect(markup).toContain('Completion Users');
+    expect(markup).toContain('unique users');
+    expect(markup).toContain('Users with Copilot activity in the selected report period');
+    expect(markup).toContain('Chat');
+    expect(markup).toContain('Completions');
+    expect(markup).toContain('Agent mode');
+    expect(markup).toContain('Code review');
+    expect(markup).toContain('CLI');
     expect(markup).toContain('>2<');
     expect(markup.match(/>1</g)?.length).toBeGreaterThanOrEqual(5);
+    expect(markup.match(/users · 50%/g)?.length).toBe(5);
+    expect(markup.match(/role="progressbar"/g)?.length).toBe(5);
   });
 
   it('keeps the paged users table labels, feature chips, and empty state', () => {

--- a/src/components/features/users/sections/UsersSummarySection.tsx
+++ b/src/components/features/users/sections/UsersSummarySection.tsx
@@ -1,32 +1,105 @@
 import type { UserSummary } from '../../../../types/metrics';
-import DashboardStatsCard from '../../../ui/DashboardStatsCard';
-import StatsGrid from '../../../ui/StatsGrid';
 
 interface UsersSummarySectionProps {
   sectionId: string;
   users: UserSummary[];
 }
 
+interface FeatureAdoption {
+  label: string;
+  users: number;
+}
+
 export default function UsersSummarySection({
   sectionId,
   users,
 }: UsersSummarySectionProps) {
-  const chatUsers = users.filter(user => user.used_chat).length;
-  const agentUsers = users.filter(user => user.used_agent).length;
-  const codeReviewUsers = users.filter(user => user.used_copilot_code_review_active || user.used_copilot_code_review_passive).length;
-  const cliUsers = users.filter(user => user.used_cli).length;
-  const completionUsers = users.filter(user => user.total_code_generation_activities > 0).length;
+  const totalUsers = users.length;
+  const featureAdoption: FeatureAdoption[] = [
+    {
+      label: 'Chat',
+      users: users.filter(user => user.used_chat).length,
+    },
+    {
+      label: 'Completions',
+      users: users.filter(user => user.total_code_generation_activities > 0).length,
+    },
+    {
+      label: 'Agent mode',
+      users: users.filter(user => user.used_agent).length,
+    },
+    {
+      label: 'Code review',
+      users: users.filter(user =>
+        user.used_copilot_code_review_active ||
+        user.used_copilot_code_review_passive
+      ).length,
+    },
+    {
+      label: 'CLI',
+      users: users.filter(user => user.used_cli).length,
+    },
+  ];
 
   return (
-    <div id={sectionId}>
-      <StatsGrid className="mb-6" columns={{ base: 2, md: 6 }} gapClassName="gap-4">
-        <DashboardStatsCard value={users.length} label="Total Users" accent="blue" />
-        <DashboardStatsCard value={chatUsers} label="Chat Users" accent="teal" />
-        <DashboardStatsCard value={agentUsers} label="Agent Users" accent="indigo" />
-        <DashboardStatsCard value={codeReviewUsers} label="Code Review Users" accent="cyan" />
-        <DashboardStatsCard value={cliUsers} label="CLI Users" accent="rose" />
-        <DashboardStatsCard value={completionUsers} label="Completion Users" accent="amber" />
-      </StatsGrid>
+    <div id={sectionId} className="mb-6 scroll-mt-28">
+      <div className="grid gap-8 rounded-lg border border-[#d1d9e0] bg-white p-6 md:grid-cols-[minmax(220px,0.8fr)_minmax(0,1.7fr)] md:gap-0">
+        <div className="md:pr-8">
+          <p className="text-xs font-semibold uppercase tracking-wider text-blue-700">
+            Total Users
+          </p>
+          <p className="mt-3 text-5xl font-bold tracking-tight text-gray-900">
+            {totalUsers.toLocaleString()}
+          </p>
+          <h2 className="mt-2 text-xl font-semibold text-gray-900">
+            unique users
+          </h2>
+          <p className="mt-3 max-w-sm text-sm leading-6 text-gray-600">
+            Users with Copilot activity in the selected report period. Feature
+            adoption shows how many of them used each experience.
+          </p>
+        </div>
+
+        <div className="border-t border-gray-200 pt-8 md:border-l md:border-t-0 md:pl-8 md:pt-0">
+          <div className="space-y-4">
+            {featureAdoption.map(feature => {
+              const adoptionPercentage = totalUsers === 0
+                ? 0
+                : Math.round((feature.users / totalUsers) * 100);
+
+              return (
+                <div key={feature.label}>
+                  <div className="mb-1.5 flex items-baseline justify-between gap-4">
+                    <span className="text-sm font-medium text-gray-800">
+                      {feature.label}
+                    </span>
+                    <span className="text-sm tabular-nums text-gray-600">
+                      <strong className="font-semibold text-gray-900">
+                        {feature.users.toLocaleString()}
+                      </strong>
+                      {' '}
+                      users · {adoptionPercentage}%
+                    </span>
+                  </div>
+                  <div
+                    className="h-2 overflow-hidden rounded-full bg-gray-100"
+                    role="progressbar"
+                    aria-label={`${feature.label} adoption`}
+                    aria-valuemin={0}
+                    aria-valuemax={100}
+                    aria-valuenow={adoptionPercentage}
+                  >
+                    <div
+                      className="h-full rounded-full bg-blue-600"
+                      style={{ width: `${adoptionPercentage}%` }}
+                    />
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Why

The Users summary gave six related metrics equal visual weight, obscuring the relationship between the total population and feature adoption. This redesign makes that hierarchy explicit and enables faster comparison across Copilot experiences.

| Commit | Change |
|--------|--------|
| `feat: add adoption rail to users summary` | Replaces the summary-card row with a descriptive total-user panel, responsive divider, and accessible adoption rails with counts and percentages. |