### PR TITLE
fix: sync documented model catalog

### DIFF
--- a/src/domain/__tests__/modelConfig.test.ts
+++ b/src/domain/__tests__/modelConfig.test.ts
@@ -36,6 +36,7 @@ describe('modelConfig', () => {
       expect(getModelCategory('Gemini 3.6 Flash')).toBe('Versatile');
       expect(getModelCategory('Grok 4.5')).toBe('Versatile');
       expect(getModelCategory('Kimi K3')).toBe('Powerful');
+      expect(getModelCategory('MAI-Code-1.1-Flash')).toBe('Lightweight');
       expect(getModelCategory('legacy-model')).toBeUndefined();
     });
 

--- a/src/domain/modelConfig.ts
+++ b/src/domain/modelConfig.ts
@@ -88,6 +88,7 @@ export const KNOWN_MODELS: Model[] = [
   new Model('gemini-3.5-flash', 'Lightweight'),
   new Model('gemini-3.6-flash', 'Versatile'),
   new Model('mai-code-1-flash', 'Lightweight'),
+  new Model('mai-code-1.1-flash', 'Lightweight'),
   new Model('kimi-k2.7-code', 'Versatile'),
   new Model('kimi-k3', 'Powerful'),
   new Model('auto'),


### PR DESCRIPTION
## Why

The GitHub Copilot pricing page lists `MAI-Code-1.1-Flash` as a Lightweight model, but the viewer catalog did not recognize it. This update keeps model categorization aligned with the published pricing catalog.

| Commit | Change |
|--------|--------|
| `fix: sync documented model catalog` | Add `MAI-Code-1.1-Flash` as a Lightweight known model and cover its published category with a regression test |