### PR TITLE
Add Aqua, marimo, and Obsidian to IDE catalog

### DIFF
--- a/src/components/icons/IDEIcons.tsx
+++ b/src/components/icons/IDEIcons.tsx
@@ -180,6 +180,41 @@ const RubyMineIcon = () => (
   </svg>
 );
 
+// Aqua — JetBrains test automation IDE; no official Simple Icons vector, so
+// it follows the family's monogram convention (black square, white lettering)
+// used for RubyMine/RustRover.
+const AquaIcon = () => (
+  <svg className="w-5 h-5" viewBox="0 0 24 24" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg">
+    <path d="M0 0v24h24V0H0z" fill="#000" />
+    <text
+      x="12"
+      y="13.4"
+      textAnchor="middle"
+      fontFamily="Arial, Helvetica, sans-serif"
+      fontSize="8.5"
+      fontWeight="700"
+      fill="#fff"
+    >
+      QA
+    </text>
+    <path d="M2.28 19.5h9V21h-9z" fill="#fff" />
+  </svg>
+);
+
+// marimo — brand mark is a simple green circle (marimo is a round moss-ball).
+const MarimoIcon = () => (
+  <svg className="w-5 h-5" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+    <circle cx="12" cy="12" r="10" fill="#1C7361" />
+  </svg>
+);
+
+// Obsidian — from Simple Icons (CC0)
+const ObsidianIcon = () => (
+  <svg className="w-5 h-5" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+    <path d="M19.355 18.538a68.967 68.959 0 0 0 1.858-2.954.81.81 0 0 0-.062-.9c-.516-.685-1.504-2.075-2.042-3.362-.553-1.321-.636-3.375-.64-4.377a1.707 1.707 0 0 0-.358-1.05l-3.198-4.064a3.744 3.744 0 0 1-.076.543c-.106.503-.307 1.004-.536 1.5-.134.29-.29.6-.446.914l-.31.626c-.516 1.068-.997 2.227-1.132 3.59-.124 1.26.046 2.73.815 4.481.128.011.257.025.386.044a6.363 6.363 0 0 1 3.326 1.505c.916.79 1.744 1.922 2.415 3.5zM8.199 22.569c.073.012.146.02.22.02.78.024 2.095.092 3.16.29.87.16 2.593.64 4.01 1.055 1.083.316 2.198-.548 2.355-1.664.114-.814.33-1.735.725-2.58l-.01.005c-.67-1.87-1.522-3.078-2.416-3.849a5.295 5.295 0 0 0-2.778-1.257c-1.54-.216-2.952.19-3.84.45.532 2.218.368 4.829-1.425 7.531zM5.533 9.938c-.023.1-.056.197-.098.29L2.82 16.059a1.602 1.602 0 0 0 .313 1.772l4.116 4.24c2.103-3.101 1.796-6.02.836-8.3-.728-1.73-1.832-3.081-2.55-3.831zM9.32 14.01c.615-.183 1.606-.465 2.745-.534-.683-1.725-.848-3.233-.716-4.577.154-1.552.7-2.847 1.235-3.95.113-.235.223-.454.328-.664.149-.297.288-.577.419-.86.217-.47.379-.885.46-1.27.08-.38.08-.72-.014-1.043-.095-.325-.297-.675-.68-1.06a1.6 1.6 0 0 0-1.475.36l-4.95 4.452a1.602 1.602 0 0 0-.513.952l-.427 2.83c.672.59 2.328 2.316 3.335 4.711.09.21.175.43.253.653z" fill="#7C3AED"/>
+  </svg>
+);
+
 const DefaultIDEIcon = () => (
   <svg className="w-5 h-5" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
     <path d="M3 3h18a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2z" stroke="#6B7280" strokeWidth="2" fill="none"/>
@@ -210,6 +245,9 @@ const ideIconMap: Record<IDEIconKey, React.ComponentType> = {
   zed: ZedIcon,
   copilot_app: CopilotAppIcon,
   copilot_cli: CopilotIcon,
+  aqua: AquaIcon,
+  marimo: MarimoIcon,
+  obsidian: ObsidianIcon,
 };
 
 export const getIDEIcon = (ideName: string): React.ComponentType => {

--- a/src/utils/ideMetadata.test.ts
+++ b/src/utils/ideMetadata.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { formatIDEName } from './ideNames';
 import { getIDEIcon } from '../components/icons/IDEIcons';
-import { getIdeColor } from '../components/charts/utils/chartColors';
+import { getIdeColor, hasIdeColor } from '../components/charts/utils/chartColors';
 
 describe('shared IDE metadata registry', () => {
   it('keeps visual studio aliases in sync across label, icon, and color helpers', () => {
@@ -34,5 +34,24 @@ describe('shared IDE metadata registry', () => {
     expect(formatIDEName('copilot_app')).toBe('Copilot App');
     expect(getIDEIcon('copilot_app')).not.toBe(getIDEIcon('copilot_cli'));
     expect(getIdeColor('copilot_app', 0)).toBe('#000000');
+  });
+
+  it('maps Aqua with display name and a distinct icon, falling back to sequential color like other JetBrains monogram IDEs', () => {
+    expect(formatIDEName('aqua')).toBe('Aqua');
+    expect(getIDEIcon('aqua')).not.toBe(getIDEIcon('vscode'));
+    expect(getIDEIcon('aqua')).not.toBe(getIDEIcon('rubymine'));
+    expect(hasIdeColor('aqua')).toBe(false);
+  });
+
+  it('maps marimo with display name, icon, and brand color', () => {
+    expect(formatIDEName('marimo')).toBe('marimo');
+    expect(getIDEIcon('marimo')).not.toBe(getIDEIcon('vscode'));
+    expect(getIdeColor('marimo', 0)).toBe('#1C7361');
+  });
+
+  it('maps Obsidian with display name, icon, and brand color', () => {
+    expect(formatIDEName('obsidian')).toBe('Obsidian');
+    expect(getIDEIcon('obsidian')).not.toBe(getIDEIcon('vscode'));
+    expect(getIdeColor('obsidian', 0)).toBe('#7C3AED');
   });
 });

--- a/src/utils/ideMetadata.ts
+++ b/src/utils/ideMetadata.ts
@@ -20,7 +20,10 @@ export type IDEIconKey =
   | 'xcode'
   | 'zed'
   | 'copilot_app'
-  | 'copilot_cli';
+  | 'copilot_cli'
+  | 'aqua'
+  | 'marimo'
+  | 'obsidian';
 
 interface IDEMetadataDefinition {
   keys: readonly [string, ...string[]];
@@ -59,6 +62,9 @@ const IDE_METADATA_DEFINITIONS: readonly IDEMetadataDefinition[] = [
   { keys: ['zed', 'zed:zed-copilot'], label: 'Zed', iconKey: 'zed', color: '#F9CE49' },
   { keys: ['copilot_app'], label: 'Copilot App', iconKey: 'copilot_app', color: '#000000' },
   { keys: ['copilot_cli'], label: 'Copilot CLI', iconKey: 'copilot_cli', color: '#DB61A2' },
+  { keys: ['aqua'], label: 'Aqua', iconKey: 'aqua' },
+  { keys: ['marimo'], label: 'marimo', iconKey: 'marimo', color: '#1C7361' },
+  { keys: ['obsidian'], label: 'Obsidian', iconKey: 'obsidian', color: '#7C3AED' },
   { keys: ['sublime_text'], color: '#FF9800' },
 ];
 


### PR DESCRIPTION
## Why

Adds three new IDEs (Aqua, marimo, Obsidian) to the shared IDE metadata registry so their usage shows up in client tables and charts with proper display names and icons instead of falling back to the raw slug and a generic icon.

## Approach

Each IDE was registered in `src/utils/ideMetadata.ts` (the single source of truth for label, icon key, and brand color), with matching SVG components added to `src/components/icons/IDEIcons.tsx`:

- **Aqua** (JetBrains): no official vector mark is published, so it reuses the same black-square monogram convention already used for RubyMine/RustRover. It intentionally has no standalone brand color, so charts fall back to the shared sequential palette like its JetBrains siblings.
- **marimo**: uses a simple green circle matching the marimo-team brand mark (marimo is named after a round moss ball) and its real brand teal (`#1C7361`), taken from marimo's own logotype asset.
- **Obsidian**: uses the official Simple Icons vector and brand color (`#7C3AED`) for an accurate, recognizable mark.

Went through a couple of iterations on Aqua/marimo/Obsidian after review feedback to move away from invented shapes/colors and align with each brand's real mark (or the existing family convention where no official mark exists).

## Verification

`npm run build && npm run lint && npm run test:run` all pass, including new/updated tests in `src/utils/ideMetadata.test.ts` covering label, icon, and color resolution for the three new IDEs.