### PR TITLE
Add models by category breakdown to Model Usage

### DIFF
--- a/src/components/ModelCategoryBreakdown.tsx
+++ b/src/components/ModelCategoryBreakdown.tsx
@@ -1,0 +1,126 @@
+'use client';
+
+import type { ModelCategoryDetailRow } from '../types/metrics';
+import type { ModelCategoryTable } from '../read-models/models';
+import { formatNumber } from '../utils/formatters';
+import { modelCategoryColors } from './charts/utils/chartColors';
+import { getModelIcon } from './icons/ModelIcons';
+import DisclosureSection from './ui/DisclosureSection';
+import MetricsTable, { TableColumn } from './ui/MetricsTable';
+
+interface ModelCategoryBreakdownProps {
+  categoryTables: ModelCategoryTable[];
+}
+
+const HEADER_CLASS = 'px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider';
+const NUMERIC_HEADER_CLASS = 'px-4 py-2 text-right text-xs font-medium text-gray-500 uppercase tracking-wider';
+const CELL_CLASS = 'px-4 py-2 whitespace-nowrap text-sm text-gray-900';
+const NUMERIC_CELL_CLASS = `${CELL_CLASS} text-right tabular-nums`;
+
+/** Keeps sub-0.05% models from all rendering as an indistinguishable "0.0%". */
+function formatShare(share: number): string {
+  if (share > 0 && share < 0.05) return '<0.1%';
+  return `${share.toFixed(1)}%`;
+}
+
+const columns: TableColumn<ModelCategoryDetailRow>[] = [
+  {
+    id: 'displayName',
+    header: 'Model',
+    renderCell: (row) => {
+      const Icon = getModelIcon(row.model);
+      return (
+        <div className="flex items-center gap-2 min-w-0">
+          <span className="flex-shrink-0" aria-hidden="true">
+            <Icon />
+          </span>
+          <span className="truncate" title={row.model}>{row.displayName}</span>
+        </div>
+      );
+    },
+    className: `${CELL_CLASS} max-w-xs`,
+    headerClassName: HEADER_CLASS,
+  },
+  {
+    id: 'interactions',
+    header: 'Interactions',
+    renderCell: (row) => formatNumber(row.interactions),
+    className: NUMERIC_CELL_CLASS,
+    headerClassName: NUMERIC_HEADER_CLASS,
+  },
+  {
+    id: 'sharePercentage',
+    header: 'Share',
+    renderCell: (row) => formatShare(row.sharePercentage),
+    className: NUMERIC_CELL_CLASS,
+    headerClassName: NUMERIC_HEADER_CLASS,
+  },
+  {
+    id: 'users',
+    header: 'Users',
+    renderCell: (row) => formatNumber(row.users),
+    className: NUMERIC_CELL_CLASS,
+    headerClassName: NUMERIC_HEADER_CLASS,
+  },
+];
+
+export default function ModelCategoryBreakdown({ categoryTables }: ModelCategoryBreakdownProps) {
+  if (categoryTables.length === 0) return null;
+
+  return (
+    <div className="bg-white rounded-md border border-[#d1d9e0] print:border-gray-300 print:break-inside-avoid">
+      <div className="px-6 py-4 border-b border-gray-200">
+        <h3 className="text-lg font-semibold text-gray-900">Models by Category</h3>
+        <p className="text-sm text-gray-600 mt-1">
+          Expand a category to see which models it covers. Share is the model&apos;s portion of all
+          user-initiated interactions in the report.
+        </p>
+      </div>
+      <div className="px-6 py-4 space-y-3">
+        {categoryTables.map(table => (
+          <DisclosureSection
+            key={table.category}
+            defaultExpanded={false}
+            containerClassName="border border-gray-200 rounded-md overflow-hidden"
+            buttonClassName="flex items-center justify-between w-full px-4 py-3 bg-gray-50 hover:bg-gray-100 transition-colors"
+            contentClassName="border-t border-gray-200"
+            labelClassName="flex flex-1 items-center justify-between gap-4 pr-3 min-w-0"
+            label={
+              <>
+                <span className="flex items-center gap-2 min-w-0">
+                  <span
+                    className="w-2.5 h-2.5 rounded-full flex-shrink-0"
+                    style={{ backgroundColor: modelCategoryColors[table.category].solid }}
+                    aria-hidden="true"
+                  />
+                  <span className="text-sm font-semibold text-gray-900 truncate">{table.category}</span>
+                  <span className="text-xs text-gray-500 flex-shrink-0">
+                    {table.rows.length} {table.rows.length === 1 ? 'model' : 'models'}
+                  </span>
+                </span>
+                <span className="text-xs text-gray-600 tabular-nums flex-shrink-0">
+                  {formatNumber(table.interactions)} interactions
+                  <span className="text-gray-400"> · </span>
+                  {formatShare(table.sharePercentage)}
+                  <span className="text-gray-400"> · </span>
+                  {formatNumber(table.users)} unique users
+                </span>
+              </>
+            }
+          >
+            <MetricsTable
+              data={table.rows}
+              columns={columns}
+              getRowKey={(row) => row.model}
+              tableClassName="w-full"
+              tableContainerClassName="overflow-x-auto"
+              theadClassName="bg-gray-50 border-b border-gray-200"
+              tbodyClassName="divide-y divide-gray-100"
+              rowClassName={() => 'hover:bg-gray-50'}
+            />
+          </DisclosureSection>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/ModelDetailsView.tsx
+++ b/src/components/ModelDetailsView.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import ModelsUsageChart from './charts/ModelsUsageChart';
 import ModelCategoryDistributionChart from './charts/ModelCategoryDistributionChart';
 import AutoModeAdoptionTrendChart from './charts/AutoModeAdoptionTrendChart';
+import ModelCategoryBreakdown from './ModelCategoryBreakdown';
 import type { ModelDetailsReadModel } from '../read-models/models';
 import { ViewPanel } from './ui';
 import { MODEL_DETAILS_SECTIONS } from './layout/contextSections';
@@ -21,8 +22,15 @@ export default function ModelDetailsView({ model }: ModelDetailsViewProps) {
     dates,
     modelTotal,
     autoTotal,
+    categoryTables,
   } = model;
-  const [allModelsSection, modelTypesSection, autoModelsSection, autoAdoptionSection] = MODEL_DETAILS_SECTIONS;
+  const [
+    allModelsSection,
+    modelTypesSection,
+    modelsByCategorySection,
+    autoModelsSection,
+    autoAdoptionSection,
+  ] = MODEL_DETAILS_SECTIONS;
 
   return (
     <ViewPanel
@@ -42,6 +50,9 @@ export default function ModelDetailsView({ model }: ModelDetailsViewProps) {
             dates={dates}
             totalInteractions={modelTotal}
           />
+        </div>
+        <div id={modelsByCategorySection.id} className="scroll-mt-28">
+          <ModelCategoryBreakdown categoryTables={categoryTables} />
         </div>
         <div id={autoModelsSection.id} className="scroll-mt-28">
           <ModelsUsageChart modelEntries={autoModels} dates={dates} totalInteractions={autoTotal} variant="auto" />

--- a/src/components/charts/ModelCategoryDistributionChart.tsx
+++ b/src/components/charts/ModelCategoryDistributionChart.tsx
@@ -70,7 +70,7 @@ export default function ModelCategoryDistributionChart({
       ]}
       chartHeight="h-96"
       footer={
-        <p className="text-xs text-gray-600 mb-4">
+        <p className="text-xs text-gray-600">
           Categories follow GitHub&apos;s published Copilot model pricing catalog. Legacy and
           unmapped models appear as Uncategorized.
         </p>

--- a/src/components/icons/ModelIcons.tsx
+++ b/src/components/icons/ModelIcons.tsx
@@ -48,6 +48,13 @@ const MicrosoftIcon = () => (
   </svg>
 );
 
+// Moonshot AI — from Simple Icons (CC0). Matches Kimi-* models.
+const MoonshotIcon = () => (
+  <svg className="w-5 h-5" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+    <path d="m1.053 16.91 9.538 2.55a21 20.981 0 0 0 .06 2.031l5.956 1.592a12 11.99 0 0 1-15.554-6.172m-1.02-5.79 11.352 3.035a21 20.981 0 0 0-.469 2.01l10.817 2.89a12 11.99 0 0 1-1.845 2.004L.658 15.918a12 11.99 0 0 1-.625-4.796m1.593-5.146L13.573 9.17a21 20.981 0 0 0-1.01 1.874l11.297 3.02a21 20.981 0 0 1-.67 2.362l-11.55-3.087L.125 10.26a12 11.99 0 0 1 1.499-4.285ZM6.067 1.58l11.285 3.016a21 20.981 0 0 0-1.688 1.719l7.824 2.091a21 20.981 0 0 1 .513 2.664L2.107 5.218a12 11.99 0 0 1 3.96-3.638M21.68 4.866 7.222 1.003A12 11.99 0 0 1 21.68 4.866" fill="#000"/>
+  </svg>
+);
+
 const DefaultModelIcon = () => (
   <svg className="w-5 h-5" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
     <circle cx="12" cy="12" r="9" stroke="#6B7280" strokeWidth="2" fill="none"/>
@@ -66,6 +73,7 @@ const MODEL_VENDORS: ModelVendor[] = [
   { matches: name => name.startsWith('gemini'), Icon: GeminiIcon },
   { matches: name => name.startsWith('mai'), Icon: MicrosoftIcon },
   { matches: name => name.startsWith('grok'), Icon: XAIIcon },
+  { matches: name => name.startsWith('kimi') || name.startsWith('moonshot'), Icon: MoonshotIcon },
 ];
 
 export const getModelIcon = (modelName: string): React.ComponentType => {

--- a/src/components/layout/contextSections.ts
+++ b/src/components/layout/contextSections.ts
@@ -60,6 +60,7 @@ export const CLIENT_VERSIONS_SECTIONS: ContextSection[] = [
 export const MODEL_DETAILS_SECTIONS: ContextSection[] = [
   { id: 'model-usage-all', label: 'All Models' },
   { id: 'model-type-distribution', label: 'Model Types' },
+  { id: 'models-by-category', label: 'Models by Category' },
   { id: 'model-usage-auto', label: 'Auto Models' },
   { id: 'model-auto-adoption', label: 'Auto Adoption' },
 ];

--- a/src/components/ui/DisclosureSection.tsx
+++ b/src/components/ui/DisclosureSection.tsx
@@ -4,13 +4,16 @@ import { useId, useState } from 'react';
 import type { ReactNode } from 'react';
 
 interface DisclosureSectionProps {
-  label: string;
+  label: ReactNode;
   children: ReactNode;
   defaultExpanded?: boolean;
   containerClassName?: string;
   buttonClassName?: string;
   contentClassName?: string;
+  labelClassName?: string;
 }
+
+const DEFAULT_LABEL_CLASS = 'text-sm font-medium text-gray-700';
 
 const DEFAULT_CONTAINER_CLASS = 'border-t border-gray-200 pt-4';
 const DEFAULT_BUTTON_CLASS =
@@ -24,6 +27,7 @@ export default function DisclosureSection({
   containerClassName,
   buttonClassName,
   contentClassName,
+  labelClassName,
 }: DisclosureSectionProps) {
   const [isExpanded, setIsExpanded] = useState(defaultExpanded);
   const contentId = useId();
@@ -37,12 +41,13 @@ export default function DisclosureSection({
         aria-expanded={isExpanded}
         aria-controls={contentId}
       >
-        <span className="text-sm font-medium text-gray-700">{label}</span>
+        <span className={labelClassName ?? DEFAULT_LABEL_CLASS}>{label}</span>
         <svg
           className={`w-5 h-5 text-gray-500 transition-transform duration-200 ${isExpanded ? 'rotate-180' : ''}`}
           fill="none"
           stroke="currentColor"
           viewBox="0 0 24 24"
+          aria-hidden="true"
         >
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
         </svg>

--- a/src/domain/__tests__/metricsAggregator.test.ts
+++ b/src/domain/__tests__/metricsAggregator.test.ts
@@ -678,6 +678,7 @@ describe('metricsAggregator', () => {
           model: 'gpt-4o',
           total: 44,
           dailyData: { '2024-01-15': 44 },
+          users: 1,
         },
       ]);
       expect(userDetails?.dailyModelUsage).toEqual(aggregated.models.modelUsageData);
@@ -808,6 +809,7 @@ describe('metricsAggregator', () => {
           model: 'auto',
           total: 1,
           dailyData: { '2024-01-15': 1 },
+          users: 1,
         },
       ]);
       expect(aggregated.models.modelBreakdownData.autoModeAdoptionTrend).toEqual([
@@ -924,6 +926,7 @@ describe('metricsAggregator', () => {
             '2024-01-15': 15,
             '2024-01-16': 3,
           },
+          users: 2,
         },
         {
           model: 'claude-sonnet-4.6',
@@ -931,6 +934,7 @@ describe('metricsAggregator', () => {
           dailyData: {
             '2024-01-15': 5,
           },
+          users: 1,
         },
       ]);
     });

--- a/src/domain/aggregation/__tests__/modelAggregation.test.ts
+++ b/src/domain/aggregation/__tests__/modelAggregation.test.ts
@@ -113,16 +113,19 @@ describe('model aggregation orchestration', () => {
         model: 'gpt-5',
         total: 6,
         dailyData: { '2024-01-15': 6 },
+        users: 1,
       },
       {
         model: 'gpt-4o',
         total: 4,
         dailyData: { '2024-01-16': 4 },
+        users: 1,
       },
       {
         model: 'unknown',
         total: 3,
         dailyData: { '2024-01-16': 3 },
+        users: 1,
       },
     ]);
   });

--- a/src/domain/calculators/__tests__/modelBreakdownCalculator.test.ts
+++ b/src/domain/calculators/__tests__/modelBreakdownCalculator.test.ts
@@ -183,15 +183,28 @@ describe('modelBreakdownCalculator', () => {
       expect(data.modelTotal).toBe(35);
       expect(data.unknownTotal).toBe(5);
       expect(data.allModels).toEqual([
-        { model: 'gpt-4o', total: 20, dailyData: { '2024-01-15': 20 } },
-        { model: 'gpt-5', total: 10, dailyData: { '2024-01-15': 10 } },
-        { model: 'unknown', total: 5, dailyData: { '2024-01-15': 5 } },
+        { model: 'gpt-4o', total: 20, dailyData: { '2024-01-15': 20 }, users: 1 },
+        { model: 'gpt-5', total: 10, dailyData: { '2024-01-15': 10 }, users: 1 },
+        { model: 'unknown', total: 5, dailyData: { '2024-01-15': 5 }, users: 1 },
       ]);
       expect(data.modelCategories).toEqual([
-        { category: 'Versatile', total: 20, dailyData: { '2024-01-15': 20 } },
-        { category: 'Powerful', total: 10, dailyData: { '2024-01-15': 10 } },
-        { category: 'Uncategorized', total: 5, dailyData: { '2024-01-15': 5 } },
+        { category: 'Versatile', total: 20, dailyData: { '2024-01-15': 20 }, users: 1 },
+        { category: 'Powerful', total: 10, dailyData: { '2024-01-15': 10 }, users: 1 },
+        { category: 'Uncategorized', total: 5, dailyData: { '2024-01-15': 5 }, users: 1 },
       ]);
+    });
+
+    it('should count distinct users per model and category', () => {
+      const acc = createModelBreakdownAccumulator();
+      accumulateModelBreakdown(acc, '2024-01-15', 1, makeModelFeature('gpt-5', 'code_completion', 10));
+      accumulateModelBreakdown(acc, '2024-01-15', 2, makeModelFeature('gpt-5', 'code_completion', 20));
+      accumulateModelBreakdown(acc, '2024-01-16', 3, makeModelFeature('gpt-4o', 'code_completion', 15));
+      const data = computeModelBreakdownData(acc);
+
+      expect(data.allModels.find(entry => entry.model === 'gpt-5')?.users).toBe(2);
+      expect(data.allModels.find(entry => entry.model === 'gpt-4o')?.users).toBe(1);
+      expect(data.modelCategories.find(entry => entry.category === 'Powerful')?.users).toBe(2);
+      expect(data.modelCategories.find(entry => entry.category === 'Versatile')?.users).toBe(1);
     });
 
     it('should aggregate daily interactions by published model category', () => {
@@ -201,9 +214,9 @@ describe('modelBreakdownCalculator', () => {
       accumulateModelBreakdown(acc, '2024-01-16', 1, makeModelFeature('claude-opus-4.8', 'chat_panel', 5));
 
       expect(computeModelBreakdownData(acc).modelCategories).toEqual([
-        { category: 'Lightweight', total: 8, dailyData: { '2024-01-15': 8 } },
-        { category: 'Versatile', total: 12, dailyData: { '2024-01-15': 12 } },
-        { category: 'Powerful', total: 5, dailyData: { '2024-01-16': 5 } },
+        { category: 'Lightweight', total: 8, dailyData: { '2024-01-15': 8 }, users: 1 },
+        { category: 'Versatile', total: 12, dailyData: { '2024-01-15': 12 }, users: 1 },
+        { category: 'Powerful', total: 5, dailyData: { '2024-01-16': 5 }, users: 1 },
       ]);
     });
   });

--- a/src/domain/calculators/modelBreakdownCalculator.ts
+++ b/src/domain/calculators/modelBreakdownCalculator.ts
@@ -15,6 +15,7 @@ import { computeAdoptionTrendFromUserSets } from './adoptionTrendHelpers';
 interface ModelAccEntry {
   total: number;
   dailyData: Map<string, number>;
+  userIds: Set<number>;
 }
 
 export interface ModelBreakdownAccumulator {
@@ -47,14 +48,18 @@ function accumulateModelEntry(
   modelsMap: Map<string, ModelAccEntry>,
   model: string,
   date: string,
-  count: number
+  count: number,
+  userId?: number
 ): void {
   if (!modelsMap.has(model)) {
-    modelsMap.set(model, { total: 0, dailyData: new Map() });
+    modelsMap.set(model, { total: 0, dailyData: new Map(), userIds: new Set() });
   }
   const entry = modelsMap.get(model)!;
   entry.total += count;
   entry.dailyData.set(date, (entry.dailyData.get(date) || 0) + count);
+  if (userId !== undefined) {
+    entry.userIds.add(userId);
+  }
 }
 
 export function accumulateModelBreakdown(
@@ -76,7 +81,7 @@ export function accumulateModelBreakdown(
   if (isCliFeature(modelFeature.feature) && interactionCount > 0) {
     accumulator.allDates.add(date);
     accumulator.cliTotal += interactionCount;
-    accumulateModelEntry(accumulator.cliModels, normalizedModel || 'unknown', date, interactionCount);
+    accumulateModelEntry(accumulator.cliModels, normalizedModel || 'unknown', date, interactionCount, userId);
   }
 
   if (isActiveAutoModeFeature(modelFeature)) {
@@ -89,7 +94,7 @@ export function accumulateModelBreakdown(
     const autoUsageCount = modelFeature.user_initiated_interaction_count > 0
       ? modelFeature.user_initiated_interaction_count
       : activityCount;
-    accumulateModelEntry(accumulator.autoModels, normalizedModel, date, autoUsageCount);
+    accumulateModelEntry(accumulator.autoModels, normalizedModel, date, autoUsageCount, userId);
     return;
   }
 
@@ -99,12 +104,13 @@ export function accumulateModelBreakdown(
 
   accumulator.allDates.add(date);
   accumulator.modelTotal += interactionCount;
-  accumulateModelEntry(accumulator.allModels, normalizedModel || 'unknown', date, interactionCount);
+  accumulateModelEntry(accumulator.allModels, normalizedModel || 'unknown', date, interactionCount, userId);
   accumulateModelEntry(
     accumulator.modelCategories,
     getModelCategory(normalizedModel) ?? 'Uncategorized',
     date,
-    interactionCount
+    interactionCount,
+    userId
   );
 
   if (isUnknown) {
@@ -125,6 +131,7 @@ function buildModelEntries(
         model,
         total: entry.total,
         dailyData,
+        users: entry.userIds.size,
       };
     })
     .sort((a, b) => b.total - a.total);
@@ -148,6 +155,7 @@ function buildModelCategoryEntries(
       category,
       total: entry.total,
       dailyData: Object.fromEntries(entry.dailyData),
+      users: entry.userIds.size,
     }];
   });
 }

--- a/src/domain/modelConfig.ts
+++ b/src/domain/modelConfig.ts
@@ -7,6 +7,11 @@ export { isActiveAutoModeFeature, normalizeModelName } from './autoMode';
 
 export type ModelCategory = 'Lightweight' | 'Powerful' | 'Versatile';
 
+/**
+ * Display order for model categories, from least to most capable, with unmapped models last.
+ */
+export const MODEL_CATEGORY_ORDER = ['Lightweight', 'Versatile', 'Powerful', 'Uncategorized'] as const;
+
 export class Model {
   constructor(
     public readonly name: string,

--- a/src/read-models/__tests__/modelsCliReadModels.test.ts
+++ b/src/read-models/__tests__/modelsCliReadModels.test.ts
@@ -12,28 +12,33 @@ function makeModelMetrics(): AggregatedMetrics {
           model: 'gpt-5',
           total: 11,
           dailyData: { '2026-01-15': 11 },
+          users: 1,
         }],
         modelCategories: [{
           category: 'Powerful',
           total: 11,
           dailyData: { '2026-01-15': 11 },
+          users: 1,
         }],
         autoModels: [
           {
             model: 'auto',
             total: 4.5,
             dailyData: { '2026-01-15': 4.5 },
+            users: 1,
           },
           {
             model: 'auto-secondary',
             total: -1.25,
             dailyData: { '2026-01-16': -1.25 },
+            users: 1,
           },
         ],
         cliModels: [{
           model: 'gpt-5',
           total: 99,
           dailyData: { '2026-01-15': 99 },
+          users: 1,
         }],
         autoModeAdoptionTrend: [{
           date: '2026-01-15',
@@ -102,6 +107,7 @@ function makeCliMetrics(): AggregatedMetrics {
           model: 'gpt-5',
           total: 6,
           dailyData: { '2026-01-15': 6 },
+          users: 1,
         }],
         dates: ['fallback-model-date'],
         cliTotal: 6,
@@ -124,6 +130,19 @@ describe('model details read model', () => {
       dates: metrics.models.modelBreakdownData.dates,
       modelTotal: 11,
       autoTotal: 3.25,
+      categoryTables: [{
+        category: 'Powerful',
+        users: 1,
+        interactions: 11,
+        sharePercentage: 100,
+        rows: [{
+          model: 'gpt-5',
+          displayName: 'Gpt 5',
+          interactions: 11,
+          sharePercentage: 100,
+          users: 1,
+        }],
+      }],
     });
     expect(model.allModels).toBe(metrics.models.modelBreakdownData.allModels);
     expect(model.allModels[0]).toBe(metrics.models.modelBreakdownData.allModels[0]);
@@ -157,6 +176,7 @@ describe('model details read model', () => {
       'dates',
       'modelTotal',
       'autoTotal',
+      'categoryTables',
     ]);
     expect(model).not.toHaveProperty('modelBreakdownData');
     expect(model).not.toHaveProperty('cliModels');
@@ -177,6 +197,7 @@ describe('model details read model', () => {
       dates: [],
       modelTotal: 0,
       autoTotal: 0,
+      categoryTables: [],
     });
     expect(model.allModels).toBe(metrics.models.modelBreakdownData.allModels);
     expect(model.modelCategories).toBe(metrics.models.modelBreakdownData.modelCategories);
@@ -207,6 +228,7 @@ describe('model details read model', () => {
       dates: metrics.models.modelBreakdownData.dates,
       modelTotal: 0,
       autoTotal: 0,
+      categoryTables: [],
     });
   });
 

--- a/src/read-models/models.ts
+++ b/src/read-models/models.ts
@@ -1,4 +1,20 @@
 import type { AggregatedMetrics } from '../types/aggregatedMetrics';
+import type {
+  ModelCategoryDetailRow,
+  ModelCategoryUsageEntry,
+  ModelDailyUsageEntry,
+  ModelUsageCategory,
+} from '../types/metrics';
+import { getModelCategory, MODEL_CATEGORY_ORDER } from '../domain/modelConfig';
+import { formatModelDisplayName } from '../utils/formatters';
+
+export interface ModelCategoryTable {
+  category: ModelUsageCategory;
+  users: number;
+  interactions: number;
+  sharePercentage: number;
+  rows: ModelCategoryDetailRow[];
+}
 
 export interface ModelDetailsReadModel {
   allModels: AggregatedMetrics['models']['modelBreakdownData']['allModels'];
@@ -10,6 +26,47 @@ export interface ModelDetailsReadModel {
   dates: AggregatedMetrics['models']['modelBreakdownData']['dates'];
   modelTotal: number;
   autoTotal: number;
+  categoryTables: ModelCategoryTable[];
+}
+
+function buildCategoryTables(
+  allModels: ModelDailyUsageEntry[],
+  modelCategories: ModelCategoryUsageEntry[],
+  modelTotal: number
+): ModelCategoryTable[] {
+  const modelsByCategory = new Map<ModelUsageCategory, ModelDailyUsageEntry[]>();
+  for (const entry of allModels) {
+    const category = getModelCategory(entry.model) ?? 'Uncategorized';
+    const list = modelsByCategory.get(category) ?? [];
+    list.push(entry);
+    modelsByCategory.set(category, list);
+  }
+
+  const categoryEntries = new Map(modelCategories.map(entry => [entry.category, entry]));
+
+  return MODEL_CATEGORY_ORDER.flatMap(category => {
+    const models = modelsByCategory.get(category);
+    if (!models || models.length === 0) return [];
+
+    const categoryEntry = categoryEntries.get(category);
+    const interactions = categoryEntry?.total ?? models.reduce((sum, entry) => sum + entry.total, 0);
+
+    const rows: ModelCategoryDetailRow[] = models.map(entry => ({
+      model: entry.model,
+      displayName: formatModelDisplayName(entry.model),
+      interactions: entry.total,
+      sharePercentage: modelTotal > 0 ? (entry.total / modelTotal) * 100 : 0,
+      users: entry.users,
+    }));
+
+    return [{
+      category,
+      users: categoryEntry?.users ?? 0,
+      interactions,
+      sharePercentage: modelTotal > 0 ? (interactions / modelTotal) * 100 : 0,
+      rows,
+    }];
+  });
 }
 
 export function selectModelDetailsReadModel(
@@ -32,5 +89,6 @@ export function selectModelDetailsReadModel(
     dates,
     modelTotal,
     autoTotal: autoModels.reduce((sum, entry) => sum + entry.total, 0),
+    categoryTables: buildCategoryTables(allModels, modelCategories, modelTotal),
   };
 }

--- a/src/types/metrics.ts
+++ b/src/types/metrics.ts
@@ -202,6 +202,7 @@ export interface ModelDailyUsageEntry {
   model: string;
   total: number;
   dailyData: Record<string, number>;
+  users: number;
 }
 
 export type ModelUsageCategory = 'Lightweight' | 'Powerful' | 'Versatile' | 'Uncategorized';
@@ -210,6 +211,15 @@ export interface ModelCategoryUsageEntry {
   category: ModelUsageCategory;
   total: number;
   dailyData: Record<string, number>;
+  users: number;
+}
+
+export interface ModelCategoryDetailRow {
+  model: string;
+  displayName: string;
+  interactions: number;
+  sharePercentage: number;
+  users: number;
 }
 
 export interface AutoModeAdoptionTrendEntry {


### PR DESCRIPTION
## Why

The Model Usage page showed which model *categories* were used over time, but not which models made up each category. This adds a per-category model breakdown so you can see, at a glance, which models drive each tier and how many people actually use them.

| Commit | Change |
|--------|--------|
| `feat:` track unique users per model and model category | Model breakdown accumulators collect distinct user IDs, so every model and category entry now reports a unique user count alongside its interaction total |
| `feat:` add Moonshot AI icon for Kimi models | Kimi models were falling back to the generic model icon |
| `feat:` add models by category breakdown card | New expandable card under Model Type Distribution listing each model with icon, interactions, share of all interactions, and unique users |

### Notes for reviewers

- The tables live in a dedicated card rather than the `ChartContainer` footer, which `charts.instructions.md` reserves for insight tiles. `ModelCategoryDistributionChart` is back to being chart-only.
- Category headers carry a color dot matching the chart series plus model count, interactions, share, and unique users, so the summary is readable without expanding.
- `DisclosureSection.label` was widened from `string` to `ReactNode` (with an optional `labelClassName`) to support the richer header; existing call sites are unaffected.
- `MODEL_CATEGORY_ORDER` moved into `domain/modelConfig.ts` so the read-model and chart share one ordering.
- Added a `models-by-category` entry to the context nav.