### PR TITLE
fix: categorize Grok 4.6 model

### DIFF
--- a/src/domain/__tests__/modelConfig.test.ts
+++ b/src/domain/__tests__/modelConfig.test.ts
@@ -36,6 +36,7 @@ describe('modelConfig', () => {
       expect(getModelCategory('Gemini 3.6 Flash')).toBe('Versatile');
       expect(getModelCategory('Gemini 3.7 Flash')).toBe('Versatile');
       expect(getModelCategory('Grok 4.5')).toBe('Versatile');
+      expect(getModelCategory('Grok 4.6')).toBe('Versatile');
       expect(getModelCategory('Kimi K3')).toBe('Powerful');
       expect(getModelCategory('MAI-Code-1.1-Flash')).toBe('Lightweight');
       expect(getModelCategory('legacy-model')).toBeUndefined();

--- a/src/domain/modelConfig.ts
+++ b/src/domain/modelConfig.ts
@@ -52,6 +52,7 @@ export const KNOWN_MODELS: Model[] = [
   new Model('gpt-5.6-terra', 'Versatile'),
   new Model('grok-code-fast-1', 'Lightweight'),
   new Model('grok-4.5', 'Versatile'),
+  new Model('grok-4.6', 'Versatile'),
   new Model('o3', 'Powerful'),
   new Model('o3-mini', 'Lightweight'),
   new Model('o4-mini', 'Lightweight'),


### PR DESCRIPTION
## Why

GitHub's Copilot billing catalog lists Grok 4.6 as a Versatile model, but the local known-model catalog did not recognize it. This update keeps model categorization aligned with the published pricing page.

| Commit | Change |
|--------|--------|
| `fix: categorize Grok 4.6 model` | Add Grok 4.6 as a Versatile known model and cover its category lookup with a test |