### PR TITLE
fix: sync Gemini model category

### DIFF
--- a/src/domain/__tests__/modelConfig.test.ts
+++ b/src/domain/__tests__/modelConfig.test.ts
@@ -34,6 +34,7 @@ describe('modelConfig', () => {
       expect(getModelCategory('Gemini 3.0 Flash')).toBe('Lightweight');
       expect(getModelCategory('Claude Opus 5')).toBe('Powerful');
       expect(getModelCategory('Gemini 3.6 Flash')).toBe('Versatile');
+      expect(getModelCategory('Gemini 3.7 Flash')).toBe('Versatile');
       expect(getModelCategory('Grok 4.5')).toBe('Versatile');
       expect(getModelCategory('Kimi K3')).toBe('Powerful');
       expect(getModelCategory('MAI-Code-1.1-Flash')).toBe('Lightweight');

--- a/src/domain/modelConfig.ts
+++ b/src/domain/modelConfig.ts
@@ -87,6 +87,7 @@ export const KNOWN_MODELS: Model[] = [
   new Model('gemini-3-flash', 'Lightweight'),
   new Model('gemini-3.5-flash', 'Lightweight'),
   new Model('gemini-3.6-flash', 'Versatile'),
+  new Model('gemini-3.7-flash', 'Versatile'),
   new Model('mai-code-1-flash', 'Lightweight'),
   new Model('mai-code-1.1-flash', 'Lightweight'),
   new Model('kimi-k2.7-code', 'Versatile'),


### PR DESCRIPTION
## Why

The Copilot pricing catalog now includes Gemini 3.7 Flash, and the local model configuration was missing it. This keeps known-model recognition and category reporting aligned with GitHub's published Lightweight, Powerful, and Versatile categories.

| Commit | Change |
|--------|--------|
| `fix: sync Gemini model category` | Add Gemini 3.7 Flash as a Versatile known model and cover it with a regression test |

The production build remains blocked by unrelated pre-existing TypeScript errors in chart and metrics-parser tests.