### PR TITLE
Add surface productivity analysis

### DIFF
--- a/.impeccable/live/config.json
+++ b/.impeccable/live/config.json
@@ -1,0 +1,6 @@
+{
+  "files": ["src/app/layout.tsx"],
+  "insertBefore": "</body>",
+  "commentSyntax": "jsx",
+  "cspChecked": true
+}

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,0 +1,33 @@
+# Product
+
+## Register
+
+product
+
+## Users
+
+Engineering leaders and GitHub Copilot administrators reviewing organization-level usage exports in a focused analytics workflow. They need to understand adoption, compare how Copilot surfaces are used, identify meaningful patterns, and decide where enablement or deeper investigation is warranted.
+
+## Product Purpose
+
+Provide a private, client-side workspace for turning GitHub Copilot user-level metrics exports into trustworthy, actionable analysis. Success means users can move from a broad organizational signal to the relevant feature, client, language, model, or user detail without mistaking activity metrics for proven causal outcomes.
+
+## Brand Personality
+
+Analytical, trustworthy, decision-oriented. The product should communicate evidence clearly, explain metric limitations, and help users reach a defensible interpretation without overstating certainty.
+
+## Anti-references
+
+Avoid dense BI-style dashboards dominated by filters, controls, and undifferentiated charts. Avoid decorative analytics, unexplained composite scores, and visual hierarchy that makes every metric appear equally important.
+
+## Design Principles
+
+- Lead with the decision the evidence can support, then make the underlying measures inspectable.
+- Distinguish observed activity from interpretation and avoid implying causation.
+- Prefer a focused analytical narrative over a wall of interchangeable charts.
+- Preserve context while moving from organization-level patterns to detailed evidence.
+- Keep sensitive metrics local and make the client-side data boundary clear.
+
+## Accessibility & Inclusion
+
+Match the existing application accessibility baseline and component behavior. Continue to use text labels alongside color, preserve keyboard-accessible controls, and follow the existing responsive and reduced-motion conventions where present.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Visualize GitHub Copilot usage metrics from your organization. Upload metrics ND
 - Drill down into individual user activity with feature adoption radar charts
 - Model usage analysis
 - CLI adoption trends, sessions, and token usage
+- IDE, CLI, and Copilot App productivity-proxy comparison
 - IDE and VS Code extension version analysis
 - Statistics by programming language and Copilot feature
 - Responsive layout, deployable as a static site to GitHub Pages

--- a/docs/project-overview.md
+++ b/docs/project-overview.md
@@ -42,7 +42,7 @@ Next.js App Router SPA, TypeScript, Tailwind CSS. All rendering is client-side.
 - `NavigationContext` (`src/state/NavigationContext.tsx`) — manages current view and selected user
 - `MetricsWorkerContext` (`src/state/MetricsWorkerContext.tsx`) — owns the main-thread worker client lifecycle and exposes parse, user-detail, and reset operations
 
-**All view components consume pre-aggregated data.** No component accesses raw `CopilotMetrics[]` directly. The canonical `AggregatedMetrics` worker/UI contract is declared in `src/types/aggregatedMetrics.ts` and groups every aggregate under one owning domain slice. Feature read-model selectors in `src/read-models/` navigate only the slices they need; overview, executive summary, users, user details, Copilot adoption, AI adoption phases, Copilot impact, languages, clients, client versions, model details, CLI adoption, and AI credits retain their narrow runtime projections. Standard route adapters in `src/components/layout/routes/` own the selector and route each non-specialized view to the relevant presentation boundary, so only the selected route computes its projection. The feature-owned `UserDetailsRoute` in `src/components/features/user-details/` owns user selection, on-demand worker requests, stale-result protection, redirects, recovery, and delivery of the user-details view model. The worker retains a compact user-detail accumulator so it can serve those requests without moving raw records onto the main thread.
+**All view components consume pre-aggregated data.** No component accesses raw `CopilotMetrics[]` directly. The canonical `AggregatedMetrics` worker/UI contract is declared in `src/types/aggregatedMetrics.ts` and groups every aggregate under one owning domain slice. Feature read-model selectors in `src/read-models/` navigate only the slices they need; overview, executive summary, users, user details, Copilot adoption, AI adoption phases, Copilot impact, surface productivity, languages, clients, client versions, model details, CLI adoption, and AI credits retain their narrow runtime projections. Standard route adapters in `src/components/layout/routes/` own the selector and route each non-specialized view to the relevant presentation boundary, so only the selected route computes its projection. The feature-owned `UserDetailsRoute` in `src/components/features/user-details/` owns user selection, on-demand worker requests, stale-result protection, redirects, recovery, and delivery of the user-details view model. The worker retains a compact user-detail accumulator so it can serve those requests without moving raw records onto the main thread.
 
 ### 3.2. Code Organization
 
@@ -82,7 +82,8 @@ AggregatedMetrics
 ├── clients   IDE stats/counts and plugin versions
 ├── models    daily model usage and model breakdown
 ├── cli       session, token, and adoption series
