### PR TITLE
feat: add average LOC impact

### DIFF
--- a/src/components/AiCreditsView.tsx
+++ b/src/components/AiCreditsView.tsx
@@ -178,6 +178,19 @@ export default function AiCreditsView({ model }: AiCreditsViewProps) {
       ),
     },
     {
+      id: 'avgLocImpact',
+      header: 'Avg LOC Impact',
+      headerClassName: headerRightClass,
+      className: `${valueCellClass} align-top`,
+      renderCell: (bucket) => (
+        <span className="whitespace-nowrap tabular-nums">
+          <span className="text-green-600">+{formatAverage(bucket.avgLocAdded)}</span>
+          <span className="text-gray-400">/</span>
+          <span className="text-red-600">-{formatAverage(bucket.avgLocDeleted)}</span>
+        </span>
+      ),
+    },
+    {
       id: 'topModels',
       header: 'Top Models - interactions',
       headerClassName: 'px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider min-w-[180px]',

--- a/src/domain/calculators/__tests__/usageDistributionCalculator.test.ts
+++ b/src/domain/calculators/__tests__/usageDistributionCalculator.test.ts
@@ -74,6 +74,8 @@ describe('usageDistributionCalculator', () => {
     expect(populated.avgDaysActive).toBe(2);
     expect(populated.totalLocAdded).toBe(100);
     expect(populated.totalLocDeleted).toBe(20);
+    expect(populated.avgLocAdded).toBe(100);
+    expect(populated.avgLocDeleted).toBe(20);
     expect(populated.topModels[0]).toMatchObject({ total: 8, uniqueUsers: 1 });
     expect(populated.topClients[0]).toMatchObject({ name: 'vscode', total: 5, uniqueUsers: 1 });
   });

--- a/src/domain/calculators/usageDistributionCalculator.ts
+++ b/src/domain/calculators/usageDistributionCalculator.ts
@@ -18,6 +18,8 @@ export interface UsageDistributionBucket {
   avgDaysActive: number;
   totalLocAdded: number;
   totalLocDeleted: number;
+  avgLocAdded: number;
+  avgLocDeleted: number;
   topModels: AiAdoptionPhaseTopEntry[];
   topClients: AiAdoptionPhaseTopEntry[];
 }
@@ -70,6 +72,8 @@ function aggregateBucket(
     avgDaysActive: userCount > 0 ? totalDaysActive / userCount : 0,
     totalLocAdded,
     totalLocDeleted,
+    avgLocAdded: userCount > 0 ? totalLocAdded / userCount : 0,
+    avgLocDeleted: userCount > 0 ? totalLocDeleted / userCount : 0,
     topModels: computeTopEntries(models),
     topClients: computeTopEntries(clients),
   };

--- a/src/read-models/__tests__/aiCreditsReadModel.test.ts
+++ b/src/read-models/__tests__/aiCreditsReadModel.test.ts
@@ -46,6 +46,8 @@ function makeAiCreditsMetrics(): AggregatedMetrics {
         avgDaysActive: 1.5,
         totalLocAdded: 10,
         totalLocDeleted: 2,
+        avgLocAdded: 10,
+        avgLocDeleted: 2,
         topModels: [{ name: 'gpt-5', total: 4, uniqueUsers: 1 }],
         topClients: [{ name: 'vscode', total: 3, uniqueUsers: 1 }],
       }],


### PR DESCRIPTION
## Why

AI Credits usage segments need a per-user LOC impact measure alongside their aggregate totals. This makes it easier to compare the typical code impact of each consumption segment.

| Commit | Change |
|--------|--------|
| `feat: add average LOC impact` | Adds per-user LOC averages to usage buckets and displays them in the AI Credits distribution table.
