### PR TITLE
Fix mixed Chart.js dataset typing

### DIFF
--- a/src/components/charts/utils/chartStyles.ts
+++ b/src/components/charts/utils/chartStyles.ts
@@ -2,6 +2,8 @@
 
 import type { ChartDataset } from 'chart.js';
 
+type LineDataset = Omit<ChartDataset<'line', (number | null)[]>, 'tooltip'>;
+
 /**
  * Centralized dataset styling presets for Chart.js charts.
  * Reduces duplication across chart components.
@@ -46,8 +48,8 @@ export function createLineDataset(
   color: string,
   label: string,
   data: (number | null)[],
-  options: Partial<ChartDataset<'line', (number | null)[]>> = {}
-) {
+  options: Partial<LineDataset> = {}
+): LineDataset {
   const alphaColor = color.replace('rgb', 'rgba').replace(')', ', 0.1)');
   
   return {
@@ -72,8 +74,8 @@ export function createFilledLineDataset(
   color: string,
   label: string,
   data: (number | null)[],
-  options: Partial<ChartDataset<'line', (number | null)[]>> = {}
-) {
+  options: Partial<LineDataset> = {}
+): LineDataset {
   return createLineDataset(color, label, data, { fill: true, ...options });
 }
 


### PR DESCRIPTION
## Why

The GitHub Pages build fails when Chart.js combines bar and line datasets because the shared line helpers expose line-only tooltip callback types. Narrowing the helper contract prevents those incompatible optional types from entering mixed datasets without changing chart rendering.

| Commit | Change |
|--------|--------|
| `fix: constrain mixed chart line dataset types` | Excludes line-only tooltip options from shared line dataset helpers so mixed bar/line charts type-check in CI. |