### PR TITLE
fix: categorize Kimi K3 model

### DIFF
--- a/src/domain/__tests__/modelConfig.test.ts
+++ b/src/domain/__tests__/modelConfig.test.ts
@@ -35,6 +35,7 @@ describe('modelConfig', () => {
       expect(getModelCategory('Claude Opus 5')).toBe('Powerful');
       expect(getModelCategory('Gemini 3.6 Flash')).toBe('Versatile');
       expect(getModelCategory('Grok 4.5')).toBe('Versatile');
+      expect(getModelCategory('Kimi K3')).toBe('Powerful');
       expect(getModelCategory('legacy-model')).toBeUndefined();
     });
 

--- a/src/domain/modelConfig.ts
+++ b/src/domain/modelConfig.ts
@@ -89,6 +89,7 @@ export const KNOWN_MODELS: Model[] = [
   new Model('gemini-3.6-flash', 'Versatile'),
   new Model('mai-code-1-flash', 'Lightweight'),
   new Model('kimi-k2.7-code', 'Versatile'),
+  new Model('kimi-k3', 'Powerful'),
   new Model('auto'),
   new Model('unknown'),
 ];


### PR DESCRIPTION
## Why

GitHub Copilot pricing now lists Kimi K3 as a Powerful model, but the local known-model catalog did not include it. This update keeps model recognition and category breakdowns aligned with the published documentation.

| Commit | Change |
|--------|--------|
| `fix: categorize Kimi K3 model` | Add Kimi K3 to the known catalog as Powerful and cover the category with a regression test. |