### PR TITLE
test: fix CI TypeScript fixtures

### DIFF
--- a/src/components/charts/utils/adoptionTrendChart.test.ts
+++ b/src/components/charts/utils/adoptionTrendChart.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest';
+import type { TooltipItem } from 'chart.js';
 import {
   createAdoptionTrendChartConfig,
   createAdoptionTrendSummaryStats,
@@ -94,13 +95,15 @@ describe('createAdoptionTrendChartConfig', () => {
       title: { display: true, text: 'Cumulative Users' },
       grid: { drawOnChartArea: false },
     });
-    expect(options.scales.y2).toMatchObject({
+    expect((options.scales as Record<string, unknown>).y2).toMatchObject({
       display: false,
       min: 0,
       max: 100,
     });
 
-    const tooltipLines = options.plugins.tooltip.callbacks.afterBody([{ dataIndex: 1 }]);
+    const tooltipLines = options.plugins.tooltip.callbacks.afterBody!([
+      { dataIndex: 1 } as TooltipItem<'line' | 'bar'>,
+    ]);
     expect(tooltipLines).toEqual([
       '',
       'Total Active: 0',

--- a/src/components/charts/utils/chartOptions.test.ts
+++ b/src/components/charts/utils/chartOptions.test.ts
@@ -34,14 +34,14 @@ describe('createDualAxisChartOptions', () => {
       beginAtZero: true,
       ticks: { stepSize: 1_000 },
     });
-    expect(options.scales.y.ticks.callback).toBe(formatTick);
+    expect(options.scales.y.ticks!.callback).toBe(formatTick);
     expect(options.scales.y1).toMatchObject({
       title: { display: true, text: 'Average' },
       beginAtZero: true,
       grid: { drawOnChartArea: false },
     });
-    expect(options.scales.y1.ticks.callback).toBe(formatTick);
-    expect(options.scales.y2).toMatchObject({
+    expect(options.scales.y1.ticks!.callback).toBe(formatTick);
+    expect((options.scales as Record<string, unknown>).y2).toMatchObject({
       display: false,
       position: 'right',
       beginAtZero: true,

--- a/src/domain/__tests__/metricsAggregator.orchestration.test.ts
+++ b/src/domain/__tests__/metricsAggregator.orchestration.test.ts
@@ -253,6 +253,7 @@ describe('metrics aggregation orchestration characterization', () => {
       editModeImpactData: [...defaults.impact.editModeImpactData],
       inlineModeImpactData: [...defaults.impact.inlineModeImpactData],
       askModeImpactData: [...defaults.impact.askModeImpactData],
+      copilotAppImpactData: [...defaults.impact.copilotAppImpactData],
       cliImpactData: [...defaults.impact.cliImpactData],
       joinedImpactData: [...defaults.impact.joinedImpactData],
     };
@@ -288,6 +289,9 @@ describe('metrics aggregation orchestration characterization', () => {
       usageDistributionData: [...defaults.ai.usageDistributionData],
       dailyAiCreditsData: [...defaults.ai.dailyAiCreditsData],
     };
+    const surfaceProductivityAggregation = {
+      ...defaults.productivity,
+    };
     const aggregated = assembleAggregatedMetrics({
       coreStatsAggregation,
       userSummaryAggregation,
@@ -298,6 +302,7 @@ describe('metrics aggregation orchestration characterization', () => {
       modelAggregation,
       cliAggregation,
       aiAggregation,
+      surfaceProductivityAggregation,
     });
     expect(aggregated.overview.stats).toBe(coreStatsAggregation.stats);
     expect(aggregated.overview.engagementData).toBe(
@@ -339,12 +344,16 @@ describe('metrics aggregation orchestration characterization', () => {
     expect(aggregated.impact.askModeImpactData).toBe(
       impactAggregation.askModeImpactData
     );
+    expect(aggregated.impact.copilotAppImpactData).toBe(
+      impactAggregation.copilotAppImpactData
+    );
     expect(aggregated.impact.cliImpactData).toBe(
       impactAggregation.cliImpactData
     );
     expect(aggregated.impact.joinedImpactData).toBe(
       impactAggregation.joinedImpactData
     );
+    expect(aggregated.productivity).toBe(surfaceProductivityAggregation);
     expect(aggregated.languages.languageStats).toBe(
       languageAggregation.languageStats
     );

--- a/src/domain/__tests__/metricsParser.test.ts
+++ b/src/domain/__tests__/metricsParser.test.ts
@@ -18,6 +18,16 @@ const baseParserMetricOverrides: Partial<CopilotMetrics> = {
   used_chat: true,
 };
 
+const zeroInteractionMetrics = {
+  user_initiated_interaction_count: 0,
+  code_generation_activity_count: 0,
+  code_acceptance_activity_count: 0,
+  loc_added_sum: 0,
+  loc_deleted_sum: 0,
+  loc_suggested_to_add_sum: 0,
+  loc_suggested_to_delete_sum: 0,
+};
+
 function makeParserMetric(overrides: Partial<CopilotMetrics> = {}): CopilotMetrics {
   return makeMetric({ ...baseParserMetricOverrides, ...overrides });
 }
@@ -202,6 +212,7 @@ describe('metricsParser', () => {
     it('should infer App usage and interactions from App features only', () => {
       const result = parseMetricsLine(makeParserMetricLine({
         totals_by_feature: [{
+          ...zeroInteractionMetrics,
           feature: 'copilot_app',
           user_initiated_interaction_count: 7,
         }],
@@ -227,6 +238,7 @@ describe('metricsParser', () => {
           },
         },
         totals_by_feature: [{
+          ...zeroInteractionMetrics,
           feature: 'copilot_app',
           user_initiated_interaction_count: 0,
         }],
@@ -268,10 +280,12 @@ describe('metricsParser', () => {
       const result = parseMetricsLine(makeParserMetricLine({
         used_copilot_app: true,
         totals_by_ide: [{
+          ...zeroInteractionMetrics,
           ide: 'copilot_app',
           user_initiated_interaction_count: 0,
         }],
         totals_by_feature: [{
+          ...zeroInteractionMetrics,
           feature: 'copilot_app',
           user_initiated_interaction_count: 2,
         }],
@@ -291,6 +305,7 @@ describe('metricsParser', () => {
       const result = parseMetricsLine(makeParserMetricLine({
         used_copilot_app: false,
         totals_by_ide: [{
+          ...zeroInteractionMetrics,
           ide: 'copilot_app',
           user_initiated_interaction_count: 2,
         }],
@@ -303,6 +318,7 @@ describe('metricsParser', () => {
       const result = parseMetricsLine(makeParserMetricLine({
         used_copilot_app: false,
         totals_by_ide: [{
+          ...zeroInteractionMetrics,
           ide: 'copilot_app',
           loc_suggested_to_add_sum: 4,
         }],
@@ -324,6 +340,7 @@ describe('metricsParser', () => {
           },
         },
         totals_by_ide: [{
+          ...zeroInteractionMetrics,
           ide: 'copilot_app',
           user_initiated_interaction_count: 0,
         }],
@@ -453,10 +470,18 @@ describe('metricsParser', () => {
       const pool = new StringPool();
       const firstLine = makeParserMetricLine({
         totals_by_ide: [
-          { ide: 'vscode', user_initiated_interaction_count: 5 },
+          {
+            ...zeroInteractionMetrics,
+            ide: 'vscode',
+            user_initiated_interaction_count: 5,
+          },
         ],
         totals_by_feature: [
-          { feature: 'code_completion', user_initiated_interaction_count: 3 },
+          {
+            ...zeroInteractionMetrics,
+            feature: 'code_completion',
+            user_initiated_interaction_count: 3,
+          },
         ],
         totals_by_language_feature: [
           {
@@ -491,10 +516,18 @@ describe('metricsParser', () => {
       const secondLine = makeParserMetricLine({
         user_id: 456,
         totals_by_ide: [
-          { ide: 'vscode', user_initiated_interaction_count: 5 },
+          {
+            ...zeroInteractionMetrics,
+            ide: 'vscode',
+            user_initiated_interaction_count: 5,
+          },
         ],
         totals_by_feature: [
-          { feature: 'code_completion', user_initiated_interaction_count: 3 },
+          {
+            ...zeroInteractionMetrics,
+            feature: 'code_completion',
+            user_initiated_interaction_count: 3,
+          },
         ],
         totals_by_language_feature: [
           {


### PR DESCRIPTION
## Why

This fixes the test-only TypeScript drift that broke the CI build in [run 32283817622](https://github.com/asizikov-demos/copilot-user-level-statistics-viewer/actions/runs/32283817622/job/96168502835). It aligns parser fixtures, aggregation wiring, and Chart.js assertions with the current production contracts.

| Commit | Change |
|--------|--------|
| `test: fix CI TypeScript fixtures` | Updates stale test fixtures and Chart.js test typing so the build type-check passes. |