### PR TITLE
fix: require categories for known models

### DIFF
--- a/src/domain/__tests__/modelConfig.test.ts
+++ b/src/domain/__tests__/modelConfig.test.ts
@@ -42,16 +42,16 @@ describe('modelConfig', () => {
       expect(getModelCategory('legacy-model')).toBeUndefined();
     });
 
-    it('should categorize every non-sentinel known model', () => {
+    it('should categorize every known model', () => {
       expect(
         KNOWN_MODELS
-          .filter(model => model.name !== 'auto' && model.name !== 'unknown')
           .every(model => model.category !== undefined)
       ).toBe(true);
     });
 
-    it('should include the unknown sentinel', () => {
-      expect(KNOWN_MODELS.some(model => model.name === 'unknown')).toBe(true);
+    it('should keep sentinel values out of the known model catalog', () => {
+      expect(isKnownModelName('auto')).toBe(false);
+      expect(isKnownModelName('unknown')).toBe(false);
     });
 
     it('should recognize known models after normalization', () => {

--- a/src/domain/modelConfig.ts
+++ b/src/domain/modelConfig.ts
@@ -15,7 +15,7 @@ export const MODEL_CATEGORY_ORDER = ['Lightweight', 'Versatile', 'Powerful', 'Un
 export class Model {
   constructor(
     public readonly name: string,
-    public readonly category?: ModelCategory
+    public readonly category: ModelCategory
   ) {}
 }
 
@@ -93,8 +93,6 @@ export const KNOWN_MODELS: Model[] = [
   new Model('mai-code-1.1-flash', 'Lightweight'),
   new Model('kimi-k2.7-code', 'Versatile'),
   new Model('kimi-k3', 'Powerful'),
-  new Model('auto'),
-  new Model('unknown'),
 ];
 
 const UNKNOWN_MODEL_NAME = 'unknown';


### PR DESCRIPTION
## Why

The Copilot pricing catalog defines three model categories, but the local known-model list also contained uncategorized sentinel values. This change keeps the catalog aligned with the documented category model and prevents future uncategorized known entries.

| Commit | Change |
|--------|--------|
| `fix: require categories for known models` | Require every catalog model to use Lightweight, Powerful, or Versatile, and keep `auto`/`unknown` sentinels out of the catalog. |