### PR TITLE
Fix Copilot App user details and IDE overlap

### DIFF
--- a/src/components/charts/CLIOverlapChart.tsx
+++ b/src/components/charts/CLIOverlapChart.tsx
@@ -17,12 +17,16 @@ interface CLIOverlapChartProps {
   ideStats: IDEStatsData[];
 }
 
-export default function CLIOverlapChart({ ideStats }: CLIOverlapChartProps) {
-  const sorted = sortBySelector(
-    ideStats.filter(ide => ide.uniqueUsers > 0),
+export function getCliOverlapIdeRows(ideStats: IDEStatsData[]): IDEStatsData[] {
+  return sortBySelector(
+    ideStats.filter(ide => ide.ide !== 'copilot_app' && ide.uniqueUsers > 0),
     ide => ide.cliOverlapUsers / ide.uniqueUsers,
     'desc',
   );
+}
+
+export default function CLIOverlapChart({ ideStats }: CLIOverlapChartProps) {
+  const sorted = getCliOverlapIdeRows(ideStats);
 
   const labels = sorted.map(ide => formatIDEName(ide.ide));
   const cliOverlap = sorted.map(ide => ide.cliOverlapUsers);

--- a/src/components/charts/__tests__/CLIOverlapChart.test.ts
+++ b/src/components/charts/__tests__/CLIOverlapChart.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import type { IDEStatsData } from '../../../types/metrics';
+import { getCliOverlapIdeRows } from '../CLIOverlapChart';
+
+function makeIdeStats(overrides: Partial<IDEStatsData>): IDEStatsData {
+  return {
+    ide: 'vscode',
+    uniqueUsers: 1,
+    cliOverlapUsers: 0,
+    totalEngagements: 0,
+    totalGenerations: 0,
+    totalAcceptances: 0,
+    locAdded: 0,
+    locDeleted: 0,
+    locSuggestedToAdd: 0,
+    locSuggestedToDelete: 0,
+    ...overrides,
+  };
+}
+
+describe('CLIOverlapChart', () => {
+  it('omits the synthetic Copilot App client while retaining normal IDE rows', () => {
+    const rows = getCliOverlapIdeRows([
+      makeIdeStats({ ide: 'copilot_app', uniqueUsers: 8, cliOverlapUsers: 0 }),
+      makeIdeStats({ ide: 'vscode', uniqueUsers: 10, cliOverlapUsers: 5 }),
+      makeIdeStats({ ide: 'jetbrains', uniqueUsers: 4, cliOverlapUsers: 1 }),
+      makeIdeStats({ ide: 'unused', uniqueUsers: 0, cliOverlapUsers: 0 }),
+    ]);
+
+    expect(rows.map(row => row.ide)).toEqual(['vscode', 'jetbrains']);
+  });
+});

--- a/src/components/features/user-details/day-details/DayDetailsModal.tsx
+++ b/src/components/features/user-details/day-details/DayDetailsModal.tsx
@@ -10,8 +10,9 @@ import DayImpactCard from './DayImpactCard';
 import DayFeatureBreakdown from './DayFeatureBreakdown';
 import DayClientDistributionChart from '../charts/DayClientDistributionChart';
 import type { VoidCallback } from '../../../../types/events';
-import { isAgentFeature, isCliFeature, isCodeCompletionFeature } from '../../../../domain/featureCategories';
+import { isAgentFeature, isCliFeature, isCodeCompletionFeature, isCopilotAppFeature } from '../../../../domain/featureCategories';
 import { formatAiCreditCost } from '../../../../utils/formatters';
+import { getTotalUserInitiatedInteractionCount } from '../../../../domain/assumedInteractions';
 
 interface DayDetailsModalProps {
   isOpen: boolean;
@@ -49,6 +50,28 @@ interface FeaturePill {
   className: string;
 }
 
+function hasCopilotAppActivity(dayMetrics: UserDayData): boolean {
+  const appTotals = dayMetrics.totals_by_copilot_app;
+  return Boolean(dayMetrics.used_copilot_app)
+    || Boolean(appTotals && (
+      appTotals.session_count > 0
+      || appTotals.request_count > 0
+      || appTotals.prompt_count > 0
+      || appTotals.token_usage.prompt_tokens_sum > 0
+      || appTotals.token_usage.output_tokens_sum > 0
+    ))
+    || dayMetrics.totals_by_feature.some(
+      (f) => isCopilotAppFeature(f.feature) && (
+        f.user_initiated_interaction_count > 0
+        || f.code_generation_activity_count > 0
+        || f.code_acceptance_activity_count > 0
+      )
+    )
+    || dayMetrics.totals_by_ide.some(
+      (ide) => ide.ide === 'copilot_app' && getTotalUserInitiatedInteractionCount(ide) > 0
+    );
+}
+
 function buildFeaturePills(dayMetrics: UserDayData, hasCliActivity: boolean): FeaturePill[] {
   const features = dayMetrics.totals_by_feature ?? [];
   const usedCompletions = features.some(
@@ -77,6 +100,9 @@ function buildFeaturePills(dayMetrics: UserDayData, hasCliActivity: boolean): Fe
   }
   if (hasCliActivity) {
     pills.push({ label: 'CLI', className: `${pillBase} bg-teal-100 text-teal-800` });
+  }
+  if (hasCopilotAppActivity(dayMetrics)) {
+    pills.push({ label: 'Copilot App', className: `${pillBase} bg-gray-100 text-gray-800` });
   }
   if (usedCompletions) {
     pills.push({ label: 'Completions', className: `${pillBase} bg-blue-100 text-blue-800` });
@@ -112,6 +138,9 @@ const clientColumns: TableColumn<ClientRow>[] = [
   { id: 'locDeleted', header: 'LOC Deleted', headerClassName: headerRight, className: cellRight, renderCell: (r) => r.loc_deleted_sum.toLocaleString() },
   { id: 'pluginVersion', header: 'Plugin Version', headerClassName: headerRight, className: cellRight, renderCell: (r) => r.plugin_version },
 ];
+
+const usageStatLabelClass = 'text-xs font-medium text-gray-500 uppercase tracking-wider';
+const usageStatValueClass = 'mt-1 text-2xl font-semibold text-gray-900';
 
 const languageModelColumns: TableColumn<LanguageModelRow>[] = [
   { id: 'language', header: 'Language', headerClassName: headerLeft, className: cellLeft, renderCell: (r) => r.language || 'Unknown' },
@@ -158,7 +187,9 @@ export default function DayDetailsModal({ isOpen, onClose, date, dayMetrics, use
   const cliInteractionCount = cliDayTotals.interactionCount;
 
   const featurePills = hasData ? buildFeaturePills(dayMetrics!, hasCliActivity) : [];
-  const ideClientRows = hasData ? mapIdeClientActivityRows(dayMetrics!.totals_by_ide) : [];
+  const ideClientRows = hasData ? mapIdeClientActivityRows(
+    dayMetrics!.totals_by_ide.filter((ide) => ide.ide !== 'copilot_app')
+  ) : [];
   const ideVersionByClient = hasData
     ? new Map(dayMetrics!.totals_by_ide.map((ide) => [
       ide.ide,
@@ -192,6 +223,21 @@ export default function DayDetailsModal({ isOpen, onClose, date, dayMetrics, use
         : 'Unknown',
     }] : []),
   ] : [];
+  const copilotAppUsage = hasData && hasCopilotAppActivity(dayMetrics!)
+    ? dayMetrics!.totals_by_copilot_app
+    : undefined;
+
+  const formatCount = (value: number) => value.toLocaleString();
+  const formatAverageTokens = (value: number) => value.toLocaleString(undefined, {
+    maximumFractionDigits: 1,
+  });
+
+  const renderCopilotAppUsageStat = (label: string, value: string) => (
+    <div className="rounded-md border border-gray-200 bg-gray-50 p-4">
+      <div className={usageStatLabelClass}>{label}</div>
+      <div className={usageStatValueClass}>{value}</div>
+    </div>
+  );
 
   return (
     <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
@@ -294,6 +340,26 @@ export default function DayDetailsModal({ isOpen, onClose, date, dayMetrics, use
                   totalsByModelFeature={dayMetrics.totals_by_model_feature}
                 />
               </div>
+
+              {copilotAppUsage && (
+                <div className="bg-white rounded-md border border-[#d1d9e0] p-6">
+                  <h4 className="text-lg font-semibold text-gray-900 mb-1">Copilot App Usage</h4>
+                  <p className="text-sm text-gray-600 mb-4">
+                    Session and token totals reported by totals_by_copilot_app for this day.
+                  </p>
+                  <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+                    {renderCopilotAppUsageStat('Sessions', formatCount(copilotAppUsage.session_count))}
+                    {renderCopilotAppUsageStat('Requests', formatCount(copilotAppUsage.request_count))}
+                    {renderCopilotAppUsageStat('Prompts', formatCount(copilotAppUsage.prompt_count))}
+                    {renderCopilotAppUsageStat('Prompt tokens', formatCount(copilotAppUsage.token_usage.prompt_tokens_sum))}
+                    {renderCopilotAppUsageStat('Output tokens', formatCount(copilotAppUsage.token_usage.output_tokens_sum))}
+                    {renderCopilotAppUsageStat(
+                      'Avg tokens / request',
+                      formatAverageTokens(copilotAppUsage.token_usage.avg_tokens_per_request)
+                    )}
+                  </div>
+                </div>
+              )}
 
               {/* Activity by Client section (includes IDE & CLI clients) */}
               <div className="bg-white rounded-md border border-[#d1d9e0] p-6">

--- a/src/components/features/user-details/day-details/__tests__/DayDetailsModal.test.tsx
+++ b/src/components/features/user-details/day-details/__tests__/DayDetailsModal.test.tsx
@@ -1,0 +1,112 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it, vi } from 'vitest';
+import type { UserDayData } from '../../../../../types/metrics';
+import DayDetailsModal from '../DayDetailsModal';
+
+vi.mock('../DayImpactCard', () => ({
+  default: () => <div>Impact card</div>,
+}));
+
+vi.mock('../DayFeatureBreakdown', () => ({
+  default: () => <div>Feature breakdown</div>,
+}));
+
+vi.mock('../../charts/DayClientDistributionChart', () => ({
+  default: () => <div>Client distribution</div>,
+}));
+
+function makeDayMetrics(overrides: Partial<UserDayData> = {}): UserDayData {
+  return {
+    day: '2024-01-15',
+    user_initiated_interaction_count: 0,
+    code_generation_activity_count: 0,
+    code_acceptance_activity_count: 0,
+    loc_added_sum: 0,
+    loc_deleted_sum: 0,
+    loc_suggested_to_add_sum: 0,
+    loc_suggested_to_delete_sum: 0,
+    ai_credits_used: 0,
+    used_copilot_app: false,
+    used_copilot_coding_agent: false,
+    used_copilot_code_review_active: false,
+    used_copilot_code_review_passive: false,
+    totals_by_feature: [],
+    totals_by_ide: [],
+    totals_by_language_feature: [],
+    totals_by_language_model: [],
+    totals_by_model_feature: [],
+    ...overrides,
+  };
+}
+
+describe('DayDetailsModal', () => {
+  it('identifies Copilot App activity and renders app session and token totals separately from IDE clients', () => {
+    const markup = renderToStaticMarkup(
+      <DayDetailsModal
+        isOpen
+        onClose={vi.fn()}
+        date="2024-01-15"
+        userLogin="octocat"
+        dayMetrics={makeDayMetrics({
+          used_copilot_app: true,
+          totals_by_copilot_app: {
+            session_count: 1,
+            request_count: 90,
+            prompt_count: 7,
+            token_usage: {
+              avg_tokens_per_request: 138654.93,
+              output_tokens_sum: 49838,
+              prompt_tokens_sum: 12429106,
+            },
+          },
+          totals_by_ide: [
+            {
+              ide: 'copilot_app',
+              user_initiated_interaction_count: 90,
+              code_generation_activity_count: 0,
+              code_acceptance_activity_count: 0,
+              loc_added_sum: 0,
+              loc_deleted_sum: 0,
+              loc_suggested_to_add_sum: 0,
+              loc_suggested_to_delete_sum: 0,
+            },
+            {
+              ide: 'vscode',
+              user_initiated_interaction_count: 3,
+              code_generation_activity_count: 2,
+              code_acceptance_activity_count: 1,
+              loc_added_sum: 5,
+              loc_deleted_sum: 1,
+              loc_suggested_to_add_sum: 8,
+              loc_suggested_to_delete_sum: 2,
+              last_known_plugin_version: {
+                sampled_at: '2024-01-15T00:00:00Z',
+                plugin: 'vscode-copilot',
+                plugin_version: '1.2.3',
+              },
+            },
+          ],
+        })}
+      />
+    );
+
+    expect(markup).toContain('Copilot App');
+    expect(markup).toContain('Copilot App Usage');
+    expect(markup).toContain('Session and token totals reported by totals_by_copilot_app for this day.');
+    expect(markup).toContain('Sessions');
+    expect(markup).toContain('>1<');
+    expect(markup).toContain('Requests');
+    expect(markup).toContain('>90<');
+    expect(markup).toContain('Prompts');
+    expect(markup).toContain('>7<');
+    expect(markup).toContain('Prompt tokens');
+    expect(markup).toContain('>12,429,106<');
+    expect(markup).toContain('Output tokens');
+    expect(markup).toContain('>49,838<');
+    expect(markup).toContain('Avg tokens / request');
+    expect(markup).toContain('>138,654.9<');
+    expect(markup).toContain('VS Code');
+    expect(markup).toContain('vscode-copilot v1.2.3');
+    expect(markup).not.toContain('<span>Copilot App</span>');
+  });
+});

--- a/src/domain/calculators/userDetailCalculator.ts
+++ b/src/domain/calculators/userDetailCalculator.ts
@@ -267,6 +267,7 @@ export function accumulateUserDetail(
     loc_suggested_to_add_sum: metric.loc_suggested_to_add_sum,
     loc_suggested_to_delete_sum: metric.loc_suggested_to_delete_sum,
     ai_credits_used: metric.ai_credits_used,
+    used_copilot_app: metric.used_copilot_app ?? false,
     used_copilot_coding_agent: usedCopilotCloudAgent,
     used_copilot_code_review_active: metric.used_copilot_code_review_active ?? false,
     used_copilot_code_review_passive: metric.used_copilot_code_review_passive ?? false,

--- a/src/types/metrics.ts
+++ b/src/types/metrics.ts
@@ -246,6 +246,7 @@ export interface UserDayData {
   loc_suggested_to_add_sum: number;
   loc_suggested_to_delete_sum: number;
   ai_credits_used: number;
+  used_copilot_app?: boolean;
   used_copilot_coding_agent: boolean;
   used_copilot_code_review_active: boolean;
   used_copilot_code_review_passive: boolean;


### PR DESCRIPTION
## Why

Copilot App activity was being omitted from per-user day details while also leaking into IDE-oriented views. This change keeps Copilot App metrics visible where they belong and prevents synthetic app rows from being labeled as IDE-only usage.

| Commit | Change |
|--------|--------|
| `fix: show Copilot App day details` | Adds a dedicated Copilot App day-details section with session, request, prompt, and token totals while keeping app activity out of IDE/plugin client rows. |
| `fix: exclude Copilot App from CLI IDE overlap` | Filters the synthetic `copilot_app` row from CLI Adoption by IDE while retaining normal IDE rows. |