### PR TITLE
chore: add 7-day dependency cooldown to dependabot and npm

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,5 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/.npmrc
+++ b/.npmrc
@@ -2,3 +2,6 @@
 # @typescript-eslint v8 officially supports ESLint 10, but peer deps metadata not yet updated
 # Remove this when @typescript-eslint updates peer dependencies to include eslint@^10.0.0
 legacy-peer-deps=true
+
+# Supply chain cooldown: only install package versions published at least 7 days ago (npm >= 11.10)
+min-release-age=7


### PR DESCRIPTION
## Why

Fast-moving npm supply chain attacks are typically detected and yanked within hours of a malicious publish. Adding a cooldown window means newly published versions are never installed or proposed during that high-risk window.

## What changed

- **`.github/dependabot.yml`** — added `cooldown: default-days: 7` to the npm ecosystem entry. Dependabot will wait 7 days after a version is published before proposing an update ([dependabot cooldown option](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#cooldown-)).
- **`.npmrc`** — added `min-release-age=7`, so local and CI installs reject package versions published within the last 7 days (requires npm >= 11.10).

## Notes / caveats

- npm's `min-release-age` currently applies to all packages with no exclusion support, and cannot be combined with `--before`. It can be bypassed per-invocation with `--min-release-age=0` if a hotfix is ever needed.
- The build's TypeScript step currently fails on `main` due to 19 pre-existing errors in test files (unrelated to this config-only change; verified identical errors at the merge-base). A separate fix is in progress.