### PR TITLE
fix: categorize Kimi K3 model

### DIFF
--- a/src/domain/__tests__/modelConfig.test.ts
+++ b/src/domain/__tests__/modelConfig.test.ts
@@ -35,6 +35,7 @@ describe('modelConfig', () => {
       expect(getModelCategory('Claude Opus 5')).toBe('Powerful');
       expect(getModelCategory('Gemini 3.6 Flash')).toBe('Versatile');
       expect(getModelCategory('Grok 4.5')).toBe('Versatile');
+      expect(getModelCategory('Kimi K3')).toBe('Powerful');
       expect(getModelCategory('legacy-model')).toBeUndefined();
     });
 
@@ -54,6 +55,7 @@ describe('modelConfig', () => {
       expect(isKnownModelName('GPT-5')).toBe(true);
       expect(isKnownModelName('Claude Opus 4.6 (fast mode)')).toBe(true);
       expect(isKnownModelName('Gemini 3.5 Flash')).toBe(true);
+      expect(isKnownModelName('Kimi K3')).toBe(true);
     });
 
     it('should not treat arbitrary non-empty model names as known models', () => {

--- a/src/domain/modelConfig.ts
+++ b/src/domain/modelConfig.ts
@@ -89,6 +89,7 @@ export const KNOWN_MODELS: Model[] = [
   new Model('gemini-3.6-flash', 'Versatile'),
   new Model('mai-code-1-flash', 'Lightweight'),
   new Model('kimi-k2.7-code', 'Versatile'),
+  new Model('kimi-k3', 'Powerful'),
   new Model('auto'),
   new Model('unknown'),
 ];


### PR DESCRIPTION
## Why

The live GitHub Copilot models and pricing catalog lists Kimi K3 as a Powerful model, but the local known-model catalog did not recognize it. This update keeps model categorization aligned so Kimi K3 is included in the correct category.

| Commit | Change |
|--------|--------|
| `fix: categorize Kimi K3 model` | Add Kimi K3 as a Powerful known model and cover category/recognition behavior with tests. |