-└── ai        adoption phases, usage distribution, and credits
+├── ai        adoption phases, usage distribution, and credits
+└── productivity surface reach, active user-days, attributed LOC, and overlap cohorts
 ```
 
 Pure selectors under `src/read-models/` project stable nested references from those slices into unchanged UI contracts without copying, sorting, filtering, or mutation. Selectors may contain only existing deterministic, feature-specific scalar or date derivations, such as client CLI totals, the model-details auto total, CLI model chart dates, and the AI credits user total. Executive summary composes across `overview`, `impact`, and `adoption`; user-details routing preserves the complete grouped aggregate object as its dataset identity.
@@ -97,6 +98,7 @@ Established boundaries cover:
 - clients and client versions
 - model details and CLI adoption
 - AI credits
+- surface productivity
 
 Phase 4 feature read-model boundaries, Phase 6 feature-oriented component organization, Phase 7 thin view routing, Phase 8 grouped aggregate contract migration, and Phase 10 boundary enforcement/cleanup are complete. The typed standard-route registry delegates all non-user-details routes, while the user-details feature owns the complete specialized lifecycle. `ViewRouter` retains only metrics-wide gates and top-level route selection. Phase 9 input-validation work was removed from scope because metrics inputs are validated upstream before they reach this viewer.
 

--- a/src/__tests__/factories/aggregatedMetrics.ts
+++ b/src/__tests__/factories/aggregatedMetrics.ts
@@ -40,6 +40,12 @@ export const AGGREGATED_METRICS_SLICE_KEYS = {
   models: ['modelUsageData', 'modelBreakdownData'],
   cli: ['dailyCliSessionData', 'dailyCliTokenData', 'dailyCliAdoptionTrend'],
   ai: ['aiAdoptionPhaseData', 'usageDistributionData', 'dailyAiCreditsData'],
+  productivity: [
+    'totalActiveUsers',
+    'surfaceSummaries',
+    'dailyProductivity',
+    'cohortSummaries',
+  ],
 } as const satisfies {
   [Slice in keyof AggregatedMetrics]: readonly (keyof AggregatedMetrics[Slice])[];
 };
@@ -63,6 +69,7 @@ export function makeAggregatedMetrics(
     models: { ...defaults.models, ...overrides.models },
     cli: { ...defaults.cli, ...overrides.cli },
     ai: { ...defaults.ai, ...overrides.ai },
+    productivity: { ...defaults.productivity, ...overrides.productivity },
   };
 }
 

--- a/src/components/features/surface-productivity/CohortContextTable.tsx
+++ b/src/components/features/surface-productivity/CohortContextTable.tsx
@@ -1,0 +1,71 @@
+import type { SurfaceCohortSummary } from '../../../types/surfaceProductivity';
+import { COHORT_LABELS } from './surfaceMetadata';
+
+interface CohortContextTableProps {
+  cohorts: SurfaceCohortSummary[];
+}
+
+function formatSigned(value: number): string {
+  return `${value >= 0 ? '+' : ''}${value.toLocaleString()}`;
+}
+
+export default function CohortContextTable({
+  cohorts,
+}: CohortContextTableProps) {
+  return (
+    <section
+      id="surface-productivity-overlap"
+      className="scroll-mt-28 overflow-hidden rounded-md border border-[#d1d9e0] bg-white"
+    >
+      <div className="border-b border-gray-200 px-6 py-4">
+        <h2 className="text-lg font-semibold text-gray-900">Overlap context</h2>
+        <p className="mt-1 max-w-3xl text-sm text-gray-600">
+          Whole-user outcomes grouped by the surfaces each person used. These
+          medians provide context, but do not attribute a multi-surface
+          user&apos;s total output to any single surface.
+        </p>
+      </div>
+      <div className="overflow-x-auto">
+        <table className="min-w-full divide-y divide-gray-200">
+          <thead className="bg-gray-50">
+            <tr>
+              <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+                Usage pattern
+              </th>
+              <th className="px-6 py-3 text-right text-xs font-medium uppercase tracking-wider text-gray-500">
+                Users
+              </th>
+              <th className="px-6 py-3 text-right text-xs font-medium uppercase tracking-wider text-gray-500">
+                Median active days
+              </th>
+              <th className="px-6 py-3 text-right text-xs font-medium uppercase tracking-wider text-gray-500">
+                Median net LOC
+              </th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-200">
+            {cohorts.map(cohort => (
+              <tr key={cohort.cohort}>
+                <th
+                  scope="row"
+                  className="whitespace-nowrap px-6 py-4 text-left text-sm font-medium text-gray-900"
+                >
+                  {COHORT_LABELS[cohort.cohort]}
+                </th>
+                <td className="whitespace-nowrap px-6 py-4 text-right text-sm text-gray-900">
+                  {cohort.users.toLocaleString()}
+                </td>
+                <td className="whitespace-nowrap px-6 py-4 text-right text-sm text-gray-900">
+                  {cohort.medianActiveDays.toLocaleString()}
+                </td>
+                <td className="whitespace-nowrap px-6 py-4 text-right text-sm text-gray-900">
+                  {formatSigned(cohort.medianNetLocImpact)}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}

--- a/src/components/features/surface-productivity/SurfaceComparisonTable.tsx
+++ b/src/components/features/surface-productivity/SurfaceComparisonTable.tsx
@@ -1,0 +1,153 @@
+import type { SurfaceProductivitySummary } from '../../../types/surfaceProductivity';
+import {
+  SURFACE_METADATA,
+  SURFACE_ORDER,
+} from './surfaceMetadata';
+
+interface SurfaceComparisonTableProps {
+  summaries: SurfaceProductivitySummary[];
+}
+
+function LocImpact({
+  locAdded,
+  locDeleted,
+}: {
+  locAdded: number;
+  locDeleted: number;
+}) {
+  return (
+    <>
+      <span className="text-green-600">+{locAdded.toLocaleString()}</span>
+      <span className="text-gray-400"> / </span>
+      <span className="text-red-600">-{locDeleted.toLocaleString()}</span>
+    </>
+  );
+}
+
+function getAverage(value: number, count: number): number {
+  if (count === 0) return 0;
+  return Math.round((value / count) * 10) / 10;
+}
+
+export default function SurfaceComparisonTable({
+  summaries,
+}: SurfaceComparisonTableProps) {
+  const summariesBySurface = new Map(
+    summaries.map(summary => [summary.surface, summary])
+  );
+
+  return (
+    <section
+      id="surface-productivity-comparison"
+      className="scroll-mt-28 overflow-hidden rounded-md border border-[#d1d9e0] bg-white"
+    >
+      <div className="border-b border-gray-200 px-6 py-4">
+        <h2 className="text-lg font-semibold text-gray-900">
+          Surface comparison
+        </h2>
+        <p className="mt-1 max-w-3xl text-sm text-gray-600">
+          Compare reach and active user-days separately from LOC impact. Rates
+          use each surface&apos;s own active days as the denominator.
+        </p>
+      </div>
+      <div className="overflow-x-auto">
+        <table className="min-w-full divide-y divide-gray-200">
+          <thead className="bg-gray-50">
+            <tr>
+              {[
+                'Surface',
+                'Reach',
+                'Active user-days',
+                'Days / user',
+                'LOC impact',
+                'Avg LOC impact / user',
+                'LOC / active day',
+              ].map((label, index) => (
+                <th
+                  key={label}
+                  scope="col"
+                  className={`px-6 py-3 text-xs font-medium uppercase tracking-wider text-gray-500 ${
+                    index === 0 ? 'text-left' : 'text-right'
+                  }`}
+                >
+                  {label}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-200">
+            {SURFACE_ORDER.map(surface => {
+              const summary = summariesBySurface.get(surface);
+              const metadata = SURFACE_METADATA[surface];
+              return (
+                <tr key={surface}>
+                  <th
+                    scope="row"
+                    className="min-w-64 px-6 py-4 text-left font-normal"
+                  >
+                    <div className="flex items-start gap-3">
+                      <span
+                        className={`mt-1.5 h-2.5 w-2.5 shrink-0 rounded-full ${metadata.dotClassName}`}
+                        aria-hidden="true"
+                      />
+                      <span>
+                        <span className="block text-sm font-semibold text-gray-900">
+                          {metadata.label}
+                        </span>
+                        <span className="mt-0.5 block text-xs text-gray-500">
+                          {metadata.shortDescription}
+                        </span>
+                      </span>
+                    </div>
+                  </th>
+                  <td className="whitespace-nowrap px-6 py-4 text-right text-sm text-gray-900">
+                    {summary?.uniqueUsers.toLocaleString() ?? '0'}
+                    <span className="ml-1 text-gray-500">
+                      ({summary?.reachPercentage ?? 0}%)
+                    </span>
+                  </td>
+                  <td className="whitespace-nowrap px-6 py-4 text-right text-sm text-gray-900">
+                    {summary?.activeUserDays.toLocaleString() ?? '0'}
+                  </td>
+                  <td className="whitespace-nowrap px-6 py-4 text-right text-sm text-gray-900">
+                    {summary?.activeDaysPerUser.toLocaleString() ?? '0'}
+                  </td>
+                  <td className="whitespace-nowrap px-6 py-4 text-right text-sm font-medium text-gray-900">
+                    <LocImpact
+                      locAdded={summary?.locAdded ?? 0}
+                      locDeleted={summary?.locDeleted ?? 0}
+                    />
+                  </td>
+                  <td className="whitespace-nowrap px-6 py-4 text-right text-sm text-gray-900">
+                    <LocImpact
+                      locAdded={getAverage(
+                        summary?.locAdded ?? 0,
+                        summary?.uniqueUsers ?? 0
+                      )}
+                      locDeleted={getAverage(
+                        summary?.locDeleted ?? 0,
+                        summary?.uniqueUsers ?? 0
+                      )}
+                    />
+                  </td>
+                  <td className="whitespace-nowrap px-6 py-4 text-right text-sm text-gray-900">
+                    <LocImpact
+                      locAdded={getAverage(
+                        summary?.locAdded ?? 0,
+                        summary?.activeUserDays ?? 0
+                      )}
+                      locDeleted={getAverage(
+                        summary?.locDeleted ?? 0,
+                        summary?.activeUserDays ?? 0
+                      )}
+                    />
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}

--- a/src/components/features/surface-productivity/SurfaceProductivityTrendChart.tsx
+++ b/src/components/features/surface-productivity/SurfaceProductivityTrendChart.tsx
@@ -1,0 +1,121 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import type { TooltipItem } from 'chart.js';
+import { Line } from 'react-chartjs-2';
+import type { SurfaceProductivityReadModel } from '../../../read-models/surfaceProductivity';
+import type {
+  CopilotSurface,
+  DailySurfaceProductivity,
+} from '../../../types/surfaceProductivity';
+import { formatShortDate } from '../../../utils/formatters';
+import { mapReportRangeData } from '../../../utils/timeSeries';
+import { registerChartJS } from '../../charts/utils/chartSetup';
+import { createBaseChartOptions, yAxisFormatters } from '../../charts/utils/chartOptions';
+import { createLineDataset } from '../../charts/utils/chartStyles';
+import ChartContainer from '../../ui/ChartContainer';
+import ChartToggleButtons from '../../ui/ChartToggleButtons';
+import {
+  SURFACE_METADATA,
+  SURFACE_ORDER,
+} from './surfaceMetadata';
+
+registerChartJS();
+
+type TrendMetric = 'activeUsers' | 'netLocImpact';
+
+interface SurfaceProductivityTrendChartProps {
+  model: Pick<
+    SurfaceProductivityReadModel,
+    'dailyProductivity' | 'reportStartDay' | 'reportEndDay'
+  >;
+}
+
+const EMPTY_SURFACE_DAY: DailySurfaceProductivity['surfaces'][CopilotSurface] = {
+  activeUsers: 0,
+  locAdded: 0,
+  locDeleted: 0,
+  netLocImpact: 0,
+};
+
+const TOGGLE_OPTIONS = [
+  { value: 'activeUsers', label: 'Daily active users' },
+  { value: 'netLocImpact', label: 'Daily net LOC' },
+] satisfies Array<{ value: TrendMetric; label: string }>;
+
+export default function SurfaceProductivityTrendChart({
+  model,
+}: SurfaceProductivityTrendChartProps) {
+  const [metric, setMetric] = useState<TrendMetric>('activeUsers');
+  const data = useMemo(
+    () =>
+      mapReportRangeData(
+        model.dailyProductivity,
+        model.reportStartDay,
+        model.reportEndDay,
+        entry => entry.date,
+        (date, entry) => ({
+          date,
+          surfaces: entry?.surfaces ?? {
+            ide: EMPTY_SURFACE_DAY,
+            cli: EMPTY_SURFACE_DAY,
+            copilotApp: EMPTY_SURFACE_DAY,
+          },
+        })
+      ),
+    [model.dailyProductivity, model.reportEndDay, model.reportStartDay]
+  );
+
+  const chartData = {
+    labels: data.map(entry => formatShortDate(entry.date)),
+    datasets: SURFACE_ORDER.map(surface =>
+      createLineDataset(
+        SURFACE_METADATA[surface].color,
+        SURFACE_METADATA[surface].label,
+        data.map(entry => entry.surfaces[surface][metric])
+      )
+    ),
+  };
+  const isActiveUsers = metric === 'activeUsers';
+  const options = createBaseChartOptions({
+    xAxisLabel: 'Date',
+    yAxisLabel: isActiveUsers ? 'Active users' : 'Net lines changed',
+    beginAtZero: isActiveUsers,
+    yTicksCallback: yAxisFormatters.localeNumber,
+    tooltipLabelCallback: (context: TooltipItem<'line' | 'bar'>) => {
+      const value = context.parsed.y ?? 0;
+      if (isActiveUsers) {
+        return `${context.dataset.label}: ${value.toLocaleString()} active users`;
+      }
+      return `${context.dataset.label}: ${value >= 0 ? '+' : ''}${value.toLocaleString()} net LOC`;
+    },
+  });
+  const hasActivity = data.some(entry =>
+    SURFACE_ORDER.some(surface =>
+      entry.surfaces[surface].activeUsers > 0
+      || entry.surfaces[surface].netLocImpact !== 0
+    )
+  );
+
+  return (
+    <ChartContainer
+      title="How surface activity changes over time"
+      description={
+        isActiveUsers
+          ? 'Daily users are counted once per surface. A person active in more than one surface appears in each relevant series.'
+          : 'Net LOC is lines added minus lines deleted, attributed to the surface that reported the activity.'
+      }
+      headerActions={
+        <ChartToggleButtons
+          options={TOGGLE_OPTIONS}
+          value={metric}
+          onChange={setMetric}
+        />
+      }
+      isEmpty={!hasActivity}
+      emptyState="No IDE, CLI, or Copilot App activity was detected in this report."
+    >
+      <Line data={chartData} options={options} />
+    </ChartContainer>
+  );
+}

--- a/src/components/features/surface-productivity/SurfaceProductivityView.tsx
+++ b/src/components/features/surface-productivity/SurfaceProductivityView.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+import type { SurfaceProductivityReadModel } from '../../../read-models/surfaceProductivity';
+import { ViewPanel } from '../../ui';
+import DisclosureSection from '../../ui/DisclosureSection';
+import CohortContextTable from './CohortContextTable';
+import SurfaceComparisonTable from './SurfaceComparisonTable';
+import SurfaceProductivityTrendChart from './SurfaceProductivityTrendChart';
+
+interface SurfaceProductivityViewProps {
+  model: SurfaceProductivityReadModel;
+}
+
+export default function SurfaceProductivityView({
+  model,
+}: SurfaceProductivityViewProps) {
+  return (
+    <ViewPanel
+      headerProps={{
+        title: 'Productivity by Copilot Surface',
+        description:
+          'Compare how active work and LOC impact are distributed across IDE, CLI, and Copilot App activity.',
+      }}
+      afterHeader={
+        <div
+          className="mt-4 rounded-md border border-blue-200 bg-blue-50 px-4 py-3 text-sm text-blue-950"
+          role="note"
+        >
+          <span className="font-semibold">Activity proxy, not causation.</span>{' '}
+          Active days and LOC impact describe where Copilot-assisted work was
+          observed. They do not measure code quality, engineering velocity, or
+          individual developer performance.
+        </div>
+      }
+      contentClassName="space-y-8"
+    >
+      <SurfaceComparisonTable summaries={model.surfaceSummaries} />
+
+      <section id="surface-productivity-trend" className="scroll-mt-28">
+        <SurfaceProductivityTrendChart model={model} />
+      </section>
+
+      <CohortContextTable cohorts={model.cohortSummaries} />
+
+      <section
+        id="surface-productivity-method"
+        className="scroll-mt-28 rounded-md border border-[#d1d9e0] bg-white p-6"
+      >
+        <DisclosureSection
+          label="How to read this view"
+          containerClassName=""
+          buttonClassName="flex w-full items-center justify-between rounded-md bg-gray-50 px-4 py-3 text-left transition-colors hover:bg-gray-100"
+          contentClassName="mt-4 space-y-3 text-sm text-gray-600"
+        >
+          <p>
+            <span className="font-medium text-gray-900">IDE activity</span> is
+            detected from IDE-attributed interactions or LOC. CLI and Copilot
+            App activity use their client totals, usage flags, and
+            feature-attributed activity.
+          </p>
+          <p>
+            <span className="font-medium text-gray-900">Active user-days</span>{' '}
+            count one person once per day within each surface. A person using
+            multiple surfaces on the same day contributes to each relevant
+            surface.
+          </p>
+          <p>
+            <span className="font-medium text-gray-900">Net LOC impact</span> is
+            lines added minus lines deleted. IDE LOC comes from IDE-attributed
+            totals; CLI and Copilot App LOC come from their feature-attributed
+            totals.
+          </p>
+          <p>
+            Surface comparisons are observational. Differences may reflect
+            user role, task type, adoption maturity, or self-selection rather
+            than an effect caused by the surface itself.
+          </p>
+        </DisclosureSection>
+      </section>
+    </ViewPanel>
+  );
+}

--- a/src/components/features/surface-productivity/__tests__/SurfaceProductivityTables.test.tsx
+++ b/src/components/features/surface-productivity/__tests__/SurfaceProductivityTables.test.tsx
@@ -1,0 +1,106 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+import type {
+  SurfaceCohortSummary,
+  SurfaceProductivitySummary,
+} from '../../../../types/surfaceProductivity';
+import CohortContextTable from '../CohortContextTable';
+import SurfaceComparisonTable from '../SurfaceComparisonTable';
+
+const summaries: SurfaceProductivitySummary[] = [
+  {
+    surface: 'ide',
+    uniqueUsers: 12,
+    reachPercentage: 80,
+    activeUserDays: 48,
+    activeDaysPerUser: 4,
+    locAdded: 1200,
+    locDeleted: 200,
+    netLocImpact: 1000,
+    netLocPerActiveDay: 20.8,
+  },
+  {
+    surface: 'cli',
+    uniqueUsers: 5,
+    reachPercentage: 33.3,
+    activeUserDays: 10,
+    activeDaysPerUser: 2,
+    locAdded: 250,
+    locDeleted: 50,
+    netLocImpact: 200,
+    netLocPerActiveDay: 20,
+  },
+  {
+    surface: 'copilotApp',
+    uniqueUsers: 2,
+    reachPercentage: 13.3,
+    activeUserDays: 3,
+    activeDaysPerUser: 1.5,
+    locAdded: 90,
+    locDeleted: 10,
+    netLocImpact: 80,
+    netLocPerActiveDay: 26.7,
+  },
+];
+
+const cohorts: SurfaceCohortSummary[] = [
+  {
+    cohort: 'ideOnly',
+    users: 8,
+    medianActiveDays: 3,
+    medianNetLocImpact: 120,
+  },
+  {
+    cohort: 'cliOnly',
+    users: 1,
+    medianActiveDays: 2,
+    medianNetLocImpact: 40,
+  },
+  {
+    cohort: 'copilotAppOnly',
+    users: 0,
+    medianActiveDays: 0,
+    medianNetLocImpact: 0,
+  },
+  {
+    cohort: 'multiSurface',
+    users: 6,
+    medianActiveDays: 5,
+    medianNetLocImpact: 340,
+  },
+];
+
+describe('surface productivity tables', () => {
+  it('renders all surfaces with separate reach, activity, and LOC measures', () => {
+    const markup = renderToStaticMarkup(
+      <SurfaceComparisonTable summaries={summaries} />
+    );
+
+    expect(markup).toContain('Surface comparison');
+    expect(markup).toContain('IDE');
+    expect(markup).toContain('CLI');
+    expect(markup).toContain('Copilot App');
+    expect(markup).toContain('Active user-days');
+    expect(markup).toContain('LOC impact');
+    expect(markup).toContain('Avg LOC impact / user');
+    expect(markup).toContain('LOC / active day');
+    expect(markup).toContain('(80%)');
+    expect(markup).toContain('text-green-600">+1,200');
+    expect(markup).toContain('text-red-600">-200');
+    expect(markup).toContain('text-green-600">+100');
+    expect(markup).toContain('text-red-600">-16.7');
+    expect(markup).toContain('text-green-600">+25');
+    expect(markup).toContain('text-red-600">-4.2');
+  });
+
+  it('keeps multi-surface users visible without attributing their outcome to one surface', () => {
+    const markup = renderToStaticMarkup(
+      <CohortContextTable cohorts={cohorts} />
+    );
+
+    expect(markup).toContain('Overlap context');
+    expect(markup).toContain('Multiple surfaces');
+    expect(markup).toContain('do not attribute');
+    expect(markup).toContain('Copilot App only');
+  });
+});

--- a/src/components/features/surface-productivity/index.ts
+++ b/src/components/features/surface-productivity/index.ts
@@ -1,0 +1,1 @@
+export { default as SurfaceProductivityView } from './SurfaceProductivityView';

--- a/src/components/features/surface-productivity/surfaceMetadata.ts
+++ b/src/components/features/surface-productivity/surfaceMetadata.ts
@@ -1,0 +1,45 @@
+import type {
+  CopilotSurface,
+  SurfaceCohort,
+} from '../../../types/surfaceProductivity';
+
+export interface SurfaceMetadata {
+  label: string;
+  shortDescription: string;
+  color: string;
+  dotClassName: string;
+}
+
+export const SURFACE_ORDER: readonly CopilotSurface[] = [
+  'ide',
+  'cli',
+  'copilotApp',
+];
+
+export const SURFACE_METADATA: Record<CopilotSurface, SurfaceMetadata> = {
+  ide: {
+    label: 'IDE',
+    shortDescription: 'Editor-attributed activity across installed IDE clients',
+    color: 'rgb(59, 130, 246)',
+    dotClassName: 'bg-blue-500',
+  },
+  cli: {
+    label: 'CLI',
+    shortDescription: 'Copilot CLI sessions and CLI-attributed code impact',
+    color: 'rgb(244, 63, 94)',
+    dotClassName: 'bg-rose-500',
+  },
+  copilotApp: {
+    label: 'Copilot App',
+    shortDescription: 'Activity attributed to the Copilot App surface',
+    color: 'rgb(20, 184, 166)',
+    dotClassName: 'bg-teal-500',
+  },
+};
+
+export const COHORT_LABELS: Record<SurfaceCohort, string> = {
+  ideOnly: 'IDE only',
+  cliOnly: 'CLI only',
+  copilotAppOnly: 'Copilot App only',
+  multiSurface: 'Multiple surfaces',
+};

--- a/src/components/layout/contextSections.ts
+++ b/src/components/layout/contextSections.ts
@@ -27,6 +27,13 @@ export const CLI_ADOPTION_SECTIONS: ContextSection[] = [
   { id: 'cli-models-usage', label: 'CLI Models Daily Usage' },
 ];
 
+export const SURFACE_PRODUCTIVITY_SECTIONS: ContextSection[] = [
+  { id: 'surface-productivity-comparison', label: 'Surface Comparison' },
+  { id: 'surface-productivity-trend', label: 'Activity Trend' },
+  { id: 'surface-productivity-overlap', label: 'Overlap Context' },
+  { id: 'surface-productivity-method', label: 'Method' },
+];
+
 export const CLIENT_ANALYSIS_SECTIONS: ContextSection[] = [
   { id: 'client-distribution', label: 'Client Distribution' },
   { id: 'client-insights', label: 'Insights' },
@@ -75,4 +82,5 @@ export const CONTEXT_SECTIONS: Partial<Record<ViewMode, ContextSection[]>> = {
   [VIEW_MODES.CLIENT_VERSIONS]: CLIENT_VERSIONS_SECTIONS,
   [VIEW_MODES.USER_DETAILS]: USER_DETAILS_SECTIONS,
   [VIEW_MODES.MODEL_DETAILS]: MODEL_DETAILS_SECTIONS,
+  [VIEW_MODES.SURFACE_PRODUCTIVITY]: SURFACE_PRODUCTIVITY_SECTIONS,
 };

--- a/src/components/layout/navigationItems.tsx
+++ b/src/components/layout/navigationItems.tsx
@@ -50,6 +50,15 @@ export const NAV_ITEMS: NavItem[] = [
     ),
   },
   {
+    label: 'Surface',
+    view: VIEW_MODES.SURFACE_PRODUCTIVITY,
+    icon: (
+      <svg className="w-5 h-5" aria-hidden="true" focusable="false" fill="none" stroke="currentColor" strokeWidth={1.5} viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 18h16.5M5.25 15V9.75m6.75 5.25V5.25m6.75 9.75v-3.75" />
+      </svg>
+    ),
+  },
+  {
     label: 'Copilot Impact',
     view: VIEW_MODES.COPILOT_IMPACT,
     icon: (

--- a/src/components/layout/routes/__tests__/standardRouteRegistry.test.tsx
+++ b/src/components/layout/routes/__tests__/standardRouteRegistry.test.tsx
@@ -13,6 +13,7 @@ import type {
 } from '../../../../read-models/overview';
 import type { LanguagesReadModel } from '../../../../read-models/languages';
 import type { UsersReadModel } from '../../../../read-models/users';
+import type { SurfaceProductivityReadModel } from '../../../../read-models/surfaceProductivity';
 import type { AggregatedMetrics } from '../../../../types/aggregatedMetrics';
 import { VIEW_MODES } from '../../../../types/navigation';
 import {
@@ -35,6 +36,7 @@ import {
   ModelDetailsRouteAdapter,
   OverviewRouteAdapter,
   UsersRouteAdapter,
+  SurfaceProductivityRouteAdapter,
   type StandardRouteContext,
 } from '../standardRouteAdapters';
 
@@ -61,6 +63,8 @@ const mocks = vi.hoisted(() => ({
     vi.fn<(metrics: AggregatedMetrics) => CopilotImpactReadModel>(),
   selectLanguagesReadModel:
     vi.fn<(metrics: AggregatedMetrics) => LanguagesReadModel>(),
+  selectSurfaceProductivityReadModel:
+    vi.fn<(metrics: AggregatedMetrics) => SurfaceProductivityReadModel>(),
   overviewView:
     vi.fn<
       (props: {
@@ -86,6 +90,8 @@ const mocks = vi.hoisted(() => ({
     vi.fn<(props: { model: CopilotImpactReadModel }) => void>(),
   languagesView:
     vi.fn<(props: { model: LanguagesReadModel }) => void>(),
+  surfaceProductivityView:
+    vi.fn<(props: { model: SurfaceProductivityReadModel }) => void>(),
   aboutView: vi.fn(),
 }));
 
@@ -126,6 +132,11 @@ vi.mock('../../../../read-models/impact', () => ({
   selectCopilotImpactReadModel: mocks.selectCopilotImpactReadModel,
 }));
 
+vi.mock('../../../../read-models/surfaceProductivity', () => ({
+  selectSurfaceProductivityReadModel:
+    mocks.selectSurfaceProductivityReadModel,
+}));
+
 vi.mock('../../../features/client-versions', () => ({
   ClientVersionsView: (props: { model: ClientVersionsReadModel }) => {
     mocks.clientVersionsView(props);
@@ -157,6 +168,15 @@ vi.mock('../../../features/impact', () => ({
 vi.mock('../../../features/languages', () => ({
   LanguagesView: (props: { model: LanguagesReadModel }) => {
     mocks.languagesView(props);
+    return null;
+  },
+}));
+
+vi.mock('../../../features/surface-productivity', () => ({
+  SurfaceProductivityView: (props: {
+    model: SurfaceProductivityReadModel;
+  }) => {
+    mocks.surfaceProductivityView(props);
     return null;
   },
 }));
@@ -205,6 +225,7 @@ describe('standard route registry', () => {
   let clientVersionsModel: ClientVersionsReadModel;
   let copilotImpactModel: CopilotImpactReadModel;
   let languagesModel: LanguagesReadModel;
+  let surfaceProductivityModel: SurfaceProductivityReadModel;
 
   beforeEach(() => {
     const aggregatedMetrics = aggregateMetrics([makeMetric()]).aggregated;
@@ -247,6 +268,7 @@ describe('standard route registry', () => {
       editModeImpactData: aggregatedMetrics.impact.editModeImpactData,
       inlineModeImpactData: aggregatedMetrics.impact.inlineModeImpactData,
       askModeImpactData: aggregatedMetrics.impact.askModeImpactData,
+      copilotAppImpactData: aggregatedMetrics.impact.copilotAppImpactData,
       cliImpactData: aggregatedMetrics.impact.cliImpactData,
       joinedImpactData: aggregatedMetrics.impact.joinedImpactData,
     };
@@ -255,6 +277,14 @@ describe('standard route registry', () => {
       languageFeatureImpactData: aggregatedMetrics.languages.languageFeatureImpactData,
       dailyLanguageGenerationsData: aggregatedMetrics.languages.dailyLanguageGenerationsData,
       dailyLanguageLocData: aggregatedMetrics.languages.dailyLanguageLocData,
+    };
+    surfaceProductivityModel = {
+      reportStartDay: aggregatedMetrics.overview.stats.reportStartDay,
+      reportEndDay: aggregatedMetrics.overview.stats.reportEndDay,
+      totalActiveUsers: aggregatedMetrics.productivity.totalActiveUsers,
+      surfaceSummaries: aggregatedMetrics.productivity.surfaceSummaries,
+      dailyProductivity: aggregatedMetrics.productivity.dailyProductivity,
+      cohortSummaries: aggregatedMetrics.productivity.cohortSummaries,
     };
     context = {
       aggregatedMetrics,
@@ -271,6 +301,9 @@ describe('standard route registry', () => {
     mocks.selectClientVersionsReadModel.mockReturnValue(clientVersionsModel);
     mocks.selectCopilotImpactReadModel.mockReturnValue(copilotImpactModel);
     mocks.selectLanguagesReadModel.mockReturnValue(languagesModel);
+    mocks.selectSurfaceProductivityReadModel.mockReturnValue(
+      surfaceProductivityModel
+    );
   });
 
   it('covers every view mode except specialized user details', () => {
@@ -302,6 +335,7 @@ describe('standard route registry', () => {
       [VIEW_MODES.AI_ADOPTION_PHASES]: AiAdoptionPhasesRouteAdapter,
       [VIEW_MODES.MODEL_DETAILS]: ModelDetailsRouteAdapter,
       [VIEW_MODES.CLI_ADOPTION]: CliAdoptionRouteAdapter,
+      [VIEW_MODES.SURFACE_PRODUCTIVITY]: SurfaceProductivityRouteAdapter,
     });
   });
 
@@ -402,6 +436,7 @@ describe('standard route registry', () => {
     expect(mocks.copilotAdoptionView).toHaveBeenCalledWith({
       model: copilotAdoptionModel,
     });
+
     expect(mocks.selectAiAdoptionPhaseReadModel).toHaveBeenCalledWith(
       context.aggregatedMetrics
     );
@@ -417,6 +452,21 @@ describe('standard route registry', () => {
     expect(mocks.selectOverviewReadModel).not.toHaveBeenCalled();
     expect(mocks.selectUsersReadModel).not.toHaveBeenCalled();
     expect(mocks.selectAiCreditsReadModel).not.toHaveBeenCalled();
+  });
+
+  it('selects and renders the surface productivity adapter', () => {
+    const SurfaceProductivityAdapter = resolveStandardRouteAdapter(
+      VIEW_MODES.SURFACE_PRODUCTIVITY
+    );
+
+    renderToStaticMarkup(<SurfaceProductivityAdapter {...context} />);
+
+    expect(
+      mocks.selectSurfaceProductivityReadModel
+    ).toHaveBeenCalledWith(context.aggregatedMetrics);
+    expect(mocks.surfaceProductivityView).toHaveBeenCalledWith({
+      model: surfaceProductivityModel,
+    });
   });
 
   it('renders about without selecting aggregate-backed models', () => {

--- a/src/components/layout/routes/standardRouteAdapters.tsx
+++ b/src/components/layout/routes/standardRouteAdapters.tsx
@@ -16,6 +16,7 @@ import {
   selectOverviewReadModel,
 } from '../../../read-models/overview';
 import { selectUsersReadModel } from '../../../read-models/users';
+import { selectSurfaceProductivityReadModel } from '../../../read-models/surfaceProductivity';
 import AboutView from '../../AboutView';
 import AiCreditsView from '../../AiCreditsView';
 import CLIAdoptionView from '../../CLIAdoptionView';
@@ -29,6 +30,7 @@ import { CopilotImpactView } from '../../features/impact';
 import { LanguagesView } from '../../features/languages';
 import { OverviewDashboard } from '../../features/overview';
 import { UsersView } from '../../features/users';
+import { SurfaceProductivityView } from '../../features/surface-productivity';
 
 export interface StandardRouteContext {
   aggregatedMetrics: AggregatedMetrics;
@@ -155,6 +157,16 @@ export function CliAdoptionRouteAdapter({
   return (
     <CLIAdoptionView
       model={selectCliAdoptionReadModel(aggregatedMetrics)}
+    />
+  );
+}
+
+export function SurfaceProductivityRouteAdapter({
+  aggregatedMetrics,
+}: StandardRouteContext) {
+  return (
+    <SurfaceProductivityView
+      model={selectSurfaceProductivityReadModel(aggregatedMetrics)}
     />
   );
 }

--- a/src/components/layout/routes/standardRouteRegistry.ts
+++ b/src/components/layout/routes/standardRouteRegistry.ts
@@ -13,6 +13,7 @@ import {
   ModelDetailsRouteAdapter,
   OverviewRouteAdapter,
   UsersRouteAdapter,
+  SurfaceProductivityRouteAdapter,
   type StandardRouteAdapter,
 } from './standardRouteAdapters';
 
@@ -35,6 +36,7 @@ export const STANDARD_VIEW_MODES = [
   VIEW_MODES.AI_ADOPTION_PHASES,
   VIEW_MODES.MODEL_DETAILS,
   VIEW_MODES.CLI_ADOPTION,
+  VIEW_MODES.SURFACE_PRODUCTIVITY,
 ] as const satisfies readonly StandardViewMode[];
 
 export const STANDARD_ROUTE_REGISTRY = {
@@ -51,6 +53,7 @@ export const STANDARD_ROUTE_REGISTRY = {
   [VIEW_MODES.AI_ADOPTION_PHASES]: AiAdoptionPhasesRouteAdapter,
   [VIEW_MODES.MODEL_DETAILS]: ModelDetailsRouteAdapter,
   [VIEW_MODES.CLI_ADOPTION]: CliAdoptionRouteAdapter,
+  [VIEW_MODES.SURFACE_PRODUCTIVITY]: SurfaceProductivityRouteAdapter,
 } satisfies Record<StandardViewMode, StandardRouteAdapter>;
 
 export function isStandardViewMode(view: string): view is StandardViewMode {

--- a/src/domain/__tests__/metricsAggregator.orchestration.test.ts
+++ b/src/domain/__tests__/metricsAggregator.orchestration.test.ts
@@ -40,6 +40,7 @@ const aggregateSliceKeys = [
   'models',
   'cli',
   'ai',
+  'productivity',
 ] as const satisfies readonly (keyof AggregatedMetrics)[];
 
 const ideTotal = (ide: string, interactions: number) => ({

--- a/src/domain/aggregation/__tests__/surfaceProductivityAggregation.test.ts
+++ b/src/domain/aggregation/__tests__/surfaceProductivityAggregation.test.ts
@@ -91,6 +91,10 @@ describe('surface productivity aggregation', () => {
         user_id: 3,
         used_cli: true,
       }),
+      makeMetric({
+        day: '2024-01-17',
+        user_id: 4,
+      }),
     ];
 
     for (const record of records) {
@@ -100,6 +104,7 @@ describe('surface productivity aggregation', () => {
     const result = finalizeSurfaceProductivityAggregation(accumulator);
 
     expect(result.totalActiveUsers).toBe(3);
+    expect(result.dailyProductivity).toHaveLength(2);
     expect(result.surfaceSummaries).toEqual([
       {
         surface: 'ide',

--- a/src/domain/aggregation/__tests__/surfaceProductivityAggregation.test.ts
+++ b/src/domain/aggregation/__tests__/surfaceProductivityAggregation.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it } from 'vitest';
+import { makeMetric } from '../../../__tests__/factories/metrics';
+import type { CopilotMetrics } from '../../../types/metrics';
+import {
+  accumulateSurfaceProductivityAggregation,
+  createSurfaceProductivityAggregationAccumulator,
+  finalizeSurfaceProductivityAggregation,
+} from '../surfaceProductivityAggregation';
+
+const ideTotal = (
+  locAdded: number,
+  locDeleted: number
+): CopilotMetrics['totals_by_ide'][number] => ({
+  ide: 'vscode',
+  user_initiated_interaction_count: 1,
+  code_generation_activity_count: 1,
+  code_acceptance_activity_count: 1,
+  loc_added_sum: locAdded,
+  loc_deleted_sum: locDeleted,
+  loc_suggested_to_add_sum: locAdded,
+  loc_suggested_to_delete_sum: locDeleted,
+});
+
+const featureTotal = (
+  feature: string,
+  locAdded: number,
+  locDeleted: number
+): CopilotMetrics['totals_by_feature'][number] => ({
+  feature,
+  user_initiated_interaction_count: 1,
+  code_generation_activity_count: 1,
+  code_acceptance_activity_count: 1,
+  loc_added_sum: locAdded,
+  loc_deleted_sum: locDeleted,
+  loc_suggested_to_add_sum: locAdded,
+  loc_suggested_to_delete_sum: locDeleted,
+});
+
+describe('surface productivity aggregation', () => {
+  it('preserves explicit zero rows for every surface and cohort', () => {
+    expect(
+      finalizeSurfaceProductivityAggregation(
+        createSurfaceProductivityAggregationAccumulator()
+      )
+    ).toEqual({
+      totalActiveUsers: 0,
+      surfaceSummaries: [
+        expect.objectContaining({ surface: 'ide', uniqueUsers: 0 }),
+        expect.objectContaining({ surface: 'cli', uniqueUsers: 0 }),
+        expect.objectContaining({ surface: 'copilotApp', uniqueUsers: 0 }),
+      ],
+      dailyProductivity: [],
+      cohortSummaries: [
+        expect.objectContaining({ cohort: 'ideOnly', users: 0 }),
+        expect.objectContaining({ cohort: 'cliOnly', users: 0 }),
+        expect.objectContaining({ cohort: 'copilotAppOnly', users: 0 }),
+        expect.objectContaining({ cohort: 'multiSurface', users: 0 }),
+      ],
+    });
+  });
+
+  it('separates surface reach, active user-days, attributed LOC, and overlap cohorts', () => {
+    const accumulator = createSurfaceProductivityAggregationAccumulator();
+    const records = [
+      makeMetric({
+        day: '2024-01-15',
+        user_id: 1,
+        loc_added_sum: 60,
+        loc_deleted_sum: 7,
+        used_cli: true,
+        totals_by_ide: [ideTotal(40, 5)],
+        totals_by_feature: [featureTotal('copilot_cli', 20, 2)],
+      }),
+      makeMetric({
+        day: '2024-01-16',
+        user_id: 1,
+        loc_added_sum: 50,
+        loc_deleted_sum: 5,
+        totals_by_ide: [ideTotal(50, 5)],
+      }),
+      makeMetric({
+        day: '2024-01-15',
+        user_id: 2,
+        loc_added_sum: 30,
+        loc_deleted_sum: 3,
+        used_copilot_app: true,
+        totals_by_feature: [featureTotal('copilot_app', 30, 3)],
+      }),
+      makeMetric({
+        day: '2024-01-16',
+        user_id: 3,
+        used_cli: true,
+      }),
+    ];
+
+    for (const record of records) {
+      accumulateSurfaceProductivityAggregation(accumulator, record);
+    }
+
+    const result = finalizeSurfaceProductivityAggregation(accumulator);
+
+    expect(result.totalActiveUsers).toBe(3);
+    expect(result.surfaceSummaries).toEqual([
+      {
+        surface: 'ide',
+        uniqueUsers: 1,
+        reachPercentage: 33.3,
+        activeUserDays: 2,
+        activeDaysPerUser: 2,
+        locAdded: 90,
+        locDeleted: 10,
+        netLocImpact: 80,
+        netLocPerActiveDay: 40,
+      },
+      {
+        surface: 'cli',
+        uniqueUsers: 2,
+        reachPercentage: 66.7,
+        activeUserDays: 2,
+        activeDaysPerUser: 1,
+        locAdded: 20,
+        locDeleted: 2,
+        netLocImpact: 18,
+        netLocPerActiveDay: 9,
+      },
+      {
+        surface: 'copilotApp',
+        uniqueUsers: 1,
+        reachPercentage: 33.3,
+        activeUserDays: 1,
+        activeDaysPerUser: 1,
+        locAdded: 30,
+        locDeleted: 3,
+        netLocImpact: 27,
+        netLocPerActiveDay: 27,
+      },
+    ]);
+    expect(result.dailyProductivity).toEqual([
+      expect.objectContaining({
+        date: '2024-01-15',
+        surfaces: expect.objectContaining({
+          ide: expect.objectContaining({ activeUsers: 1, netLocImpact: 35 }),
+          cli: expect.objectContaining({ activeUsers: 1, netLocImpact: 18 }),
+          copilotApp: expect.objectContaining({
+            activeUsers: 1,
+            netLocImpact: 27,
+          }),
+        }),
+      }),
+      expect.objectContaining({
+        date: '2024-01-16',
+        surfaces: expect.objectContaining({
+          ide: expect.objectContaining({ activeUsers: 1, netLocImpact: 45 }),
+          cli: expect.objectContaining({ activeUsers: 1, netLocImpact: 0 }),
+          copilotApp: expect.objectContaining({
+            activeUsers: 0,
+            netLocImpact: 0,
+          }),
+        }),
+      }),
+    ]);
+    expect(result.cohortSummaries).toEqual([
+      {
+        cohort: 'ideOnly',
+        users: 0,
+        medianActiveDays: 0,
+        medianNetLocImpact: 0,
+      },
+      {
+        cohort: 'cliOnly',
+        users: 1,
+        medianActiveDays: 1,
+        medianNetLocImpact: 0,
+      },
+      {
+        cohort: 'copilotAppOnly',
+        users: 1,
+        medianActiveDays: 1,
+        medianNetLocImpact: 27,
+      },
+      {
+        cohort: 'multiSurface',
+        users: 1,
+        medianActiveDays: 2,
+        medianNetLocImpact: 98,
+      },
+    ]);
+  });
+});

--- a/src/domain/aggregation/surfaceProductivityAggregation.ts
+++ b/src/domain/aggregation/surfaceProductivityAggregation.ts
@@ -1,0 +1,34 @@
+import type { CopilotMetrics } from '../../types/metrics';
+import type { SurfaceProductivityMetrics } from '../../types/surfaceProductivity';
+import {
+  accumulateSurfaceProductivity,
+  createSurfaceProductivityAccumulator,
+  finalizeSurfaceProductivity,
+  type SurfaceProductivityAccumulator,
+} from '../calculators/surfaceProductivityCalculator';
+
+export interface SurfaceProductivityAggregationAccumulator {
+  productivity: SurfaceProductivityAccumulator;
+}
+
+export type SurfaceProductivityAggregationResult = SurfaceProductivityMetrics;
+
+export function createSurfaceProductivityAggregationAccumulator(
+): SurfaceProductivityAggregationAccumulator {
+  return {
+    productivity: createSurfaceProductivityAccumulator(),
+  };
+}
+
+export function accumulateSurfaceProductivityAggregation(
+  accumulator: SurfaceProductivityAggregationAccumulator,
+  metric: CopilotMetrics
+): void {
+  accumulateSurfaceProductivity(accumulator.productivity, metric);
+}
+
+export function finalizeSurfaceProductivityAggregation(
+  accumulator: SurfaceProductivityAggregationAccumulator
+): SurfaceProductivityAggregationResult {
+  return finalizeSurfaceProductivity(accumulator.productivity);
+}

--- a/src/domain/calculators/surfaceProductivityCalculator.ts
+++ b/src/domain/calculators/surfaceProductivityCalculator.ts
@@ -171,6 +171,8 @@ export function accumulateSurfaceProductivity(
 ): void {
   const userDayKey = `${metric.day}:${metric.user_id}`;
   const activity = getSurfaceActivity(metric);
+  if (!SURFACES.some(surface => activity[surface])) return;
+
   const loc = getSurfaceLoc(metric);
   const daily = accumulator.daily.get(metric.day) ?? createDailyAccumulator();
   const user = accumulator.users.get(metric.user_id) ?? {

--- a/src/domain/calculators/surfaceProductivityCalculator.ts
+++ b/src/domain/calculators/surfaceProductivityCalculator.ts
@@ -1,0 +1,321 @@
+import type { CopilotMetrics } from '../../types/metrics';
+import type {
+  CopilotSurface,
+  DailySurfaceProductivity,
+  SurfaceCohort,
+  SurfaceCohortSummary,
+  SurfaceProductivityMetrics,
+  SurfaceProductivitySummary,
+} from '../../types/surfaceProductivity';
+import { isCliFeature, isCopilotAppFeature } from '../featureCategories';
+import { compareByDateAsc } from './statsCalculators';
+
+interface SurfaceAccumulator {
+  userIds: Set<number>;
+  activeUserDays: Set<string>;
+  locAdded: number;
+  locDeleted: number;
+}
+
+interface DailySurfaceAccumulator {
+  userIds: Set<number>;
+  locAdded: number;
+  locDeleted: number;
+}
+
+interface UserCohortAccumulator {
+  activeDays: Set<string>;
+  surfaces: Set<CopilotSurface>;
+  locAdded: number;
+  locDeleted: number;
+}
+
+export interface SurfaceProductivityAccumulator {
+  allUserIds: Set<number>;
+  surfaces: Record<CopilotSurface, SurfaceAccumulator>;
+  daily: Map<string, Record<CopilotSurface, DailySurfaceAccumulator>>;
+  users: Map<number, UserCohortAccumulator>;
+}
+
+const SURFACES: readonly CopilotSurface[] = ['ide', 'cli', 'copilotApp'];
+
+function createSurfaceAccumulator(): SurfaceAccumulator {
+  return {
+    userIds: new Set(),
+    activeUserDays: new Set(),
+    locAdded: 0,
+    locDeleted: 0,
+  };
+}
+
+function createDailySurfaceAccumulator(): DailySurfaceAccumulator {
+  return {
+    userIds: new Set(),
+    locAdded: 0,
+    locDeleted: 0,
+  };
+}
+
+function createDailyAccumulator(): Record<CopilotSurface, DailySurfaceAccumulator> {
+  return {
+    ide: createDailySurfaceAccumulator(),
+    cli: createDailySurfaceAccumulator(),
+    copilotApp: createDailySurfaceAccumulator(),
+  };
+}
+
+export function createSurfaceProductivityAccumulator(): SurfaceProductivityAccumulator {
+  return {
+    allUserIds: new Set(),
+    surfaces: {
+      ide: createSurfaceAccumulator(),
+      cli: createSurfaceAccumulator(),
+      copilotApp: createSurfaceAccumulator(),
+    },
+    daily: new Map(),
+    users: new Map(),
+  };
+}
+
+function hasNonZeroValue(values: number[]): boolean {
+  return values.some(value => value !== 0);
+}
+
+function hasIdeActivity(metric: CopilotMetrics): boolean {
+  return metric.totals_by_ide.some(total => hasNonZeroValue([
+    total.user_initiated_interaction_count,
+    total.code_generation_activity_count,
+    total.code_acceptance_activity_count,
+    total.loc_added_sum,
+    total.loc_deleted_sum,
+    total.loc_suggested_to_add_sum,
+    total.loc_suggested_to_delete_sum,
+  ]));
+}
+
+function hasClientTotalsActivity(
+  totals: CopilotMetrics['totals_by_cli'] | CopilotMetrics['totals_by_copilot_app']
+): boolean {
+  if (!totals) return false;
+  return hasNonZeroValue([
+    totals.session_count,
+    totals.request_count,
+    totals.prompt_count,
+    totals.token_usage.output_tokens_sum,
+    totals.token_usage.prompt_tokens_sum,
+  ]);
+}
+
+function hasFeatureActivity(
+  metric: CopilotMetrics,
+  matchesFeature: (feature: string) => boolean
+): boolean {
+  return metric.totals_by_feature.some(total =>
+    matchesFeature(total.feature)
+    && hasNonZeroValue([
+      total.user_initiated_interaction_count,
+      total.code_generation_activity_count,
+      total.code_acceptance_activity_count,
+      total.loc_added_sum,
+      total.loc_deleted_sum,
+      total.loc_suggested_to_add_sum,
+      total.loc_suggested_to_delete_sum,
+    ])
+  );
+}
+
+function getSurfaceActivity(metric: CopilotMetrics): Record<CopilotSurface, boolean> {
+  return {
+    ide: hasIdeActivity(metric),
+    cli:
+      metric.used_cli
+      || hasClientTotalsActivity(metric.totals_by_cli)
+      || hasFeatureActivity(metric, isCliFeature),
+    copilotApp:
+      (metric.used_copilot_app ?? false)
+      || hasClientTotalsActivity(metric.totals_by_copilot_app)
+      || hasFeatureActivity(metric, isCopilotAppFeature),
+  };
+}
+
+function getSurfaceLoc(
+  metric: CopilotMetrics
+): Record<CopilotSurface, { locAdded: number; locDeleted: number }> {
+  const ide = metric.totals_by_ide.reduce(
+    (total, entry) => ({
+      locAdded: total.locAdded + entry.loc_added_sum,
+      locDeleted: total.locDeleted + entry.loc_deleted_sum,
+    }),
+    { locAdded: 0, locDeleted: 0 }
+  );
+  const cli = { locAdded: 0, locDeleted: 0 };
+  const copilotApp = { locAdded: 0, locDeleted: 0 };
+
+  for (const feature of metric.totals_by_feature) {
+    if (isCliFeature(feature.feature)) {
+      cli.locAdded += feature.loc_added_sum;
+      cli.locDeleted += feature.loc_deleted_sum;
+    }
+    if (isCopilotAppFeature(feature.feature)) {
+      copilotApp.locAdded += feature.loc_added_sum;
+      copilotApp.locDeleted += feature.loc_deleted_sum;
+    }
+  }
+
+  return { ide, cli, copilotApp };
+}
+
+export function accumulateSurfaceProductivity(
+  accumulator: SurfaceProductivityAccumulator,
+  metric: CopilotMetrics
+): void {
+  const userDayKey = `${metric.day}:${metric.user_id}`;
+  const activity = getSurfaceActivity(metric);
+  const loc = getSurfaceLoc(metric);
+  const daily = accumulator.daily.get(metric.day) ?? createDailyAccumulator();
+  const user = accumulator.users.get(metric.user_id) ?? {
+    activeDays: new Set<string>(),
+    surfaces: new Set<CopilotSurface>(),
+    locAdded: 0,
+    locDeleted: 0,
+  };
+
+  accumulator.allUserIds.add(metric.user_id);
+  user.activeDays.add(metric.day);
+  user.locAdded += metric.loc_added_sum;
+  user.locDeleted += metric.loc_deleted_sum;
+
+  for (const surface of SURFACES) {
+    if (!activity[surface]) continue;
+
+    const surfaceAccumulator = accumulator.surfaces[surface];
+    surfaceAccumulator.userIds.add(metric.user_id);
+    surfaceAccumulator.activeUserDays.add(userDayKey);
+    surfaceAccumulator.locAdded += loc[surface].locAdded;
+    surfaceAccumulator.locDeleted += loc[surface].locDeleted;
+
+    daily[surface].userIds.add(metric.user_id);
+    daily[surface].locAdded += loc[surface].locAdded;
+    daily[surface].locDeleted += loc[surface].locDeleted;
+    user.surfaces.add(surface);
+  }
+
+  accumulator.daily.set(metric.day, daily);
+  accumulator.users.set(metric.user_id, user);
+}
+
+function round(value: number, precision = 1): number {
+  const multiplier = 10 ** precision;
+  return Math.round(value * multiplier) / multiplier;
+}
+
+function median(values: number[]): number {
+  if (values.length === 0) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  const midpoint = Math.floor(sorted.length / 2);
+  if (sorted.length % 2 === 1) return sorted[midpoint];
+  return round((sorted[midpoint - 1] + sorted[midpoint]) / 2);
+}
+
+function getCohort(surfaces: Set<CopilotSurface>): SurfaceCohort | null {
+  if (surfaces.size > 1) return 'multiSurface';
+  if (surfaces.has('ide')) return 'ideOnly';
+  if (surfaces.has('cli')) return 'cliOnly';
+  if (surfaces.has('copilotApp')) return 'copilotAppOnly';
+  return null;
+}
+
+function finalizeSurfaceSummaries(
+  accumulator: SurfaceProductivityAccumulator
+): SurfaceProductivitySummary[] {
+  const totalActiveUsers = accumulator.allUserIds.size;
+
+  return SURFACES.map(surface => {
+    const data = accumulator.surfaces[surface];
+    const uniqueUsers = data.userIds.size;
+    const activeUserDays = data.activeUserDays.size;
+    const netLocImpact = data.locAdded - data.locDeleted;
+
+    return {
+      surface,
+      uniqueUsers,
+      reachPercentage:
+        totalActiveUsers > 0 ? round((uniqueUsers / totalActiveUsers) * 100) : 0,
+      activeUserDays,
+      activeDaysPerUser:
+        uniqueUsers > 0 ? round(activeUserDays / uniqueUsers) : 0,
+      locAdded: data.locAdded,
+      locDeleted: data.locDeleted,
+      netLocImpact,
+      netLocPerActiveDay:
+        activeUserDays > 0 ? round(netLocImpact / activeUserDays) : 0,
+    };
+  });
+}
+
+function finalizeDailyProductivity(
+  accumulator: SurfaceProductivityAccumulator
+): DailySurfaceProductivity[] {
+  return Array.from(accumulator.daily.entries())
+    .map(([date, surfaces]) => ({
+      date,
+      surfaces: {
+        ide: {
+          activeUsers: surfaces.ide.userIds.size,
+          locAdded: surfaces.ide.locAdded,
+          locDeleted: surfaces.ide.locDeleted,
+          netLocImpact: surfaces.ide.locAdded - surfaces.ide.locDeleted,
+        },
+        cli: {
+          activeUsers: surfaces.cli.userIds.size,
+          locAdded: surfaces.cli.locAdded,
+          locDeleted: surfaces.cli.locDeleted,
+          netLocImpact: surfaces.cli.locAdded - surfaces.cli.locDeleted,
+        },
+        copilotApp: {
+          activeUsers: surfaces.copilotApp.userIds.size,
+          locAdded: surfaces.copilotApp.locAdded,
+          locDeleted: surfaces.copilotApp.locDeleted,
+          netLocImpact:
+            surfaces.copilotApp.locAdded - surfaces.copilotApp.locDeleted,
+        },
+      },
+    }))
+    .sort(compareByDateAsc);
+}
+
+function finalizeCohortSummaries(
+  accumulator: SurfaceProductivityAccumulator
+): SurfaceCohortSummary[] {
+  const cohortUsers = new Map<SurfaceCohort, UserCohortAccumulator[]>([
+    ['ideOnly', []],
+    ['cliOnly', []],
+    ['copilotAppOnly', []],
+    ['multiSurface', []],
+  ]);
+
+  for (const user of accumulator.users.values()) {
+    const cohort = getCohort(user.surfaces);
+    if (cohort) cohortUsers.get(cohort)!.push(user);
+  }
+
+  return Array.from(cohortUsers.entries()).map(([cohort, users]) => ({
+    cohort,
+    users: users.length,
+    medianActiveDays: median(users.map(user => user.activeDays.size)),
+    medianNetLocImpact: median(
+      users.map(user => user.locAdded - user.locDeleted)
+    ),
+  }));
+}
+
+export function finalizeSurfaceProductivity(
+  accumulator: SurfaceProductivityAccumulator
+): SurfaceProductivityMetrics {
+  return {
+    totalActiveUsers: accumulator.allUserIds.size,
+    surfaceSummaries: finalizeSurfaceSummaries(accumulator),
+    dailyProductivity: finalizeDailyProductivity(accumulator),
+    cohortSummaries: finalizeCohortSummaries(accumulator),
+  };
+}

--- a/src/domain/metricsAggregator.ts
+++ b/src/domain/metricsAggregator.ts
@@ -63,6 +63,12 @@ import {
   finalizeAiAggregation,
   type AiAggregationResult,
 } from './aggregation/aiAggregation';
+import {
+  accumulateSurfaceProductivityAggregation,
+  createSurfaceProductivityAggregationAccumulator,
+  finalizeSurfaceProductivityAggregation,
+  type SurfaceProductivityAggregationResult,
+} from './aggregation/surfaceProductivityAggregation';
 
 interface FinalizedAggregationResults {
   coreStatsAggregation: CoreStatsAggregationResult;
@@ -74,6 +80,7 @@ interface FinalizedAggregationResults {
   modelAggregation: ModelAggregationResult;
   cliAggregation: CliAggregationResult;
   aiAggregation: AiAggregationResult;
+  surfaceProductivityAggregation: SurfaceProductivityAggregationResult;
 }
 
 export function assembleAggregatedMetrics({
@@ -86,6 +93,7 @@ export function assembleAggregatedMetrics({
   modelAggregation,
   cliAggregation,
   aiAggregation,
+  surfaceProductivityAggregation,
 }: FinalizedAggregationResults): AggregatedMetrics {
   return {
     overview: {
@@ -112,6 +120,7 @@ export function assembleAggregatedMetrics({
     },
     cli: cliAggregation,
     ai: aiAggregation,
+    productivity: surfaceProductivityAggregation,
   };
 }
 
@@ -133,6 +142,8 @@ export function aggregateMetrics(
   const modelAggregationAccumulator = createModelAggregationAccumulator();
   const impactAggregationAccumulator = createImpactAggregationAccumulator();
   const aiAggregationAccumulator = createAiAggregationAccumulator();
+  const surfaceProductivityAggregationAccumulator =
+    createSurfaceProductivityAggregationAccumulator();
   const userDetailAggregationAccumulator =
     createUserDetailAggregationAccumulator();
 
@@ -155,6 +166,10 @@ export function aggregateMetrics(
       usedCopilotCloudAgent
     );
     accumulateAiAggregation(aiAggregationAccumulator, metric);
+    accumulateSurfaceProductivityAggregation(
+      surfaceProductivityAggregationAccumulator,
+      metric
+    );
     accumulateEngagementAdoptionAggregation(
       engagementAdoptionAggregationAccumulator,
       metric,
@@ -208,6 +223,10 @@ export function aggregateMetrics(
     impactAggregationAccumulator
   );
   const aiAggregation = finalizeAiAggregation(aiAggregationAccumulator);
+  const surfaceProductivityAggregation =
+    finalizeSurfaceProductivityAggregation(
+      surfaceProductivityAggregationAccumulator
+    );
 
   return {
     aggregated: assembleAggregatedMetrics({
@@ -220,6 +239,7 @@ export function aggregateMetrics(
       modelAggregation,
       cliAggregation,
       aiAggregation,
+      surfaceProductivityAggregation,
     }),
     userDetailAccumulator,
   };

--- a/src/read-models/surfaceProductivity.ts
+++ b/src/read-models/surfaceProductivity.ts
@@ -1,0 +1,23 @@
+import type { AggregatedMetrics } from '../types/aggregatedMetrics';
+
+export interface SurfaceProductivityReadModel {
+  reportStartDay: AggregatedMetrics['overview']['stats']['reportStartDay'];
+  reportEndDay: AggregatedMetrics['overview']['stats']['reportEndDay'];
+  totalActiveUsers: AggregatedMetrics['productivity']['totalActiveUsers'];
+  surfaceSummaries: AggregatedMetrics['productivity']['surfaceSummaries'];
+  dailyProductivity: AggregatedMetrics['productivity']['dailyProductivity'];
+  cohortSummaries: AggregatedMetrics['productivity']['cohortSummaries'];
+}
+
+export function selectSurfaceProductivityReadModel(
+  metrics: AggregatedMetrics
+): SurfaceProductivityReadModel {
+  return {
+    reportStartDay: metrics.overview.stats.reportStartDay,
+    reportEndDay: metrics.overview.stats.reportEndDay,
+    totalActiveUsers: metrics.productivity.totalActiveUsers,
+    surfaceSummaries: metrics.productivity.surfaceSummaries,
+    dailyProductivity: metrics.productivity.dailyProductivity,
+    cohortSummaries: metrics.productivity.cohortSummaries,
+  };
+}

--- a/src/types/aggregatedMetrics.ts
+++ b/src/types/aggregatedMetrics.ts
@@ -28,6 +28,7 @@ import type {
   UsageDistributionBucket,
   DailyAiCreditsData,
 } from '../domain/calculators';
+import type { SurfaceProductivityMetrics } from './surfaceProductivity';
 
 export interface OverviewMetricsSlice {
   stats: MetricsStats;
@@ -99,6 +100,7 @@ export interface AggregatedMetrics {
   models: ModelsMetricsSlice;
   cli: CliMetricsSlice;
   ai: AiMetricsSlice;
+  productivity: SurfaceProductivityMetrics;
 }
 
 export interface UserDetailedMetrics {

--- a/src/types/navigation.ts
+++ b/src/types/navigation.ts
@@ -13,6 +13,7 @@ export const VIEW_MODES = {
   AI_ADOPTION_PHASES: 'aiAdoptionPhases',
   MODEL_DETAILS: 'modelDetails',
   CLI_ADOPTION: 'cliAdoption',
+  SURFACE_PRODUCTIVITY: 'surfaceProductivity',
 } as const;
 
 export type ViewMode = typeof VIEW_MODES[keyof typeof VIEW_MODES];

--- a/src/types/surfaceProductivity.ts
+++ b/src/types/surfaceProductivity.ts
@@ -1,0 +1,43 @@
+export type CopilotSurface = 'ide' | 'cli' | 'copilotApp';
+
+export interface DailySurfaceProductivity {
+  date: string;
+  surfaces: Record<CopilotSurface, {
+    activeUsers: number;
+    locAdded: number;
+    locDeleted: number;
+    netLocImpact: number;
+  }>;
+}
+
+export interface SurfaceProductivitySummary {
+  surface: CopilotSurface;
+  uniqueUsers: number;
+  reachPercentage: number;
+  activeUserDays: number;
+  activeDaysPerUser: number;
+  locAdded: number;
+  locDeleted: number;
+  netLocImpact: number;
+  netLocPerActiveDay: number;
+}
+
+export type SurfaceCohort =
+  | 'ideOnly'
+  | 'cliOnly'
+  | 'copilotAppOnly'
+  | 'multiSurface';
+
+export interface SurfaceCohortSummary {
+  cohort: SurfaceCohort;
+  users: number;
+  medianActiveDays: number;
+  medianNetLocImpact: number;
+}
+
+export interface SurfaceProductivityMetrics {
+  totalActiveUsers: number;
+  surfaceSummaries: SurfaceProductivitySummary[];
+  dailyProductivity: DailySurfaceProductivity[];
+  cohortSummaries: SurfaceCohortSummary[];
+}


### PR DESCRIPTION
## Why

Engineering leaders need a focused way to compare how IDE, CLI, and Copilot App activity relates to the current productivity proxy without presenting activity or LOC as proof of causation. This view keeps engagement, output, and cross-surface overlap explicit so the comparison remains interpretable.

| Commit | Change |
|--------|--------|
| `chore: add product design context` | Captures the product register, analytical design principles, and local Impeccable configuration. |
| `feat: add surface productivity analysis` | Adds worker-owned surface aggregation, a narrow read model, and the new Surface navigation view. |

## Approach

- Compares surface reach, active user-days, LOC added/deleted, and per-user/per-day rates without creating a composite productivity score.
- Shows daily IDE, CLI, and Copilot App trends with separate active-user and net-LOC modes.
- Adds exclusive and multi-surface cohorts to expose overlap without attributing a multi-surface user's total output to one surface.
- Keeps parsing and aggregation in the Web Worker and transfers only the grouped productivity slice to the UI.
- Uses explicit caveat and methodology copy to distinguish observed activity from code quality, velocity, or individual performance.